### PR TITLE
Add warning about Docker in getting started section

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ update-alternatives --install /usr/bin/clang clang /usr/bin/clang-18 100
 
 Install CodeChecker:
 > [!Note]
-> Currently the pip installed CodeChecker works best with these rules, which is our recommendation (as opposed to using acustom-built CodeChecker).
+> Currently the pip installed CodeChecker works best with these rules, which is our recommendation (as opposed to using a custom-built CodeChecker).
 
 ```bash
 python3 -m venv ./codechecker_venv && \

--- a/README.md
+++ b/README.md
@@ -113,6 +113,9 @@ Alternatively follow the official guide at: https://bazel.build/install
 > Don't use ccache! You should disable/remove/uninstall it, as the rules don't support it.
 <!-- TODO When we make a decision on how to handle ccache in #36, expand this section -->
 
+> [!WARNING]
+> When debugging, or reporting a bug, take into consideration which sandbox mode did bazel ran in. Be careful as the default sandbox can change if you ran [Bazel inside Docker](https://bazel.build/versions/6.5.0/docs/sandboxing#:~:text=Both%20the%20linux,run%20%2D%2Dprivileged.).
+
 How to use
 ----------
 


### PR DESCRIPTION
Why:
I had a very hard time figuring out why things worked differently in Docker. Now that I have found the answer to this question, I want to preserve it.

What:
Added a warning about Docker using different sandbox environments.

Addresses:
#64