### PR TITLE
Disable ccache

### DIFF
--- a/src/clang.bzl
+++ b/src/clang.bzl
@@ -2,6 +2,7 @@ load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 
 CLANG_TIDY_WRAPPER_SCRIPT = """#!/usr/bin/env bash
+export CCACHE_DISABLE=1
 CLANG_TIDY=$1
 shift
 OUTPUT=$1
@@ -17,6 +18,7 @@ $CLANG_TIDY --config-file=$CONFIG --export-fixes=$OUTPUT $@ 2>&1
 """
 
 CLANG_ANALYZE_WRAPPER_SCRIPT = """#!/usr/bin/env bash
+export CCACHE_DISABLE=1
 CLANG=$1
 shift
 OUTPUT=$1

--- a/src/clang_ctu.bzl
+++ b/src/clang_ctu.bzl
@@ -3,6 +3,7 @@ load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 
 CLANG_CTU_WRAPPER_SCRIPT = """#!/usr/bin/env bash
 #set -x
+export CCACHE_DISABLE=1
 REPORT_TYPE=$1
 shift
 REPORT_FILE=$1

--- a/src/code_checker.bzl
+++ b/src/code_checker.bzl
@@ -5,6 +5,7 @@ load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 
 CODE_CHECKER_WRAPPER_SCRIPT = """#!/usr/bin/env bash
+export CCACHE_DISABLE=1
 #set -x
 DATA_DIR=$1
 shift


### PR DESCRIPTION
Why: ccache can't run with bazel
What: Add `export CCACHE_DISABLE=1` to every script

fixes: #36

The `--stat` build flag still causes issues, removing that, all tests are passing on my system