### PR TITLE
Create common lib

### DIFF
--- a/test/unit/common/base.py
+++ b/test/unit/common/base.py
@@ -1,0 +1,63 @@
+"""
+Unit and functional tests
+"""
+import logging
+import os
+import re
+import shlex
+import subprocess
+import unittest
+
+class TestBase(unittest.TestCase):
+    """Unittest base abstract class"""
+    @classmethod
+    def setUpClass(cls):
+        """Load module, save environment"""
+        # Save environment and location
+        cls.save_env = os.environ
+        cls.save_cwd = os.getcwd()
+        # Move to test dir
+        cls.test_dir = os.path.abspath(os.path.dirname(__file__))
+        os.chdir(cls.test_dir)
+
+    @classmethod
+    def tearDownClass(cls):
+        """Restore environment"""
+        os.chdir(cls.save_cwd)
+        os.environ = cls.save_env
+
+    def setUp(self):
+        """Before every test"""
+        logging.debug("\n%s", "-" * 70)
+
+    def check_command(self, cmd, exit_code=0):
+        """Run shell command and check status"""
+        logging.debug("Running: %s", cmd)
+        commands = shlex.split(cmd)
+        with subprocess.Popen(commands,
+                              stdin=subprocess.PIPE,
+                              stdout=subprocess.PIPE,
+                              stderr=subprocess.PIPE) as process:
+            stdout, stderr = process.communicate()
+            self.assertEqual(
+                process.returncode,
+                exit_code, "\n" + "\n".join([
+                    f"command: {cmd}",
+                    f"stdout: {stdout.decode('utf-8')}",
+                    f"stderr: {stderr.decode('utf-8')}"]))
+            return "\n".join([
+                    f"command: {cmd}",
+                    f"stdout: {stdout.decode('utf-8')}",
+                    f"stderr: {stderr.decode('utf-8')}"])
+
+    def grep_file(self, filename, regex):
+        """Grep given filename"""
+        pattern = re.compile(regex)
+        logging.debug("RegEx = r'%s'", regex)
+        with open(filename, "r", encoding="utf-8") as fileobj:
+            for line in fileobj:
+                if pattern.search(line):
+                    logging.debug(line)
+                    return line
+        self.fail(f"Could not find r'{regex}' in '{filename}'")
+        return ""


### PR DESCRIPTION
Why:
In our unit tests, we will have a lot of repeating parts. I created this common library to avoid writing the same code thousands of times.

What:
Created a folder named common in `unit/`, added the TestBase class to it.
 In the TestBase class, I modified the check_command function to return the exit code, stdout, and stderr of the command. I utilize this functionality in cache testing, and many tests may use it in the future.

Addresses:
#22