### PR TITLE
Resolve symlinks in all plist/yaml files under the classic codechecker rule

### DIFF
--- a/src/codechecker_script.py
+++ b/src/codechecker_script.py
@@ -294,7 +294,7 @@ def resolve_symlinks():
     logging.info("Processed file paths in %d files", files_processed)
 def update_file_paths():
     """ Fix bazel sandbox paths and resolve symbolic links in generated files to real paths """
-    #fix_bazel_paths() # this is unnecessary
+    fix_bazel_paths()
     resolve_symlinks()
 
 

--- a/src/codechecker_script.py
+++ b/src/codechecker_script.py
@@ -294,7 +294,7 @@ def resolve_symlinks():
     logging.info("Processed file paths in %d files", files_processed)
 def update_file_paths():
     """ Fix bazel sandbox paths and resolve symbolic links in generated files to real paths """
-    fix_bazel_paths()
+    #fix_bazel_paths() # this is unnecessary
     resolve_symlinks()
 
 

--- a/src/codechecker_script.py
+++ b/src/codechecker_script.py
@@ -32,11 +32,10 @@ BAZEL_PATHS = {
     r"\/sandbox\/processwrapper-sandbox\/\S*\/execroot\/": "/execroot/",
     START_PATH + r"\/worker\/build\/[0-9a-fA-F]{16}\/root\/": "",
     START_PATH + r"\/[0-9a-fA-F]{32}\/execroot\/": "",
-    # The path getting into the plist file on a docker img is:
-    # bazel_codechecker/bazel-out/k8-fastbuild/...
-    # But on regular other system its:
-    # /home/.../execroot/bazel_codechecker/bazel-out/k8-fastbuild/...
-    # This is because normally the runner is not the root user
+    # Running bazel with --spawn_strategy=processwrapper-sandbox
+    # results in its path being wrongly replaced!
+    # In that case the 1st then 3rd regex will match and leave the path in a
+    # half baked state, this regex just finishes the job
     r"<string>bazel_codechecker\/": "<string>",
 }
 

--- a/src/codechecker_script.py
+++ b/src/codechecker_script.py
@@ -27,19 +27,6 @@ CODECHECKER_SEVERITIES = "{Severities}"
 CODECHECKER_ENV = "{codechecker_env}"
 COMPILE_COMMANDS = "{compile_commands}"
 
-# Note: unused
-START_PATH = r"\/(?:(?!\.\s+)\S)+"
-BAZEL_PATHS = {
-    r"\/sandbox\/processwrapper-sandbox\/\S*\/execroot\/": "/execroot/",
-    START_PATH + r"\/worker\/build\/[0-9a-fA-F]{16}\/root\/": "",
-    START_PATH + r"\/[0-9a-fA-F]{32}\/execroot\/": "",
-    # Running bazel with --spawn_strategy=processwrapper-sandbox
-    # results in its path being wrongly replaced!
-    # In that case the 1st then 3rd regex will match and leave the path in a
-    # half baked state, this regex just finishes the job
-    r"<string>bazel_codechecker\/": "<string>",
-}
-
 
 def fail(message, exit_code=1):
     """ Print error message and return exit code """
@@ -199,26 +186,6 @@ def analyze():
         fail("Make sure that the target can be built first")
 
 
-def fix_bazel_paths():
-    """ Remove Bazel leading paths in all files """
-    # Note: unused
-    stage("Fix CodeChecker output:")
-    folder = CODECHECKER_FILES
-    logging.info("Fixing Bazel paths in %s", folder)
-    counter = 0
-    for root, _, files in os.walk(folder):
-        for filename in files:
-            fullpath = os.path.join(root, filename)
-            with open(fullpath, "rt") as data_file:
-                data = data_file.read()
-                for pattern, replace in BAZEL_PATHS.items():
-                    data = re.sub(pattern, replace, data)
-            with open(fullpath, "w") as data_file:
-                data_file.write(data)
-            counter += 1
-    logging.info("Fixed Bazel paths in %d files", counter)
-
-
 def realpath(filename):
     """ Return real full absolute path for given filename """
     if os.path.exists(filename):
@@ -296,7 +263,6 @@ def resolve_symlinks():
     logging.info("Processed file paths in %d files", files_processed)
 def update_file_paths():
     """ Fix bazel sandbox paths and resolve symbolic links in generated files to real paths """
-    #fix_bazel_paths() # this is unnecessary
     resolve_symlinks()
 
 

--- a/src/codechecker_script.py
+++ b/src/codechecker_script.py
@@ -32,7 +32,7 @@ BAZEL_PATHS = {
     r"\/sandbox\/processwrapper-sandbox\/\S*\/execroot\/": "/execroot/",
     START_PATH + r"\/worker\/build\/[0-9a-fA-F]{16}\/root\/": "",
     START_PATH + r"\/[0-9a-fA-F]{32}\/execroot\/": "",
-    r"^bazel_codechecker\/": "",
+    r"<string>bazel_codechecker\/": "<string>",
 }
 
 

--- a/src/codechecker_script.py
+++ b/src/codechecker_script.py
@@ -32,6 +32,11 @@ BAZEL_PATHS = {
     r"\/sandbox\/processwrapper-sandbox\/\S*\/execroot\/": "/execroot/",
     START_PATH + r"\/worker\/build\/[0-9a-fA-F]{16}\/root\/": "",
     START_PATH + r"\/[0-9a-fA-F]{32}\/execroot\/": "",
+    # The path getting into the plist file on a docker img is:
+    # bazel_codechecker/bazel-out/k8-fastbuild/...
+    # But on regular other system its:
+    # /home/.../execroot/bazel_codechecker/bazel-out/k8-fastbuild/...
+    # This is because normally the runner is not the root user
     r"<string>bazel_codechecker\/": "<string>",
 }
 

--- a/src/codechecker_script.py
+++ b/src/codechecker_script.py
@@ -32,6 +32,7 @@ BAZEL_PATHS = {
     r"\/sandbox\/processwrapper-sandbox\/\S*\/execroot\/": "/execroot/",
     START_PATH + r"\/worker\/build\/[0-9a-fA-F]{16}\/root\/": "",
     START_PATH + r"\/[0-9a-fA-F]{32}\/execroot\/": "",
+    r"bazel_codechecker\/": "",
 }
 
 

--- a/src/codechecker_script.py
+++ b/src/codechecker_script.py
@@ -27,6 +27,7 @@ CODECHECKER_SEVERITIES = "{Severities}"
 CODECHECKER_ENV = "{codechecker_env}"
 COMPILE_COMMANDS = "{compile_commands}"
 
+# Note: unused
 START_PATH = r"\/(?:(?!\.\s+)\S)+"
 BAZEL_PATHS = {
     r"\/sandbox\/processwrapper-sandbox\/\S*\/execroot\/": "/execroot/",
@@ -200,6 +201,7 @@ def analyze():
 
 def fix_bazel_paths():
     """ Remove Bazel leading paths in all files """
+    # Note: unused
     stage("Fix CodeChecker output:")
     folder = CODECHECKER_FILES
     logging.info("Fixing Bazel paths in %s", folder)

--- a/src/codechecker_script.py
+++ b/src/codechecker_script.py
@@ -27,16 +27,17 @@ CODECHECKER_SEVERITIES = "{Severities}"
 CODECHECKER_ENV = "{codechecker_env}"
 COMPILE_COMMANDS = "{compile_commands}"
 
-START_PATH = r"\/(?:(?!\.\s+)\S)+"
 BAZEL_PATHS = {
-    r"\/sandbox\/processwrapper-sandbox\/\S*\/execroot\/": "/execroot/",
-    START_PATH + r"\/worker\/build\/[0-9a-fA-F]{16}\/root\/": "",
-    START_PATH + r"\/[0-9a-fA-F]{32}\/execroot\/": "",
-    # Running bazel with --spawn_strategy=processwrapper-sandbox
-    # results in its path being wrongly replaced!
-    # In that case the 1st then 3rd regex will match and leave the path in a
-    # half baked state, this regex just finishes the job
-    r"<string>bazel_codechecker\/": "<string>",
+    # Running with Build Barn produces path output like:
+    # /worker/build/b301eed7f2bf2fd8/root/local_path.cc
+    # By removing the part until bin we have resolved the path to a local file 
+    r"\/worker\/build\/[a-z0-9]{16}\/root\/": "",
+    # Sometimes the previous part is followed by this, before the local_path:
+    r"bazel-out\/k8-fastbuild\/bin\/": "",
+    # Virtual includes seems to be just a folder between the package and the
+    # folder containing the header files, like this:
+    # /path/to/package/_virtual_include/folder_with_headers/header.h
+    r"\/_virtual_includes\/" : "/",
 }
 
 

--- a/src/codechecker_script.py
+++ b/src/codechecker_script.py
@@ -27,7 +27,6 @@ CODECHECKER_SEVERITIES = "{Severities}"
 CODECHECKER_ENV = "{codechecker_env}"
 COMPILE_COMMANDS = "{compile_commands}"
 
-# Note: unused
 START_PATH = r"\/(?:(?!\.\s+)\S)+"
 BAZEL_PATHS = {
     r"\/sandbox\/processwrapper-sandbox\/\S*\/execroot\/": "/execroot/",
@@ -201,7 +200,6 @@ def analyze():
 
 def fix_bazel_paths():
     """ Remove Bazel leading paths in all files """
-    # Note: unused
     stage("Fix CodeChecker output:")
     folder = CODECHECKER_FILES
     logging.info("Fixing Bazel paths in %s", folder)

--- a/src/codechecker_script.py
+++ b/src/codechecker_script.py
@@ -32,7 +32,7 @@ BAZEL_PATHS = {
     r"\/sandbox\/processwrapper-sandbox\/\S*\/execroot\/": "/execroot/",
     START_PATH + r"\/worker\/build\/[0-9a-fA-F]{16}\/root\/": "",
     START_PATH + r"\/[0-9a-fA-F]{32}\/execroot\/": "",
-    r"bazel_codechecker\/": "",
+    r"^bazel_codechecker\/": "",
 }
 
 

--- a/src/codechecker_script.py
+++ b/src/codechecker_script.py
@@ -280,13 +280,12 @@ def resolve_symlinks():
     files_processed = 0
     for root, _, files in os.walk(analyze_outdir):
         for filename in files:
-            if re.search("clang-tidy", filename):
-                filepath = os.path.join(root, filename)
-                if os.path.splitext(filepath)[1] == ".plist":
-                    resolve_plist_symlinks(filepath)
-                elif os.path.splitext(filepath)[1] == ".yaml":
-                    resolve_yaml_symlinks(filepath)
-                files_processed += 1
+            filepath = os.path.join(root, filename)
+            if os.path.splitext(filepath)[1] == ".plist":
+                resolve_plist_symlinks(filepath)
+            elif os.path.splitext(filepath)[1] == ".yaml":
+                resolve_yaml_symlinks(filepath)
+            files_processed += 1
     logging.info("Processed file paths in %d files", files_processed)
 def update_file_paths():
     """ Fix bazel sandbox paths and resolve symbolic links in generated files to real paths """

--- a/src/codechecker_script.py
+++ b/src/codechecker_script.py
@@ -293,9 +293,9 @@ def resolve_symlinks():
             files_processed += 1
     logging.info("Processed file paths in %d files", files_processed)
 def update_file_paths():
-    """ Fix bazel sandbox paths and resolve symbolic links in generated files to real paths """
-    fix_bazel_paths()
+    """ Resolve symlinks from local jobs, then try fixing path from remote executors """
     resolve_symlinks()
+    fix_bazel_paths()
 
 
 def parse():

--- a/test/unit/virtual_include/test_virtual_include.py
+++ b/test/unit/virtual_include/test_virtual_include.py
@@ -102,9 +102,7 @@ class TestVirtualInclude(TestBase):
         self.assertTrue(
             os.path.isdir(f"{self.BAZEL_BIN_DIR}/_virtual_includes")
         )
-        # FIXME: In the postprocessed plists, all _virtual_include paths
-        # should've been removed. Possible fix is in the github PR #14.
-        self.assertNotEqual(
+        self.assertEqual(
             self.contains_in_files(r"/_virtual_includes/", plist_files), []
         )
 


### PR DESCRIPTION
Why:
Paths in .plist (and yaml) files have not been correctly updated to point to the original file; they pointed to a /home/.cache/ folder.

What:
I have modified the CodeChecker wrapper Python script so as not to modify the file paths listed in the list files, and resolve the symlinks that way. Also I have removed a line disabling the symlink resolution if the checker is not calng-tidy.

Addresses:
#65

This test only fixes the single codechecker job rule, not the distributed one!
