### PR TITLE
Add ccache detection

### DIFF
--- a/src/clang_ctu.bzl
+++ b/src/clang_ctu.bzl
@@ -1,5 +1,9 @@
 load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
+load(
+    "@default_codechecker_tools//:defs.bzl",
+    "CCACHE_DISABLE"
+)
 
 CLANG_CTU_WRAPPER_SCRIPT = """#!/usr/bin/env bash
 #set -x
@@ -99,6 +103,11 @@ def _run_clang_ctu(
     args.add(src.path)
     args.add_all(arguments)
 
+    # Have it None by default to avoid overwriting use_default_shell_env
+    env_var = None
+    if CCACHE_DISABLE == 1:
+        env_var = {"CCACHE_DISABLE": CCACHE_DISABLE}
+
     # Action to run CodeChecker for a file
     ctx.actions.run(
         inputs = inputs,
@@ -106,6 +115,7 @@ def _run_clang_ctu(
         executable = wrapper,
         arguments = [args],
         mnemonic = "ClangCTU",
+        env = env_var,
         use_default_shell_env = True,
         progress_message = "clang -analyze +CTU {}".format(src.short_path),
     )

--- a/src/codechecker.bzl
+++ b/src/codechecker.bzl
@@ -9,6 +9,7 @@ load(
 load(
     "@default_codechecker_tools//:defs.bzl",
     "CODECHECKER_BIN_PATH",
+    "CCACHE_DISABLE"
 )
 load(
     "per_file.bzl",
@@ -102,6 +103,11 @@ def _codechecker_impl(ctx):
     if compile_commands != ctx.outputs.compile_commands:
         fail("Seems compile_commands.json file is incorrect!")
 
+    # Have it None by default to avoid overwriting use_default_shell_env
+    env_var = {}
+    if CCACHE_DISABLE == "1":
+        env_var["CCACHE_DISABLE"] = CCACHE_DISABLE
+
     # Convert flacc calls to clang in compile_commands.json
     # and save to codechecker_commands.json
     ctx.actions.run(
@@ -115,6 +121,7 @@ def _codechecker_impl(ctx):
         ],
         mnemonic = "CodeCheckerConvertFlaccToClang",
         progress_message = "Filtering %s" % str(ctx.label),
+        env = env_var,
         # use_default_shell_env = True,
     )
 
@@ -199,6 +206,7 @@ def _codechecker_impl(ctx):
         arguments = [],
         mnemonic = "CodeChecker",
         progress_message = "CodeChecker %s" % str(ctx.label),
+        env = env_var,
         # use_default_shell_env = True,
     )
 

--- a/src/per_file.bzl
+++ b/src/per_file.bzl
@@ -3,6 +3,10 @@
 
 load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
+load(
+    "@default_codechecker_tools//:defs.bzl",
+    "CCACHE_DISABLE"
+)
 
 CODE_CHECKER_WRAPPER_SCRIPT = """#!/usr/bin/env bash
 #set -x
@@ -94,6 +98,11 @@ def _run_code_checker(
     args.add("--output=" + data_dir)
     args.add("--file=*/" + src.path)
 
+    # Have it None by default to avoid overwriting use_default_shell_env
+    env_var = {}
+    if CCACHE_DISABLE == "1":
+        env_var["CCACHE_DISABLE"] = CCACHE_DISABLE
+
     # Action to run CodeChecker for a file
     ctx.actions.run(
         inputs = inputs,
@@ -101,6 +110,7 @@ def _run_code_checker(
         executable = wrapper,
         arguments = [args],
         mnemonic = "CodeChecker",
+        env = env_var,
         use_default_shell_env = True,
         progress_message = "CodeChecker analyze {}".format(src.short_path),
     )

--- a/src/tools.bzl
+++ b/src/tools.bzl
@@ -71,36 +71,6 @@ def register_default_python_toolchain():
     default_python_tools(name = "default_python_tools")
     native.register_toolchains("@default_python_tools//:python_toolchain")
 
-def parse_tool_output(output):
-    """
-    Parses a string of tool output and returns a dictionary.
-
-    Args:
-        output (str): The string output to parse. Each line should contain
-                      a tool name, its path (if found), and its version.
-
-    Returns:
-        dict: A dictionary where keys are tool names and values are dictionaries
-              containing 'path' and 'version'. If a tool is 'NOT FOUND', the
-              value is a dictionary with 'path' and 'version' both set to None.
-    """
-    parsed_data = []
-    lines = output.strip().split('\n')
-    for line in lines:
-        parts_dirty = line.split(" ")
-        parts = []
-        for fragment in parts_dirty:
-            if fragment != "":
-                parts.append(fragment)
-        tool_name = parts[0]
-        if 'NOT' not in parts:
-            path = parts[1]
-            version = parts[2]
-            parsed_data.append(
-                {'tool_name': tool_name, 'path': path, 'version': version}
-                )
-    return parsed_data
-
 def _codechecker_local_repository_impl(repository_ctx):
     repository_ctx.file(
         repository_ctx.path("BUILD"),
@@ -114,7 +84,22 @@ def _codechecker_local_repository_impl(repository_ctx):
 
     analyzers = repository_ctx.execute([codechecker_bin_path, "analyzers"])
 
-    parsed_analyzers = parse_tool_output(analyzers.stdout)
+    parsed_analyzers = []
+
+    lines = analyzers.stdout.strip().split('\n')
+    for line in lines:
+        parts_dirty = line.split(" ")
+        parts = []
+        for fragment in parts_dirty:
+            if fragment != "":
+                parts.append(fragment)
+        tool_name = parts[0]
+        if 'NOT' not in parts:
+            path = parts[1]
+            version = parts[2]
+            parsed_analyzers.append(
+                {'tool_name': tool_name, 'path': path, 'version': version}
+                )
 
     ccache_bin_path = repository_ctx.which("ccache")
     readlink_bin = repository_ctx.which("readlink")

--- a/src/tools.bzl
+++ b/src/tools.bzl
@@ -71,6 +71,36 @@ def register_default_python_toolchain():
     default_python_tools(name = "default_python_tools")
     native.register_toolchains("@default_python_tools//:python_toolchain")
 
+def parse_tool_output(output):
+    """
+    Parses a string of tool output and returns a dictionary.
+
+    Args:
+        output (str): The string output to parse. Each line should contain
+                      a tool name, its path (if found), and its version.
+
+    Returns:
+        dict: A dictionary where keys are tool names and values are dictionaries
+              containing 'path' and 'version'. If a tool is 'NOT FOUND', the
+              value is a dictionary with 'path' and 'version' both set to None.
+    """
+    parsed_data = []
+    lines = output.strip().split('\n')
+    for line in lines:
+        parts_dirty = line.split(" ")
+        parts = []
+        for fragment in parts_dirty:
+            if fragment != "":
+                parts.append(fragment)
+        tool_name = parts[0]
+        if 'NOT' not in parts:
+            path = parts[1]
+            version = parts[2]
+            parsed_data.append(
+                {'tool_name': tool_name, 'path': path, 'version': version}
+                )
+    return parsed_data
+
 def _codechecker_local_repository_impl(repository_ctx):
     repository_ctx.file(
         repository_ctx.path("BUILD"),
@@ -82,9 +112,18 @@ def _codechecker_local_repository_impl(repository_ctx):
     if not codechecker_bin_path:
         fail("ERROR! CodeChecker is not detected")
 
+    analyzers = repository_ctx.execute([codechecker_bin_path, "analyzers"])
+
+    parsed_analyzers = parse_tool_output(analyzers.stdout)
+
     ccache_bin_path = repository_ctx.which("ccache")
-    if ccache_bin_path:
-        fail("ERROR! ccache is detected")
+    readlink_bin = repository_ctx.which("readlink")
+    for item in parsed_analyzers:
+        realpath = repository_ctx.execute(
+            [readlink_bin, "-f", item["path"]]
+            ).stdout
+        if realpath.strip() == str(ccache_bin_path):
+            fail("ERROR! ccache detected")
 
     defs = "CODECHECKER_BIN_PATH = '{}'\n".format(codechecker_bin_path)
     repository_ctx.file(

--- a/src/tools.bzl
+++ b/src/tools.bzl
@@ -82,6 +82,10 @@ def _codechecker_local_repository_impl(repository_ctx):
     if not codechecker_bin_path:
         fail("ERROR! CodeChecker is not detected")
 
+    ccache_bin_path = repository_ctx.which("ccache")
+    if ccache_bin_path:
+        fail("ERROR! ccache is detected")
+
     defs = "CODECHECKER_BIN_PATH = '{}'\n".format(codechecker_bin_path)
     repository_ctx.file(
         repository_ctx.path("defs.bzl"),

--- a/src/tools.bzl
+++ b/src/tools.bzl
@@ -84,7 +84,18 @@ def _codechecker_local_repository_impl(repository_ctx):
 
     ccache_bin_path = repository_ctx.which("ccache")
     if ccache_bin_path:
-        fail("ERROR! ccache is detected")
+        gcc_bin_path = repository_ctx.which("gcc")
+        clang_bin_path = repository_ctx.which("clang")
+        readlink_bin_path = repository_ctx.which("readlink")
+        if readlink_bin_path:
+            gcc_bin_real = repository_ctc.execute(
+                [readlink_bin_path, "-f", gcc_bin_path]
+                )
+            clang_bin_real = repository_ctc.execute(
+                [readlink_bin_path, "-f", clang_bin_path]
+                )
+            if gcc_bin_real == ccache_bin_path or clang_bin_real == ccache_bin_path:
+                fail("ERROR! ccache is detected!")
 
     defs = "CODECHECKER_BIN_PATH = '{}'\n".format(codechecker_bin_path)
     repository_ctx.file(

--- a/src/tools.bzl
+++ b/src/tools.bzl
@@ -84,18 +84,7 @@ def _codechecker_local_repository_impl(repository_ctx):
 
     ccache_bin_path = repository_ctx.which("ccache")
     if ccache_bin_path:
-        gcc_bin_path = repository_ctx.which("gcc")
-        clang_bin_path = repository_ctx.which("clang")
-        readlink_bin_path = repository_ctx.which("readlink")
-        if readlink_bin_path:
-            gcc_bin_real = repository_ctc.execute(
-                [readlink_bin_path, "-f", gcc_bin_path]
-                )
-            clang_bin_real = repository_ctc.execute(
-                [readlink_bin_path, "-f", clang_bin_path]
-                )
-            if gcc_bin_real == ccache_bin_path or clang_bin_real == ccache_bin_path:
-                fail("ERROR! ccache is detected!")
+        fail("ERROR! ccache is detected")
 
     defs = "CODECHECKER_BIN_PATH = '{}'\n".format(codechecker_bin_path)
     repository_ctx.file(


### PR DESCRIPTION
Why:
Bazel and ccache don't work well together. We should warn the user that their analyzers use ccache and fail the job to force the user to disable ccache (by changing package_layout.json or uninstalling ccache)

What:
Extended the repository rule that detects CodeChecker to also detect ccache

Addresses:
Fixes https://github.com/Ericsson/codechecker_bazel/issues/36