### PR TITLE
Add unittest on rhel9

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -106,9 +106,9 @@ jobs:
         run: |
           bazel version
           CodeChecker version
-          echo "[NOTE]: If you are debugging, its possible that " \
-               "CodeChecker finds different analyzers when running in " \
-               "bazel's sandbox environment!"
+          echo "[NOTE]: CodeChecker may find different analyzer binaries" \
+               "when invoking directly, or in bazel's sandbox environment!" \
+               "Be sure to double check during debugging."
           CodeChecker analyzers
 
       - name: Run tests


### PR DESCRIPTION
## Why
We want to support RHEL systems, so we should run our unit tests on RHEL systems too.

## What
Added a new CI job that sets up the environment for a RHEL system and runs unittest on it.

## Scope
* Limited: One acceptance is likely sufficient before merging.

## Addresses
#50 