### PR TITLE
Create a task issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/Task.yaml
+++ b/.github/ISSUE_TEMPLATE/Task.yaml
@@ -1,0 +1,27 @@
+name: Task
+description: Create a task that needs to be discussed, investigated, or implemented.
+type: task
+body:
+  - type: textarea
+    id: describe-task
+    attributes:
+      label: Describe the task
+      description: A clear and concise description of what the task is.
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: List the points detailing the parts of this task that need to be discussed/investigated/implemented.
+    validations:
+      required: true
+
+  - type: textarea
+    id: definition-of-done
+    attributes:
+      label: Definition of Done
+      description: What criteria need to be met for this issue to be closed (e.g., which files to have updated, consensus reached, feature implemented)?
+    validations:
+      required: true


### PR DESCRIPTION
Why: People who submit tasks need to follow some structure so that it's clear what the task is about, what are the action points in it, and when an issue can be regarded as completed.

What: 
* Add a general description, scope and DoD fields to the github template.
* Its quite important to do this under the original repo (under the `Ericsson` org), because issue types are an organizational setting, and if done under my own fork (under `Szelethus`) [I'm getting a warning](https://github.com/Szelethus/codechecker_bazel/blob/task_issue_template/.github/ISSUE_TEMPLATE/Task.yaml).
* For a peek, see the file here: https://github.com/Ericsson/codechecker_bazel/blob/issue-template-test/.github/ISSUE_TEMPLATE/Task.yaml
* Supersedes #48 because the source branch was changed.

Scope: The scope is minimal and a single accept should suffice.

Addresses: The task template component of #34.