### PR TITLE
Pass the correct interpreter forward

### DIFF
--- a/src/clang.bzl
+++ b/src/clang.bzl
@@ -187,30 +187,32 @@ def _run_analyzer(
     )
     return outfile
 
+def check_valid_file_type(src):
+    """
+    Returns True if the file type matches one of the permitted
+    srcs file types for C and C++ header/source files.
+    """
+    permitted_file_types = [
+        ".c",
+        ".cc",
+        ".cpp",
+        ".cxx",
+        ".c++",
+        ".C",
+        ".h",
+        ".hh",
+        ".hpp",
+        ".hxx",
+        ".inc",
+        ".inl",
+        ".H",
+    ]
+    for file_type in permitted_file_types:
+        if src.basename.endswith(file_type):
+            return True
+    return False
+
 def _rule_sources(ctx):
-    def check_valid_file_type(src):
-        """
-        Returns True if the file type matches one of the permitted srcs file types for C and C++ header/source files.
-        """
-        permitted_file_types = [
-            ".c",
-            ".cc",
-            ".cpp",
-            ".cxx",
-            ".c++",
-            ".C",
-            ".h",
-            ".hh",
-            ".hpp",
-            ".hxx",
-            ".inc",
-            ".inl",
-            ".H",
-        ]
-        for file_type in permitted_file_types:
-            if src.basename.endswith(file_type):
-                return True
-        return False
 
     srcs = []
     if hasattr(ctx.rule.attr, "srcs"):

--- a/src/clang_ctu.bzl
+++ b/src/clang_ctu.bzl
@@ -111,31 +111,32 @@ def _run_clang_ctu(
     )
     return outputs
 
+def check_valid_file_type(src):
+    """
+    Returns True if the file type matches one of the permitted
+    srcs file types for C and C++ header/source files.
+    """
+    permitted_file_types = [
+        ".c",
+        ".cc",
+        ".cpp",
+        ".cxx",
+        ".c++",
+        ".C",
+        ".h",
+        ".hh",
+        ".hpp",
+        ".hxx",
+        ".inc",
+        ".inl",
+        ".H",
+    ]
+    for file_type in permitted_file_types:
+        if src.basename.endswith(file_type):
+            return True
+    return False
+
 def _rule_sources(ctx):
-    def check_valid_file_type(src):
-        """
-        Returns True if the file type matches one of the permitted
-        srcs file types for C and C++ header/source files.
-        """
-        permitted_file_types = [
-            ".c",
-            ".cc",
-            ".cpp",
-            ".cxx",
-            ".c++",
-            ".C",
-            ".h",
-            ".hh",
-            ".hpp",
-            ".hxx",
-            ".inc",
-            ".inl",
-            ".H",
-        ]
-        for file_type in permitted_file_types:
-            if src.basename.endswith(file_type):
-                return True
-        return False
 
     srcs = []
     if hasattr(ctx.rule.attr, "srcs"):

--- a/src/code_checker.bzl
+++ b/src/code_checker.bzl
@@ -27,9 +27,9 @@ eval "$@" $COMPILE_COMMANDS_ABS >> $LOG_FILE 2>&1
 # NOTE: the following we do to get rid of md5 hash in plist file names
 ret_code=$?
 echo "===-----------------------------------------------------===" >> $LOG_FILE
-if [ $ret_code -eq 1 ]; then
+if [ $ret_code -eq 1 ] || [ $ret_code -ge 128 ]; then
     echo "===-----------------------------------------------------==="
-    echo "[ERROR]: CodeChecker returned with -1!"
+    echo "[ERROR]: CodeChecker returned with $ret_code!"
     cat $LOG_FILE
     exit 1
 fi

--- a/src/code_checker.bzl
+++ b/src/code_checker.bzl
@@ -18,11 +18,21 @@ COMPILE_COMMANDS_JSON=$1
 shift
 COMPILE_COMMANDS_ABS=$COMPILE_COMMANDS_JSON.abs
 sed 's|"directory":"."|"directory":"'$(pwd)'"|g' $COMPILE_COMMANDS_JSON > $COMPILE_COMMANDS_ABS
-echo "Running: $@" $COMPILE_COMMANDS_ABS > $LOG_FILE
-echo "==================================" >> $LOG_FILE
+echo "CodeChecker command: $@" $COMPILE_COMMANDS_ABS > $LOG_FILE
+echo "===-----------------------------------------------------===" >> $LOG_FILE
+echo "                   CodeChecker error log                   " >> $LOG_FILE
+echo "===-----------------------------------------------------===" >> $LOG_FILE
 eval "$@" $COMPILE_COMMANDS_ABS >> $LOG_FILE 2>&1
 # ls -la $DATA_DIR
 # NOTE: the following we do to get rid of md5 hash in plist file names
+ret_code=$?
+echo "===-----------------------------------------------------===" >> $LOG_FILE
+if [ $ret_code -eq 1 ]; then
+    echo "===-----------------------------------------------------==="
+    echo "[ERROR]: CodeChecker returned with -1!"
+    cat $LOG_FILE
+    exit 1
+fi
 cp $DATA_DIR/*_clang-tidy_*.plist $CLANG_TIDY_PLIST
 cp $DATA_DIR/*_clangsa_*.plist    $CLANGSA_PLIST
 
@@ -90,30 +100,32 @@ def _run_code_checker(
     )
     return outputs
 
+def check_valid_file_type(src):
+    """
+    Returns True if the file type matches one of the permitted
+    srcs file types for C and C++ header/source files.
+    """
+    permitted_file_types = [
+        ".c",
+        ".cc",
+        ".cpp",
+        ".cxx",
+        ".c++",
+        ".C",
+        ".h",
+        ".hh",
+        ".hpp",
+        ".hxx",
+        ".inc",
+        ".inl",
+        ".H",
+    ]
+    for file_type in permitted_file_types:
+        if src.basename.endswith(file_type):
+            return True
+    return False
+
 def _rule_sources(ctx):
-    def check_valid_file_type(src):
-        """
-        Returns True if the file type matches one of the permitted srcs file types for C and C++ header/source files.
-        """
-        permitted_file_types = [
-            ".c",
-            ".cc",
-            ".cpp",
-            ".cxx",
-            ".c++",
-            ".C",
-            ".h",
-            ".hh",
-            ".hpp",
-            ".hxx",
-            ".inc",
-            ".inl",
-            ".H",
-        ]
-        for file_type in permitted_file_types:
-            if src.basename.endswith(file_type):
-                return True
-        return False
 
     srcs = []
     if hasattr(ctx.rule.attr, "srcs"):

--- a/src/code_checker.bzl
+++ b/src/code_checker.bzl
@@ -153,6 +153,9 @@ def _toolchain_flags(ctx, action_name = ACTION_NAMES.cpp_compile):
         feature_configuration = feature_configuration,
         action_name = action_name,
     )
+    if "ccache" in compiler:
+        fail("ccache is not supported!")
+
     return [compiler] + flags
 
 def _compile_args(compilation_context):

--- a/src/codechecker_script.py
+++ b/src/codechecker_script.py
@@ -173,6 +173,8 @@ def analyze():
 
     output = execute("%s analyzers --details" % CODECHECKER_PATH, env=env)
     logging.debug("Analyzers:\n\n%s", output)
+    if "ccache" in output:
+        fail("ccache is not supported!")
 
     command = "%s analyze --skip=%s %s --output=%s/data --config %s %s" % (
         CODECHECKER_PATH,

--- a/src/codechecker_script.py
+++ b/src/codechecker_script.py
@@ -126,6 +126,7 @@ def input_data():
 
 def execute(cmd, env=None, codes=[0]):
     """ Execute CodeChecker commands """
+    cmd = sys.executable + ' ' + cmd
     process = subprocess.Popen(
         cmd,
         env=env,


### PR DESCRIPTION
This caused a bug when bazel wiped the environment, and while the wrapper
script was invoked with the correct interpreter, when it called CodeChecker
through popen, it used the wrong interpreter from PATH. Lets just reuse the
interpreter we were invoked with.

Depends on #1, #3, #2.