### PR TITLE
Document all bazel rules provided in the repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ codechecker_test(
 
 ### Per-file CodeChecker analysis: `code_checker_test()`
 > [!IMPORTANT]
-> The rule is still in prototype status and is subject to changes without notice. See [#31](https://github.com/Ericsson/codechecker_bazel/issues/31).
+> The rule is still in prototype status and is subject to changes or removal without notice. See [#31](https://github.com/Ericsson/codechecker_bazel/issues/31).
 > You are free to experiment and report issues however!
 
 Instead of a single CodeChecker call, the bazel rule `code_checker_test()` invokes
@@ -307,7 +307,7 @@ clang_analyze_test(
 ```
 
 > [!IMPORTANT]
-> The rule is still in prototype status and is subject to changes without notice. See [#32](https://github.com/Ericsson/codechecker_bazel/issues/32).
+> The rule is still in prototype status and is subject to changes or removal without notice. See [#32](https://github.com/Ericsson/codechecker_bazel/issues/32).
 > We are also actively pursuing better CTU support _using_ CodeChecker.
 
 The Bazel rule `clang_analyze_test()` runs The Clang Static Analyzer with [cross translation unit analysis](https://clang.llvm.org/docs/analyzer/user-docs/CrossTranslationUnit.html) analysis without CodeChecker. To use it, add the following to your BUILD file:

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Prerequisites
 We need the following tools:
 
 - Git 2 or newer (we use 2.36)
-- Bazel in between version 4 and 6 (we recommend version 6.5.0)
+- Bazel 6, not yet bazel 7 (we recommend version 6.5.0)
 - Clang 16 or newer (we use 16), we use clang-tidy
 - Python 3.8 or newer (we use 3.11)
 - CodeChecker 6.23 or newer (we use 6.23.0)
@@ -148,7 +148,7 @@ CodeChecker parse bazel-bin/path/to/results
 
 ### Build-only CodeChecker analysis: `codechecker()`
 
-This rule is functionally equivalent to `codechecker_test` but omits the test phase where either PASS or FAIL is printed.
+This rule is functionally equivalent to `codechecker_test` but omits the test phase where either PASS or FAIL isc printed.
 You can include and use it similarly as well:
 
 ```python
@@ -185,7 +185,7 @@ load(
 )
 ```
 
-Create a CodeChecker configuration file e.g. `config.json` (see example [here](https://github.com/Ericsson/codechecker_bazel/blob/main/test/config.json)) and parse it using `codechecker_config()`.
+Create a CodeChecker configuration file e.g. `config.json` (see example [test/config.json](https://github.com/Ericsson/codechecker_bazel/blob/main/test/config.json)) and parse it using `codechecker_config()`.
 
 ```python
 codechecker_config(
@@ -222,7 +222,7 @@ codechecker_test(
 
 ### Per-file CodeChecker analysis: `code_checker_test()`
 > [!IMPORTANT]
-> The rule is still in prototype status and is subject to changes without notice. See [this issue](https://github.com/Ericsson/codechecker_bazel/issues/31).
+> The rule is still in prototype status and is subject to changes without notice. See https://github.com/Ericsson/codechecker_bazel/issues/31.
 > You are free to experiment and report issues however!
 
 Instead of a single CodeChecker call, the bazel rule `code_checker_test()` invokes
@@ -300,7 +300,7 @@ clang_analyze_test(
 ```
 
 > [!IMPORTANT]
-> The rule is still in prototype status and is subject to changes without notice. See [this issue](https://github.com/Ericsson/codechecker_bazel/issues/32).
+> The rule is still in prototype status and is subject to changes without notice. See https://github.com/Ericsson/codechecker_bazel/issues/32.
 > We are also actively pursuing better CTU support _using_ CodeChecker.
 
 The Bazel rule `clang_analyze_test` runs The Clang Static Analyzer with [cross translation unit analysis](https://clang.llvm.org/docs/analyzer/user-docs/CrossTranslationUnit.html) analysis without CodeChecker. To use it, add the following to your BUILD file:

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ load(
 )
 ```
 
-Create a CodeChecker configuration file e.g. `config.json` (see example [here](https://github.com/Ericsson/codechecker_bazel/blob/readme_update/test/config.json)) and parse it using `codechecker_config()`.
+Create a CodeChecker configuration file e.g. `config.json` (see example [here](https://github.com/Ericsson/codechecker_bazel/blob/main/test/config.json)) and parse it using `codechecker_config()`.
 
 ```python
 codechecker_config(

--- a/README.md
+++ b/README.md
@@ -275,7 +275,11 @@ clang_tidy_test(
 )
 ```
 
-The Bazel aspect `clang_tidy_aspect` uses `clang_tidy_test` under the hood, but can be invoked from the command line by passing the following parameter to Bazel build/test: `--aspects @bazel_codechecker//src:clang.bzl%clang_tidy_aspect`.
+You can also run clang-tidy via the Bazel aspect `clang_tidy_aspect` that can be invoked from the command line by passing the following parameter to Bazel build/test: `--aspects @bazel_codechecker//src:clang.bzl%clang_tidy_aspect`:
+
+```bash
+bazel build ... --aspects @bazel_codechecker//src:clang.bzl%clang_tidy_aspect --output_groups=report
+```
 
 ### Clang Static Analyzer: `clang_analyze_test()` and `clang_ctu_test`
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-Bazel CodeChecker
-=================
+Bazel Rules for CodeChecker
+===========================
 
 Bazel rules for CodeChecker and other tools for Code Analysis,
 including Clang-tidy, Clang analyzer, generating compilation database
@@ -10,38 +10,41 @@ including Clang-tidy, Clang analyzer, generating compilation database
 
 ### CodeChecker
 
-CodeChecker rule `codechecker_test()` to run `CodeChecker` tool as a Bazel test.
+CodeChecker is a static analysis infrastructure that conveniently manages static analyzer engines such as the Clang Static Analyzer, Clang-tidy, GCC Static Analyzer, CppCheck and Infer.
 
 Read about CodeChecker:
 
 * GitHub: https://github.com/Ericsson/codechecker
 * Read the Docs: https://codechecker.readthedocs.io/
 
-Bazel rule for CodeChecker `codechecker_test()` uses
-Bazel rule for compilation database (compile_commands.json) `compile_commands()`
-
+The main Bazel rule for CodeChecker is `codechecker_test()`.
 
 ### Clang-tidy
 
-Bazel aspect `clang_tidy_aspect` and rule `clang_tidy_test()`
-to run `clang-tidy` "linter" tool from Bazel command line or Bazel test.
+Clang-tidy is a fast static analyzer/linter for the C family of languages. This
+repository provides Bazel aspect `clang_tidy_aspect` and rule `clang_tidy_test()`
+to run clang-tidy natively (without CodeChecker).
 
 Find more information about LLVM clang-tidy:
 
 * LLVM: https://clang.llvm.org/extra/clang-tidy
 * bazel_clang_tidy: https://github.com/erenon/bazel_clang_tidy
 
-
 ### Clang Static Analyzer
 
-Bazel rule `clang_analyze_test()` runs Clang Static Analyzer (or `clang --analyze`),
-the most (and the only?) sophisticated tool for C/C++ code analysis which implements
+The Clang Static Analyzer (or `clang --analyze`) is among
+the most sophisticated tools for C/C++ code analysis which implements
 path-sensitive, inter-procedural analysis based on symbolic execution technique.
+This repository provides the Bazel rule `clang_analyze_test()` which runs the
+Clang Static Analyzer natively (without CodeChecker)
 
 Find more information about LLVM Clang Static Analyzer:
 
 * LLVM: https://clang.llvm.org/docs/ClangStaticAnalyzer.html
 
+### Generating a compilation database
+
+There is also a Bazel rule for generating a compilation database (compile_commands.json) via `compile_commands()`. The current implementation is Bazel native and doesn't use `CodeChecker log`.
 
 Prerequisites
 -------------
@@ -49,7 +52,7 @@ Prerequisites
 We need the following tools:
 
 - Git 2 or newer (we use 2.36)
-- Bazel 4 or newer (we recommend version 6)
+- Bazel in between version 4 and 6 (we recommend version 6.5.0)
 - Clang 16 or newer (we use 16), we use clang-tidy
 - Python 3.8 or newer (we use 3.11)
 - CodeChecker 6.23 or newer (we use 6.23.0)
@@ -67,7 +70,44 @@ are available in your system, you can just add the following modules:
 How to use
 ----------
 
-To use `codechecker_test()` rule you should include it to your BUILD file:
+To use these rules you should first add `codechecker_bazel` as an
+[external dependency](https://bazel.build/versions/6.5.0/external/overview#workspace-system)
+to your `WORKSPACE` file:
+
+```python
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
+git_repository(
+    name = "bazel_codechecker",
+    remote = "https://github.com/Ericsson/codechecker_bazel.git",
+    branch = "main",
+)
+
+load(
+    "@bazel_codechecker//src:tools.bzl",
+    "register_default_codechecker",
+    "register_default_python_toolchain",
+)
+
+register_default_python_toolchain()
+
+register_default_codechecker()
+```
+## CodeChecker
+
+### Standard CodeChecker invocation: `codechecker_test()`
+
+`codechecker_test()` invokes CodeChecker the "standard way", as you'd call
+it normally from the command line. The rule first generates a compilation
+database on all targets given to the rule. Then, [`CodeChecker analyze`](https://github.com/Ericsson/codechecker/blob/master/docs/analyzer/user_guide.md#analyze)
+is run on all translation units found in those targets.
+
+> [!NOTE]
+> Even though bazel is capable of incremental builds, if any files are
+> rebuilt, this rule will reanalyze all translation units in all targets,
+> even those that needed no rebuild.
+
+To use `codechecker_test()` include it to your BUILD file:
 
 ```python
 load(
@@ -76,8 +116,9 @@ load(
 )
 ```
 
-Then use `codechecker_test()` rule passing targets you call CodeChecker for:
+Create a `codechecker_test()` target by passing other targets you'd like CodeChecker to analyze:
 
+<!-- TODO: Consider using https://github.com/bazelbuild/stardoc to document parameters -->
 ```python
 codechecker_test(
     name = "your_codechecker_rule_name",
@@ -87,7 +128,195 @@ codechecker_test(
 )
 ```
 
-Note that `compile_commands()` rule can be used independently:
+Then invoke bazel:
+
+```bash
+bazel build ://your_codechecker_rule_name
+```
+
+You can find the analysis results in the `bazel-bin/` folder, on which you
+can run [`CodeChecker store`](https://github.com/Ericsson/codechecker/blob/master/docs/web/user_guide.md#store)
+or [`CodeChecker parse`](https://github.com/Ericsson/codechecker/blob/master/docs/analyzer/user_guide.md#parse):
+
+```bash
+CodeChecker parse bazel-bin/path/to/results
+```
+
+### Build-only CodeChecker analysis: `codechecker()`
+
+This rule is functionally equivalent to `codechecker_test` but omits the test phase where either PASS or FAIL is printed.
+You can include and use it similarly as well:
+
+```python
+load(
+    "@bazel_codechecker//src:codechecker.bzl",
+    "codechecker"
+)
+```
+
+### Multiplatform CodeChechecker analysis: `codechecker_suite()`
+
+This rule is functionally equivalent to `codechecker_test` but allows for running on multiple platforms via the `platforms` parameter.
+You can include and use it similarly as well:
+
+```python
+load(
+    "@bazel_codechecker//src:codechecker.bzl",
+    "codechecker_suite"
+)
+```
+
+### `codechecker_config()`
+
+Using the Bazel rule `codechecker_config()` you can parse a CodeChecker [configuration file](https://github.com/Ericsson/codechecker/blob/master/docs/config_file.md).
+
+First, include the rule in your BUILD file:
+
+```python
+load(
+    "@bazel_codechecker//src:codechecker.bzl",
+    "codechecker_config"
+)
+```
+
+Create a CodeChecker configuration file e.g. `config.json` (see example [here](https://github.com/Szelethus/codechecker_bazel/blob/readme_update/test/config.json)) and parse it using `codechecker_config()`. 
+
+```python
+codechecker_config(
+    name = "your_codechecker_config",
+    config_file = ":config.json"
+)
+```
+
+Alternatively, you can assemble a CodeChecker configuration without a config file using the rule:
+
+```python
+codechecker_config(
+    name = "your_codechecker_config",
+    analyze = [
+        "--enable=bugprone-dangling-handle",
+        "--enable=bugprone-fold-init-type",
+        "--enable=misc-non-copyable-objects",
+        "--report-hash=context-free-v2",
+    ]
+)
+```
+
+You can now configure your `codechecker`, `codechecker_suite`, `codechecker_test` and `code_checker_test` targets using the above configuration:
+
+```python
+codechecker_test(
+    name = "your_codechecker_rule_name",
+    config = "your_codechecker_config",
+    targets = [
+        "your_target",
+    ],
+)
+```
+
+### Per-file CodeChecker analysis: `code_checker_test()`
+> [!IMPORTANT]
+> The rule is still in prototype status and is subject to changes without notice.
+> You are free to experiment and report issues however!
+
+Instead of a single CodeChecker call, the bazel rule `code_checker_test()` invokes
+[`CodeChecker analyze`](https://github.com/Ericsson/codechecker/blob/master/docs/analyzer/user_guide.md#analyze)
+_for each_ translation unit in the targets to analyze. The rule is intended to be
+able to enable incremental analyses and dispatching  analysis jobs to remote build
+agents.
+
+To use `code_checker_test()` include it to your BUILD file:
+
+```python
+load(
+    "@bazel_codechecker//src:code_checker.bzl",
+    "code_checker_test",
+)
+```
+
+Create a `code_checker_test()` target by passing other targets you'd like CodeChecker to analyze:
+
+```python
+code_checker_test(
+    name = "your_code_checker_rule_name",
+    targets = [
+        "your_target",
+    ],
+)
+```
+
+```bash
+bazel build ://your_code_checker_rule_name
+```
+
+The analysis results can be found and stored/parsed similarly to [`codechecker_test`](README.md#standard-codechecker-invocation-codechecker_test)
+
+## CodeChecker independent rules
+
+The following rules are _not_ using CodeChecker.
+
+### Clang-tidy: `clang_tidy_aspect` and `clang_tidy_test()`
+
+The Bazel rule `clang_tidy_test` runs clang-tidy natively without CodeChecker. To use it, add the following to your BUILD file:
+
+```python
+load(
+    "@bazel_codechecker//src:clang.bzl",
+    "clang_tidy_test",
+)
+
+clang_tidy_test(
+    name = "your_rule_name",
+    targets = [
+        "your_target",
+    ],
+)
+```
+
+The Bazel aspect `clang_tidy_aspect` uses `clang_tidy_test` under the hood, but can be invoked from the command line by passing the following parameter to Bazel build/test: `--aspects @bazel_codechecker//src:clang.bzl%clang_tidy_aspect`.
+
+### Clang Static Analyzer: `clang_analyze_test()` and `clang_ctu_test`
+
+The Bazel rule `clang_analyze_test` runs The Clang Static Analyzer natively without CodeChecker. To use it, add the following to your BUILD file:
+
+```python
+load(
+    "@bazel_codechecker//src:clang.bzl",
+    "clang_analyze_test",
+)
+
+clang_analyze_test(
+    name = "your_rule_name",
+    targets = [
+        "your_target",
+    ],
+)
+```
+
+> [!IMPORTANT]
+> You are welcome to experiment with `clang_ctu_test`, but it is recommended
+> (as per [the official documentation](https://clang.llvm.org/docs/analyzer/user-docs/CrossTranslationUnit.html))
+> to use CTU with CodeChecker. Please bear with us while we getting it to work!
+
+The Bazel rule `clang_analyze_test` runs The Clang Static Analyzer with [cross translation unit analysis](https://clang.llvm.org/docs/analyzer/user-docs/CrossTranslationUnit.html) analysis without CodeChecker. To use it, add the following to your BUILD file:
+
+```python
+load(
+    "@bazel_codechecker//src:clang_ctu.bzl",
+    "clang_ctu_test",
+)
+
+clang_ctu_test(
+    name = "your_code_checker_rule_name",
+    targets = [
+        "your_target",
+    ],
+)
+```
+
+### Generating a compilation database: `compile_commands()`
+
+As generating a compilation database for C/C++ is a known pain point for bazel, this repository defines the Bazel rule `compile_commands()` rule which can be used indendently of CodeChecker. The implementation is basen on https://github.com/grailbio/bazel-compilation-database with some fixes on some tricky edge cases. To use it, include the following in your BUILD file:
 
 ```python
 load(
@@ -106,7 +335,7 @@ compile_commands(
     ],
 )
 ```
-
+You can find the generated `compile_commands.json` under `bazel-bin/`.
 
 Examples
 --------

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ codechecker_test(
 
 ### Per-file CodeChecker analysis: `code_checker_test()`
 > [!IMPORTANT]
-> The rule is still in prototype status and is subject to changes without notice.
+> The rule is still in prototype status and is subject to changes without notice. See [this issue](https://github.com/Ericsson/codechecker_bazel/issues/31).
 > You are free to experiment and report issues however!
 
 Instead of a single CodeChecker call, the bazel rule `code_checker_test()` invokes
@@ -300,9 +300,8 @@ clang_analyze_test(
 ```
 
 > [!IMPORTANT]
-> You are welcome to experiment with `clang_ctu_test`, but it is recommended
-> (as per [the official documentation](https://clang.llvm.org/docs/analyzer/user-docs/CrossTranslationUnit.html))
-> to use CTU with CodeChecker. Please bear with us while we getting it to work!
+> The rule is still in prototype status and is subject to changes without notice. See [this issue](https://github.com/Ericsson/codechecker_bazel/issues/32).
+> We are also actively pursuing better CTU support _using_ CodeChecker.
 
 The Bazel rule `clang_analyze_test` runs The Clang Static Analyzer with [cross translation unit analysis](https://clang.llvm.org/docs/analyzer/user-docs/CrossTranslationUnit.html) analysis without CodeChecker. To use it, add the following to your BUILD file:
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,8 @@ can run [`CodeChecker store`](https://github.com/Ericsson/codechecker/blob/maste
 or [`CodeChecker parse`](https://github.com/Ericsson/codechecker/blob/master/docs/analyzer/user_guide.md#parse):
 
 ```bash
-CodeChecker parse bazel-bin/path/to/results
+CodeChecker parse bazel-bin/your_codechecker_rule_name/codechecker-files/data
+CodeChecker store bazel-bin/your_codechecker_rule_name/codechecker-files/data -n "Run name"
 ```
 
 <!-- For now, we consider codechecker() to be an internal rule.
@@ -185,7 +186,7 @@ load(
 )
 ```
 
-Create a CodeChecker configuration file e.g. `config.json` (see example [test/config.json](https://github.com/Ericsson/codechecker_bazel/blob/main/test/config.json)) and parse it using `codechecker_config()`.
+Create a CodeChecker configuration file e.g. `config.json` (see example [test/config.json](test/config.json)) and parse it using `codechecker_config()`.
 
 ```python
 codechecker_config(
@@ -222,7 +223,7 @@ codechecker_test(
 
 ### Per-file CodeChecker analysis: `code_checker_test()`
 > [!IMPORTANT]
-> The rule is still in prototype status and is subject to changes without notice. See https://github.com/Ericsson/codechecker_bazel/issues/31.
+> The rule is still in prototype status and is subject to changes without notice. See [#31](https://github.com/Ericsson/codechecker_bazel/issues/31).
 > You are free to experiment and report issues however!
 
 Instead of a single CodeChecker call, the bazel rule `code_checker_test()` invokes
@@ -251,7 +252,13 @@ code_checker_test(
 )
 ```
 
-You can run the analysis and store/parse the results similarly to [`codechecker_test`](README.md#standard-codechecker-invocation-codechecker_test).
+You can find the analysis results in the `bazel-bin/` folder similarly to [`codechecker_test`](README.md#standard-codechecker-invocation-codechecker_test),
+only without the `codechecker-files` directory. You can also parse/store similarly:
+
+```bash
+CodeChecker parse bazel-bin/your_code_checker_rule_name/data
+CodeChecker store bazel-bin/your_code_checker_rule_name/data -n "Run name"
+```
 
 ## CodeChecker independent rules
 
@@ -300,7 +307,7 @@ clang_analyze_test(
 ```
 
 > [!IMPORTANT]
-> The rule is still in prototype status and is subject to changes without notice. See https://github.com/Ericsson/codechecker_bazel/issues/32.
+> The rule is still in prototype status and is subject to changes without notice. See [#32](https://github.com/Ericsson/codechecker_bazel/issues/32).
 > We are also actively pursuing better CTU support _using_ CodeChecker.
 
 The Bazel rule `clang_analyze_test` runs The Clang Static Analyzer with [cross translation unit analysis](https://clang.llvm.org/docs/analyzer/user-docs/CrossTranslationUnit.html) analysis without CodeChecker. To use it, add the following to your BUILD file:

--- a/README.md
+++ b/README.md
@@ -138,7 +138,9 @@ bazel test ...
 
 You can find the analysis results in the `bazel-bin/` folder, on which you
 can run [`CodeChecker store`](https://github.com/Ericsson/codechecker/blob/master/docs/web/user_guide.md#store)
-or [`CodeChecker parse`](https://github.com/Ericsson/codechecker/blob/master/docs/analyzer/user_guide.md#parse):
+or [`CodeChecker parse`](https://github.com/Ericsson/codechecker/blob/master/docs/analyzer/user_guide.md#parse).
+The precise output path to the directory can vary, but you should look for `your_codechecker_rule_name/codechecker-files/data`.
+In simpler cases, something like the following:
 
 ```bash
 CodeChecker parse bazel-bin/your_codechecker_rule_name/codechecker-files/data
@@ -325,7 +327,7 @@ code_checker_test(
 ```
 
 You can find the analysis results in the `bazel-bin/` folder similarly to [`codechecker_test()`](README.md#standard-codechecker-invocation-codechecker_test),
-only without the `codechecker-files` directory. You can also parse/store similarly:
+only without the `codechecker-files` directory. In simple cases, the results directory can be found and parsed as follows:
 
 ```bash
 CodeChecker parse bazel-bin/your_code_checker_rule_name/data

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ load(
 )
 ```
 
-Create a `code_checker_test()` target by passing other targets you'd like CodeChecker to analyze:
+Create a `code_checker_test()` target by passing targets you'd like CodeChecker to analyze, similarly to `codechecker_test`:
 
 ```python
 code_checker_test(
@@ -251,13 +251,7 @@ code_checker_test(
 )
 ```
 
-```bash
-bazel test ://your_code_checker_rule_name
-# Or, as a part of the rest of the testsuite
-bazel test ...
-```
-
-The analysis results can be found and stored/parsed similarly to [`codechecker_test`](README.md#standard-codechecker-invocation-codechecker_test)
+You can run the analysis and store/parse the results similarly to [`codechecker_test`](README.md#standard-codechecker-invocation-codechecker_test).
 
 ## CodeChecker independent rules
 

--- a/README.md
+++ b/README.md
@@ -221,6 +221,77 @@ codechecker_test(
 )
 ```
 
+## CodeChecker independent rules
+
+The following rules are _not_ using CodeChecker.
+
+### Clang-tidy: `clang_tidy_aspect()` and `clang_tidy_test()`
+
+The Bazel rule `clang_tidy_test()` runs clang-tidy natively without CodeChecker. To use it, add the following to your BUILD file:
+
+```python
+load(
+    "@bazel_codechecker//src:clang.bzl",
+    "clang_tidy_test",
+)
+
+clang_tidy_test(
+    name = "your_rule_name",
+    targets = [
+        "your_target",
+    ],
+)
+```
+
+You can also run clang-tidy via the Bazel aspect `clang_tidy_aspect()` that can be invoked from the command line by passing the following parameter to Bazel build/test: `--aspects @bazel_codechecker//src:clang.bzl%clang_tidy_aspect`:
+
+```bash
+bazel build ... --aspects @bazel_codechecker//src:clang.bzl%clang_tidy_aspect --output_groups=report
+```
+
+### Clang Static Analyzer: `clang_analyze_test()`
+
+The Bazel rule `clang_analyze_test()` runs The Clang Static Analyzer natively without CodeChecker. To use it, add the following to your BUILD file:
+
+```python
+load(
+    "@bazel_codechecker//src:clang.bzl",
+    "clang_analyze_test",
+)
+
+clang_analyze_test(
+    name = "your_rule_name",
+    targets = [
+        "your_target",
+    ],
+)
+```
+
+### Generating a compilation database: `compile_commands()`
+
+As generating a compilation database for C/C++ is a known pain point for bazel, this repository defines the Bazel rule `compile_commands()` rule which can be used indendently of CodeChecker. The implementation is basen on https://github.com/grailbio/bazel-compilation-database with some fixes on some tricky edge cases. To use it, include the following in your BUILD file:
+
+```python
+load(
+    "@bazel_codechecker//src:compile_commands.bzl",
+    "compile_commands",
+)
+```
+
+Then use `compile_commands()` rule passing build targets:
+
+```python
+compile_commands(
+    name = "your_compile_commands_rule_name",
+    targets = [
+        "your_target",
+    ],
+)
+```
+You can find the generated `compile_commands.json` under `bazel-bin/`.
+
+## Experimental rules
+
 ### Per-file CodeChecker analysis: `code_checker_test()`
 > [!IMPORTANT]
 > The rule is still in prototype status and is subject to changes or removal without notice. See [#31](https://github.com/Ericsson/codechecker_bazel/issues/31).
@@ -260,52 +331,7 @@ CodeChecker parse bazel-bin/your_code_checker_rule_name/data
 CodeChecker store bazel-bin/your_code_checker_rule_name/data -n "Run name"
 ```
 
-## CodeChecker independent rules
-
-The following rules are _not_ using CodeChecker.
-
-### Clang-tidy: `clang_tidy_aspect()` and `clang_tidy_test()`
-
-The Bazel rule `clang_tidy_test()` runs clang-tidy natively without CodeChecker. To use it, add the following to your BUILD file:
-
-```python
-load(
-    "@bazel_codechecker//src:clang.bzl",
-    "clang_tidy_test",
-)
-
-clang_tidy_test(
-    name = "your_rule_name",
-    targets = [
-        "your_target",
-    ],
-)
-```
-
-You can also run clang-tidy via the Bazel aspect `clang_tidy_aspect()` that can be invoked from the command line by passing the following parameter to Bazel build/test: `--aspects @bazel_codechecker//src:clang.bzl%clang_tidy_aspect`:
-
-```bash
-bazel build ... --aspects @bazel_codechecker//src:clang.bzl%clang_tidy_aspect --output_groups=report
-```
-
-### Clang Static Analyzer: `clang_analyze_test()` and `clang_ctu_test()`
-
-The Bazel rule `clang_analyze_test()` runs The Clang Static Analyzer natively without CodeChecker. To use it, add the following to your BUILD file:
-
-```python
-load(
-    "@bazel_codechecker//src:clang.bzl",
-    "clang_analyze_test",
-)
-
-clang_analyze_test(
-    name = "your_rule_name",
-    targets = [
-        "your_target",
-    ],
-)
-```
-
+### Cross-translation unit analysis via the Clang Static Analyzer: `clang_ctu_test()`
 > [!IMPORTANT]
 > The rule is still in prototype status and is subject to changes or removal without notice. See [#32](https://github.com/Ericsson/codechecker_bazel/issues/32).
 > We are also actively pursuing better CTU support _using_ CodeChecker.
@@ -325,29 +351,6 @@ clang_ctu_test(
     ],
 )
 ```
-
-### Generating a compilation database: `compile_commands()`
-
-As generating a compilation database for C/C++ is a known pain point for bazel, this repository defines the Bazel rule `compile_commands()` rule which can be used indendently of CodeChecker. The implementation is basen on https://github.com/grailbio/bazel-compilation-database with some fixes on some tricky edge cases. To use it, include the following in your BUILD file:
-
-```python
-load(
-    "@bazel_codechecker//src:compile_commands.bzl",
-    "compile_commands",
-)
-```
-
-Then use `compile_commands()` rule passing build targets:
-
-```python
-compile_commands(
-    name = "your_compile_commands_rule_name",
-    targets = [
-        "your_target",
-    ],
-)
-```
-You can find the generated `compile_commands.json` under `bazel-bin/`.
 
 Examples
 --------

--- a/README.md
+++ b/README.md
@@ -131,7 +131,9 @@ codechecker_test(
 Then invoke bazel:
 
 ```bash
-bazel build ://your_codechecker_rule_name
+bazel test ://your_codechecker_rule_name
+# Or, as a part of the rest of the testsuite
+bazel test ...
 ```
 
 You can find the analysis results in the `bazel-bin/` folder, on which you
@@ -141,6 +143,8 @@ or [`CodeChecker parse`](https://github.com/Ericsson/codechecker/blob/master/doc
 ```bash
 CodeChecker parse bazel-bin/path/to/results
 ```
+
+<!-- For now, we consider codechecker() to be an internal rule.
 
 ### Build-only CodeChecker analysis: `codechecker()`
 
@@ -153,6 +157,8 @@ load(
     "codechecker"
 )
 ```
+
+-->
 
 ### Multiplatform CodeChechecker analysis: `codechecker_suite()`
 
@@ -168,7 +174,7 @@ load(
 
 ### `codechecker_config()`
 
-Using the Bazel rule `codechecker_config()` you can parse a CodeChecker [configuration file](https://github.com/Ericsson/codechecker/blob/master/docs/config_file.md).
+Using the Bazel rule `codechecker_config()` you can utilize a CodeChecker [configuration file](https://github.com/Ericsson/codechecker/blob/master/docs/config_file.md).
 
 First, include the rule in your BUILD file:
 
@@ -179,7 +185,7 @@ load(
 )
 ```
 
-Create a CodeChecker configuration file e.g. `config.json` (see example [here](https://github.com/Szelethus/codechecker_bazel/blob/readme_update/test/config.json)) and parse it using `codechecker_config()`. 
+Create a CodeChecker configuration file e.g. `config.json` (see example [here](https://github.com/Ericsson/codechecker_bazel/blob/readme_update/test/config.json)) and parse it using `codechecker_config()`.
 
 ```python
 codechecker_config(
@@ -246,7 +252,9 @@ code_checker_test(
 ```
 
 ```bash
-bazel build ://your_code_checker_rule_name
+bazel test ://your_code_checker_rule_name
+# Or, as a part of the rest of the testsuite
+bazel test ...
 ```
 
 The analysis results can be found and stored/parsed similarly to [`codechecker_test`](README.md#standard-codechecker-invocation-codechecker_test)

--- a/README.md
+++ b/README.md
@@ -162,7 +162,8 @@ load(
 -->
 
 ### Multiplatform CodeChechecker analysis: `codechecker_suite()`
-
+_TODO: Describe this rule: see issue [#44](https://github.com/Ericsson/codechecker_bazel/issues/44)._
+<!--
 This rule is functionally equivalent to `codechecker_test()` but allows for running on multiple platforms via the `platforms` parameter.
 You can include and use it similarly as well:
 
@@ -172,7 +173,7 @@ load(
     "codechecker_suite"
 )
 ```
-
+-->
 ### `codechecker_config()`
 
 Using the Bazel rule `codechecker_config()` you can utilize a CodeChecker [configuration file](https://github.com/Ericsson/codechecker/blob/master/docs/config_file.md).

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The main Bazel rule for CodeChecker is `codechecker_test()`.
 ### Clang-tidy
 
 Clang-tidy is a fast static analyzer/linter for the C family of languages. This
-repository provides Bazel aspect `clang_tidy_aspect` and rule `clang_tidy_test()`
+repository provides Bazel aspect `clang_tidy_aspect()` and rule `clang_tidy_test()`
 to run clang-tidy natively (without CodeChecker).
 
 Find more information about LLVM clang-tidy:
@@ -149,7 +149,7 @@ CodeChecker store bazel-bin/your_codechecker_rule_name/codechecker-files/data -n
 
 ### Build-only CodeChecker analysis: `codechecker()`
 
-This rule is functionally equivalent to `codechecker_test` but omits the test phase where either PASS or FAIL isc printed.
+This rule is functionally equivalent to `codechecker_test()` but omits the test phase where either PASS or FAIL isc printed.
 You can include and use it similarly as well:
 
 ```python
@@ -163,7 +163,7 @@ load(
 
 ### Multiplatform CodeChechecker analysis: `codechecker_suite()`
 
-This rule is functionally equivalent to `codechecker_test` but allows for running on multiple platforms via the `platforms` parameter.
+This rule is functionally equivalent to `codechecker_test()` but allows for running on multiple platforms via the `platforms` parameter.
 You can include and use it similarly as well:
 
 ```python
@@ -209,7 +209,7 @@ codechecker_config(
 )
 ```
 
-You can now configure your `codechecker`, `codechecker_suite`, `codechecker_test` and `code_checker_test` targets using the above configuration:
+You can now configure your `codechecker_suite()`, `codechecker_test()` and `code_checker_test()` targets using the above configuration:
 
 ```python
 codechecker_test(
@@ -241,7 +241,7 @@ load(
 )
 ```
 
-Create a `code_checker_test()` target by passing targets you'd like CodeChecker to analyze, similarly to `codechecker_test`:
+Create a `code_checker_test()` target by passing targets you'd like CodeChecker to analyze, similarly to `codechecker_test()`:
 
 ```python
 code_checker_test(
@@ -252,7 +252,7 @@ code_checker_test(
 )
 ```
 
-You can find the analysis results in the `bazel-bin/` folder similarly to [`codechecker_test`](README.md#standard-codechecker-invocation-codechecker_test),
+You can find the analysis results in the `bazel-bin/` folder similarly to [`codechecker_test()`](README.md#standard-codechecker-invocation-codechecker_test),
 only without the `codechecker-files` directory. You can also parse/store similarly:
 
 ```bash
@@ -264,9 +264,9 @@ CodeChecker store bazel-bin/your_code_checker_rule_name/data -n "Run name"
 
 The following rules are _not_ using CodeChecker.
 
-### Clang-tidy: `clang_tidy_aspect` and `clang_tidy_test()`
+### Clang-tidy: `clang_tidy_aspect()` and `clang_tidy_test()`
 
-The Bazel rule `clang_tidy_test` runs clang-tidy natively without CodeChecker. To use it, add the following to your BUILD file:
+The Bazel rule `clang_tidy_test()` runs clang-tidy natively without CodeChecker. To use it, add the following to your BUILD file:
 
 ```python
 load(
@@ -282,15 +282,15 @@ clang_tidy_test(
 )
 ```
 
-You can also run clang-tidy via the Bazel aspect `clang_tidy_aspect` that can be invoked from the command line by passing the following parameter to Bazel build/test: `--aspects @bazel_codechecker//src:clang.bzl%clang_tidy_aspect`:
+You can also run clang-tidy via the Bazel aspect `clang_tidy_aspect()` that can be invoked from the command line by passing the following parameter to Bazel build/test: `--aspects @bazel_codechecker//src:clang.bzl%clang_tidy_aspect`:
 
 ```bash
 bazel build ... --aspects @bazel_codechecker//src:clang.bzl%clang_tidy_aspect --output_groups=report
 ```
 
-### Clang Static Analyzer: `clang_analyze_test()` and `clang_ctu_test`
+### Clang Static Analyzer: `clang_analyze_test()` and `clang_ctu_test()`
 
-The Bazel rule `clang_analyze_test` runs The Clang Static Analyzer natively without CodeChecker. To use it, add the following to your BUILD file:
+The Bazel rule `clang_analyze_test()` runs The Clang Static Analyzer natively without CodeChecker. To use it, add the following to your BUILD file:
 
 ```python
 load(
@@ -310,7 +310,7 @@ clang_analyze_test(
 > The rule is still in prototype status and is subject to changes without notice. See [#32](https://github.com/Ericsson/codechecker_bazel/issues/32).
 > We are also actively pursuing better CTU support _using_ CodeChecker.
 
-The Bazel rule `clang_analyze_test` runs The Clang Static Analyzer with [cross translation unit analysis](https://clang.llvm.org/docs/analyzer/user-docs/CrossTranslationUnit.html) analysis without CodeChecker. To use it, add the following to your BUILD file:
+The Bazel rule `clang_analyze_test()` runs The Clang Static Analyzer with [cross translation unit analysis](https://clang.llvm.org/docs/analyzer/user-docs/CrossTranslationUnit.html) analysis without CodeChecker. To use it, add the following to your BUILD file:
 
 ```python
 load(
@@ -355,7 +355,7 @@ Examples
 In [test/BUILD](test/BUILD) you can find examples for `codechecker_test()`
 and for `compile_commands()` rules.
 
-For instance see `codechecker_pass` and `compile_commands_pass`.
+For instance see targets `codechecker_pass` and `compile_commands_pass`.
 
 Run all test Bazel targets:
 
@@ -369,6 +369,6 @@ After that you can find all artifacts in `bazel-bin` directory:
     # compile_commands.json for compile_commands_pass
     cat bazel-bin/test/compile_commands_pass/compile_commands.json
 
-To run `clang_tidy_aspect` on all C/C++ code:
+To run `clang_tidy_aspect()` on all C/C++ code:
 
     bazel build ... --aspects @bazel_codechecker//src:clang.bzl%clang_tidy_aspect --output_groups=report


### PR DESCRIPTION
I extended the README file to give a describe each rule currently found in the repository do and how can one load and use them. In particular, I wanted to draw attention to the difference in between codechecker_test and code_checker_test. Considering that many of these things are subject to change, I didn't wanna go overboard detailing each parameter yet.

This I hope is one PR among many aiming to improve our documentation. Considering that we are still in the early stages of this repository, the aim and scope are modest, and I'm not trying terribly hard to target a specific audience (soon-to-be-users, contributors, etc). Its simply an informal first impression page where every currently user-facing rules are described at least minimally.

There many other things that need to be done:
* Specify the minimal requirements and environment needed to pass all tests as they are now (https://github.com/Ericsson/codechecker_bazel/issues/29, #35 )
* A simple copy-paste command line to set up the repository and its requirements via apt, not only modules
* Have an actual user documentation, and update CONTRIBUTING.md.

Preview is here: https://github.com/Szelethus/codechecker_bazel/blob/readme_update/README.md