### PR TITLE
Add test for symlink resolution

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -79,6 +79,15 @@ cc_binary(
     ],
 )
 
+# Test for resolving virtual include prefix
+cc_binary(
+    name = "virtual_include",
+    srcs = ["src/virtual_include.cc"],
+    deps = [":test_inc"],
+    includes = ["inc"],
+)
+
+
 # Generate compile_commands.json file for host test
 compile_commands(
     name = "compile_commands_pass",
@@ -128,6 +137,14 @@ codechecker(
     ],
 )
 
+# Simplest virtual include resolution test
+codechecker(
+    name = "codechecker_virtual_include",
+    targets = [
+        "virtual_include",
+    ],
+)
+
 # Simplest codechecker_test example
 # Runs CodeChecker on "test_pass" target
 codechecker_test(
@@ -151,6 +168,9 @@ codechecker_test(
     ],
     targets = [
         "test_fail",
+    ],
+    analyze = [
+        "--analyzers clangsa clang-tidy",
     ],
 )
 

--- a/test/inc/error.h
+++ b/test/inc/error.h
@@ -1,0 +1,5 @@
+#pragma once
+
+inline void hello() {
+    int x = 10/0;
+}

--- a/test/src/virtual_include.cc
+++ b/test/src/virtual_include.cc
@@ -1,0 +1,5 @@
+#include "error.h"
+
+int main() {
+    return 0;
+}

--- a/test/test.py
+++ b/test/test.py
@@ -22,6 +22,7 @@ import shlex
 import subprocess
 import sys
 import unittest
+import glob
 
 
 class TestBase(unittest.TestCase):
@@ -199,6 +200,16 @@ class TestBasic(TestBase):
             self.BAZEL_TESTLOGS_DIR, "code_checker_ctu", "test.log")
         self.grep_file(logfile, "// CTU example")
 
+    def test_bazel_plist_path_resolved(self):
+        """Test: bazel build :codechecker_virtual_include"""
+        self.check_command("bazel build :codechecker_virtual_include", exit_code=0)
+        plist_files = glob.glob(os.path.join(self.BAZEL_BIN_DIR, "**", "*.plist"), recursive=True)
+        for plist_file in plist_files:
+            logging.debug(f"Checking file: {plist_file}")
+            with open(plist_file, "r") as f:
+                content = f.read()
+                if re.search(r"/_virtual_includes/", content):
+                    self.fail(f"Found unresolved symlink within CodeChecker report: {plist_file}")
 
 def setup_logging():
     """Setup logging level for test execution"""


### PR DESCRIPTION
Test for #14 

The problem was that paths in plist files didn't get resolved when there was an error in a header file.

To reproduce the bug, I had to:
- Add a header file that contains an error
- Add a source file that includes said header
- Add a rule for the new source file