### PR TITLE
CI for unit tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,3 +48,47 @@ jobs:
                "CodeChecker finds different analyzers when running in " \
                "bazel's sandbox environment!"
           CodeChecker analyzers
+
+  unit_test:
+    name: Unit Test
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set bazel version to 6.5.0
+        run: echo "6.5.0" > .bazelversion
+
+      - name: Setup Bazel
+        uses: bazel-contrib/setup-bazel@0.15.0
+
+      - name: Install python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install CodeChecker analyzers
+        run: |
+          sudo apt-get update --quiet
+          sudo apt-get install --no-install-recommends \
+            clang \
+            clang-tools \
+            clang-tidy
+
+      - name: Install CodeChecker
+        run: pip3 install codechecker
+
+      - name: Print versions
+        run: |
+          bazel version
+          CodeChecker version
+          echo "[NOTE]: If you are debugging, its possible that " \
+               "CodeChecker finds different analyzers when running in " \
+               "bazel's sandbox environment!"
+          CodeChecker analyzers
+
+      - name: Run tests
+        run: |
+          cd test
+          python3 test.py -vvv

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,54 +36,16 @@ jobs:
             clang \
             clang-tools \
             clang-tidy
+          # clang-extdef-mapping is only available through
+          # clang-extdef-mapping-18 by default, but during ctu analysis
+          # we use it without version number (see clang_ctu.bzl).
+          # The sed command, extracts the version number from clang
+          # it reads the number from the word version to the first decimal point.
           sudo update-alternatives --install \
             /usr/bin/clang-extdef-mapping \
             clang-extdef-mapping \
-            /usr/bin/clang-extdef-mapping-$(clang --version | head -n 1 | sed -E 's/.*version ([0-9]+)\..*/\1/') \
-            100
-
-      - name: Install CodeChecker
-        run: pip3 install codechecker
-
-      - name: Print versions
-        run: |
-          bazel version
-          CodeChecker version
-          echo "[NOTE]: If you are debugging, its possible that " \
-               "CodeChecker finds different analyzers when running in " \
-               "bazel's sandbox environment!"
-          CodeChecker analyzers
-
-  unit_test:
-    name: Unit Test
-    runs-on: ubuntu-24.04
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set bazel version to 6.5.0
-        run: echo "6.5.0" > .bazelversion
-
-      - name: Setup Bazel
-        uses: bazel-contrib/setup-bazel@0.15.0
-
-      - name: Install python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-
-      - name: Install CodeChecker analyzers
-        run: |
-          sudo apt-get update --quiet
-          sudo apt-get install --no-install-recommends \
-            clang \
-            clang-tools \
-            clang-tidy
-          sudo update-alternatives --install \
-            /usr/bin/clang-extdef-mapping \
-            clang-extdef-mapping \
-            /usr/bin/clang-extdef-mapping-$(clang --version | head -n 1 | sed -E 's/.*version ([0-9]+)\..*/\1/') \
+            /usr/bin/clang-extdef-mapping-$(clang --version | head -n 1 |
+            sed -E 's/.*version ([0-9]+)\..*/\1/') \
             100
 
       - name: Install CodeChecker

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,11 +36,11 @@ jobs:
             clang \
             clang-tools \
             clang-tidy
-          # clang-extdef-mapping is only available through
-          # clang-extdef-mapping-18 by default, but during ctu analysis
-          # we use it without version number (see clang_ctu.bzl).
-          # The sed command, extracts the version number from clang
-          # it reads the number from the word version to the first decimal point.
+          # The default naming of the clang-extdef-mapping, needed for CTU, is
+          # installed by clang-tools also contains the major version
+          # (e.g. clang-extdef-mapping-18), but the bazel rules reference it
+          # without the version number. To this end, we use update-alternatives
+          # to rename the binary to omit it.
           sudo update-alternatives --install \
             /usr/bin/clang-extdef-mapping \
             clang-extdef-mapping \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,11 @@ jobs:
             clang \
             clang-tools \
             clang-tidy
+          sudo update-alternatives --install \
+            /usr/bin/clang-extdef-mapping \
+            clang-extdef-mapping \
+            /usr/bin/clang-extdef-mapping-$(clang --version | head -n 1 | sed -E 's/.*version ([0-9]+)\..*/\1/') \
+            100
 
       - name: Install CodeChecker
         run: pip3 install codechecker
@@ -75,6 +80,11 @@ jobs:
             clang \
             clang-tools \
             clang-tidy
+          sudo update-alternatives --install \
+            /usr/bin/clang-extdef-mapping \
+            clang-extdef-mapping \
+            /usr/bin/clang-extdef-mapping-$(clang --version | head -n 1 | sed -E 's/.*version ([0-9]+)\..*/\1/') \
+            100
 
       - name: Install CodeChecker
         run: pip3 install codechecker

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   rules_test:
-    name: Analysis
+    name: Unit tests
     runs-on: ubuntu-24.04
 
     steps:
@@ -47,6 +47,7 @@ jobs:
             /usr/bin/clang-extdef-mapping-$(clang --version | head -n 1 |
             sed -E 's/.*version ([0-9]+)\..*/\1/') \
             100
+          
 
       - name: Install CodeChecker
         run: pip3 install codechecker

--- a/test/BUILD
+++ b/test/BUILD
@@ -134,7 +134,6 @@ codechecker_test(
     name = "codechecker_pass",
     analyze = [
         "--ctu",
-        "--stats",
     ],
     config = "codechecker_config_json",
     targets = [
@@ -260,7 +259,6 @@ code_checker_test(
     name = "code_checker_pass",
     options = [
         "--ctu",
-        "--stats",
     ],
     targets = [
         "test_pass",
@@ -284,7 +282,6 @@ code_checker_test(
     name = "code_checker_ctu",
     options = [
         "--ctu",
-        "--stats",
     ],
     tags = [
         "manual",


### PR DESCRIPTION
We should run the unit tests for every commit!

I have added the update-alternative command, because by default, `clang-extdef-mapping` was only accessible through `clang-extdef-mapping-18`

removed `--stat` option, opensource clang doesn't support this flag

While all tests are passing, keep #26 in mind! It only passes because we don't install cppcheck or Infer.