### PR TITLE
Add a small test project to run codechecker_bazel on

### DIFF
--- a/.github/workflows/patch-test-proj.sh
+++ b/.github/workflows/patch-test-proj.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+FORK_REPO="$1"
+FORK_BRANCH="$2"
+
+git clone --recurse https://github.com/jbeder/yaml-cpp.git
+cd yaml-cpp
+git checkout yaml-cpp-0.7.0
+
+# Specify bazel version for bazelisk
+echo "6.5.0" > .bazelversion
+
+# Add codechecker to the project
+cat <<EOF >> BUILD.bazel
+#-------------------------------------------------------
+
+# codechecker rules
+load(
+    "@bazel_codechecker//src:codechecker.bzl",
+    "codechecker_test",
+)
+load(
+    "@bazel_codechecker//src:code_checker.bzl",
+    "code_checker_test",
+)
+
+
+codechecker_test(
+    name = "codechecker_test_yaml-cpp",
+    targets = [
+        ":yaml-cpp",
+    ],
+)
+
+code_checker_test(
+    name = "code_checker_test_yaml-cpp",
+    targets = [
+        ":yaml-cpp",
+    ],
+)
+
+#-------------------------------------------------------
+EOF
+
+cat <<EOF >> WORKSPACE
+#----------------------------------------------------
+
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
+git_repository(
+    name = "bazel_codechecker",
+    remote = "https://github.com/${FORK_REPO}",
+    branch = "${FORK_BRANCH}",
+)
+
+load(
+    "@bazel_codechecker//src:tools.bzl",
+    "register_default_codechecker",
+    "register_default_python_toolchain",
+)
+
+register_default_python_toolchain()
+
+register_default_codechecker()
+
+#----------------------------------------------------
+EOF

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,3 +48,44 @@ jobs:
                "CodeChecker finds different analyzers when running in " \
                "bazel's sandbox environment!"
           CodeChecker analyzers
+
+  small_test:
+    name: Small Project Test
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set bazel version to 6.5.0
+        run: echo "6.5.0" > .bazelversion
+
+      - name: Setup Bazel
+        uses: bazel-contrib/setup-bazel@0.15.0
+
+      - name: Install python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install CodeChecker analyzers
+        run: |
+          sudo apt-get update --quiet
+          sudo apt-get install --no-install-recommends \
+            clang \
+            clang-tools \
+            clang-tidy
+
+      - name: Install CodeChecker
+        run: pip3 install codechecker
+
+      - name: Patch yaml-cpp
+        run:  |
+          sh .github/workflows/patch-test-proj.sh ${{ github.repository }} ${{ github.ref }}
+
+      - name: Run Bazel CodeChecker
+        run: |
+          cd yaml-cpp
+          bazel build :codechecker_test_yaml-cpp
+
+


### PR DESCRIPTION
Created a ci job (small_test), to run the codechecker Bazel rule on a tiny Bazel project (yaml-cpp)