### PR TITLE
Fix issue with code_checker incorrectly running on header files

### DIFF
--- a/src/code_checker.bzl
+++ b/src/code_checker.bzl
@@ -103,7 +103,7 @@ def _run_code_checker(
 def check_valid_file_type(src):
     """
     Returns True if the file type matches one of the permitted
-    srcs file types for C and C++ header/source files.
+    srcs file types for C and C++ source files.
     """
     permitted_file_types = [
         ".c",
@@ -112,13 +112,6 @@ def check_valid_file_type(src):
         ".cxx",
         ".c++",
         ".C",
-        ".h",
-        ".hh",
-        ".hpp",
-        ".hxx",
-        ".inc",
-        ".inl",
-        ".H",
     ]
     for file_type in permitted_file_types:
         if src.basename.endswith(file_type):
@@ -302,7 +295,6 @@ def _code_checker_impl(ctx):
     sources_and_headers = _collect_all_sources_and_headers(ctx)
     options = ctx.attr.default_options + ctx.attr.options
     all_files = [compile_commands_json]
-    header_extensions = (".h", ".hh", ".hpp", ".hxx", ".inc", ".inl", ".H")
     for target in ctx.attr.targets:
         if not CcInfo in target:
             continue
@@ -313,8 +305,6 @@ def _code_checker_impl(ctx):
                 compilation_context = target[CcInfo].compilation_context
                 for src in srcs:
                     args = target[CompileInfo].arguments[src]
-                    if src.path.endswith(header_extensions):
-                        continue
                     outputs = _run_code_checker(
                         ctx,
                         src,


### PR DESCRIPTION
Fix issue #7

I noticed when running CodeChecker through bazel that it tries to do analyses on header files, not only .cpp/.c files. Such analyses failed because there are no compilation commands associated with header files in compile_commands.json. The fix now skips headers.

This certainly fixes the problem immediately, but I'm not confident this is the right fix. Considering that we should analyze those files and only those we have a compilation command for, I wonder if we should instead just iterate over the compile_commands.json. Consider this PR as thinking out loud.