### PR TITLE
Fix per-file incremental analysis

### DIFF
--- a/src/code_checker.bzl
+++ b/src/code_checker.bzl
@@ -320,7 +320,7 @@ def _code_checker_impl(ctx):
                         options,
                         compile_commands_json,
                         compilation_context,
-                        sources_and_headers
+                        sources_and_headers,
                     )
                     all_files += outputs
     ctx.actions.write(

--- a/src/code_checker.bzl
+++ b/src/code_checker.bzl
@@ -62,7 +62,9 @@ def _run_code_checker(
     clangsa_plist = ctx.actions.declare_file(clangsa_plist_file_name)
     codechecker_log = ctx.actions.declare_file(codechecker_log_file_name)
 
-    inputs = depset([compile_commands_json, src], transitive = sources_and_headers)
+    # NOTE: we collect only headers, so CTU may not work!
+    headers = depset([src], transitive = [compilation_context.headers])
+    inputs = depset([compile_commands_json, src], transitive = [headers])
     outputs = [clang_tidy_plist, clangsa_plist, codechecker_log]
 
     # Create CodeChecker wrapper script

--- a/test/unit/caching/test_caching.py
+++ b/test/unit/caching/test_caching.py
@@ -73,10 +73,8 @@ class TestCaching(TestBase):
             self.fail(f"File not found!")
         ret, _, stderr = self.run_command(f"bazel build {target} --subcommands")
         self.assertEqual(ret, 0)
-        # FIXME: This should be 1; 2 means that both .cpp files were reanalyzed
-        # despite only one of them being changed.
         self.assertEqual(
-            stderr.count(f"SUBCOMMAND: # {target} [action 'CodeChecker"), 2
+            stderr.count(f"SUBCOMMAND: # {target} [action 'CodeChecker"), 1
         )
 
     def test_bazel_test_code_checker_ctu_caching(self):


### PR DESCRIPTION
Why: Incremental analysis doesn't work with the per-file rule

What: Make inputs dependent on headers only
Note: depending on headers only may mean that CTU wont work!

Test:
```
bazel clean --expunge
bazel build //test:code_checker_fail -s
vim test/src/pass.cc
bazel build //test:code_checker_fail -s
```

Addresses: #21
