### PR TITLE
Add missing shebang from the wrapper scripts

### DIFF
--- a/src/clang_ctu.bzl
+++ b/src/clang_ctu.bzl
@@ -1,7 +1,8 @@
 load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 
-CLANG_CTU_WRAPPER_SCRIPT = """#set -x
+CLANG_CTU_WRAPPER_SCRIPT = """#!/usr/bin/env bash
+#set -x
 REPORT_TYPE=$1
 shift
 REPORT_FILE=$1

--- a/src/code_checker.bzl
+++ b/src/code_checker.bzl
@@ -4,7 +4,8 @@
 load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 
-CODE_CHECKER_WRAPPER_SCRIPT = """#set -x
+CODE_CHECKER_WRAPPER_SCRIPT = """#!/usr/bin/env bash
+#set -x
 DATA_DIR=$1
 shift
 CLANG_TIDY_PLIST=$1


### PR DESCRIPTION
The lack of these caused issues in the CodeChecker github CI.