### PR TITLE
Add gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/bazel-bin
+/bazel-codechecker_bazel
+/bazel-out
+/bazel-testlogs


### PR DESCRIPTION
Why:
Bazel artifacts shouldn't be tracked by git.

What:
Added bazel artifacts to .gitignore

Scope:
* Limited: One acceptance is likely sufficient before merging.

Addresses:
closing: #56 