### PR TITLE
Make distributed rule, dynamicly declare plist files for all analyzers

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -7,7 +7,10 @@ py_binary(
 
 # Build & Test script template
 exports_files(
-    ["codechecker_script.py"],
+    [
+        "codechecker_script.py",
+        "code_checker_script.py",
+    ],
 )
 
 # The following are flags and default values for clang_tidy_aspect

--- a/src/code_checker.bzl
+++ b/src/code_checker.bzl
@@ -55,6 +55,16 @@ def _run_code_checker(
         cppcheck_plist = ctx.actions.declare_file(cppcheck_plist_file_name)
         analyzer_output_paths += "cppcheck," + cppcheck_plist.path + ";"
         outputs.append(cppcheck_plist)
+    if "gcc" in analyzers:
+        gcc_plist_file_name = "{}/{}_gcc.plist".format(*file_name_params)
+        gcc_plist = ctx.actions.declare_file(gcc_plist_file_name)
+        analyzer_output_paths += "gcc," + gcc_plist.path + ";"
+        outputs.append(gcc_plist)
+    if "infer" in analyzers:
+        infer_plist_file_name = "{}/{}_infer.plist".format(*file_name_params)
+        infer_plist = ctx.actions.declare_file(infer_plist_file_name)
+        analyzer_output_paths += "infer," + infer_plist.path + ";"
+        outputs.append(infer_plist)
 
     # Action to run CodeChecker for a file
     ctx.actions.run(

--- a/src/code_checker_script.py
+++ b/src/code_checker_script.py
@@ -21,9 +21,12 @@ import shutil
 import subprocess
 import sys
 
-DATA_DIR: str = "{data_dir}"
-ANALYZER_PLIST_PATHS: list[tuple[str, str]] = {analyzer_output_list}
-LOG_FILE: str = "{log_file}"
+DATA_DIR: str = sys.argv[1]
+FILE_PATH: str = sys.argv[2]
+ANALYZER_PLIST_PATHS: list[list[str, str]] = [
+    item.split(",") for item in sys.argv[4].split(";")
+]
+LOG_FILE: str = sys.argv[3]
 COMPILE_COMMANDS_JSON: str = "{compile_commands_json}"
 COMPILE_COMMANDS_ABSOLUTE: str = f"{COMPILE_COMMANDS_JSON}.abs"
 CODECHECKER_ARGS: str = "{codechecker_args}"
@@ -72,6 +75,8 @@ log(result.stdout)
 codechecker_cmd: list[str] = (
     ["CodeChecker", "analyze"]
     + CODECHECKER_ARGS.split()
+    + ["--output=" + DATA_DIR]
+    + ["--file=*/" + FILE_PATH] 
     + [COMPILE_COMMANDS_ABSOLUTE]
 )
 

--- a/src/code_checker_script.py
+++ b/src/code_checker_script.py
@@ -33,84 +33,109 @@ CODECHECKER_ARGS: str = "{codechecker_args}"
 
 
 def log(msg: str) -> None:
+    """
+    Append message to the log file
+    """
     with open(LOG_FILE, "a") as log_file:
         log_file.write(msg)
 
 
-with open(COMPILE_COMMANDS_JSON, "r") as original_file, open(
-    COMPILE_COMMANDS_ABSOLUTE, "w"
-) as new_file:
-    content = original_file.read()
-    # Replace '"directory":"."' with the absolute path
-    # of the current working directory
-    new_content = content.replace(
-        '"directory":".', f'"directory":"{os.getcwd()}'
-    )
-    new_file.write(new_content)
-
-with open(LOG_FILE, "w") as log_file:
-    log_file.write(
-        f"CodeChecker command: CodeChecker analyze {CODECHECKER_ARGS} \
-{COMPILE_COMMANDS_ABSOLUTE}\n"
-    )
-    log_file.write(
-        "===-----------------------------------------------------===\n"
-    )
-    log_file.write(
-        "                   CodeChecker error log                   \n"
-    )
-    log_file.write(
-        "===-----------------------------------------------------===\n"
-    )
-
-result = subprocess.run(
-    ["echo", "$PATH"],
-    shell=True,
-    env=os.environ,
-    capture_output=True,
-    text=True,
-)
-log(result.stdout)
-
-codechecker_cmd: list[str] = (
-    ["CodeChecker", "analyze"]
-    + CODECHECKER_ARGS.split()
-    + ["--output=" + DATA_DIR]
-    + ["--file=*/" + FILE_PATH] 
-    + [COMPILE_COMMANDS_ABSOLUTE]
-)
-
-try:
-    with open(LOG_FILE, "a") as log_file:
-        proc = subprocess.run(
-            codechecker_cmd,
-            env=os.environ,
-            stdout=log_file,
-            stderr=log_file,
-            check=True,
+def _create_compile_commands_json_with_absolute_paths():
+    """
+    Modifies the paths in compile_commands.json to contain the absolute path
+    of the files.
+    """
+    with open(COMPILE_COMMANDS_JSON, "r") as original_file, open(
+        COMPILE_COMMANDS_ABSOLUTE, "w"
+    ) as new_file:
+        content = original_file.read()
+        # Replace '"directory":"."' with the absolute path
+        # of the current working directory
+        new_content = content.replace(
+            '"directory":".', f'"directory":"{os.getcwd()}'
         )
-    ret_code = 0
-except subprocess.CalledProcessError as e:
-    ret_code = e.returncode
-    with open(LOG_FILE, "a") as log_file:
-        log_file.write(e.output.decode() if e.output else "")
+        new_file.write(new_content)
 
-# Log and exit on error
-if ret_code == 1 or ret_code >= 128:
+
+def _run_codechecker() -> None:
+    """
+    Runs CodeChecker analyze
+    """
+    log(
+        f"CodeChecker command: CodeChecker analyze {CODECHECKER_ARGS} \
+{COMPILE_COMMANDS_ABSOLUTE} --output={DATA_DIR} --file=*/{FILE_PATH}\n"
+    )
+    log("===-----------------------------------------------------===\n")
+    log("                   CodeChecker error log                   \n")
+    log("===-----------------------------------------------------===\n")
+
+    result = subprocess.run(
+        ["echo", "$PATH"],
+        shell=True,
+        env=os.environ,
+        capture_output=True,
+        text=True,
+    )
+    log(result.stdout)
+
+    codechecker_cmd: list[str] = (
+        ["CodeChecker", "analyze"]
+        + CODECHECKER_ARGS.split()
+        + ["--output=" + DATA_DIR]
+        + ["--file=*/" + FILE_PATH]
+        + [COMPILE_COMMANDS_ABSOLUTE]
+    )
+
+    try:
+        with open(LOG_FILE, "a") as log_file:
+            subprocess.run(
+                codechecker_cmd,
+                env=os.environ,
+                stdout=log_file,
+                stderr=log_file,
+                check=True,
+            )
+    except subprocess.CalledProcessError as e:
+        log(e.output.decode() if e.output else "")
+        if e.returncode == 1 or e.returncode >= 128:
+            _display_error(e.returncode)
+
+
+def _display_error(ret_code: int) -> None:
+    """
+    Display the log file, and exit with 1
+    """
+    # Log and exit on error
     print("===-----------------------------------------------------===")
     print(f"[ERROR]: CodeChecker returned with {ret_code}!")
     with open(LOG_FILE, "r") as log_file:
         print(log_file.read())
     sys.exit(1)
 
-# NOTE: the following we do to get rid of md5 hash in plist file names
-# Copy the plist files to the specified destinations
-for file in os.listdir(DATA_DIR):
-    for analyzer_info in ANALYZER_PLIST_PATHS:
-        if re.search(
-            rf"_{analyzer_info[0]}_.*\.plist$", file
-        ) and os.path.isfile(os.path.join(DATA_DIR, file)):
-            shutil.copy(os.path.join(DATA_DIR, file), analyzer_info[1])
+
+def _move_plist_files():
+    """
+    Move the plist files from the temporary directory to their final destination
+    """
+    # NOTE: the following we do to get rid of md5 hash in plist file names
+    # Copy the plist files to the specified destinations
+    for file in os.listdir(DATA_DIR):
+        for analyzer_info in ANALYZER_PLIST_PATHS:
+            if re.search(
+                rf"_{analyzer_info[0]}_.*\.plist$", file
+            ) and os.path.isfile(os.path.join(DATA_DIR, file)):
+                shutil.copy(os.path.join(DATA_DIR, file), analyzer_info[1])
+
+
+def main():
+    _create_compile_commands_json_with_absolute_paths()
+    _run_codechecker()
+    _move_plist_files()
+
+
+if __name__ == "__main__":
+    main()
+
 
 # I have conserved this comment from the original bash script
 # The sed commands are commented out, so we won't implement them

--- a/src/code_checker_script.py
+++ b/src/code_checker_script.py
@@ -23,7 +23,7 @@ import sys
 
 DATA_DIR: str = sys.argv[1]
 FILE_PATH: str = sys.argv[2]
-ANALYZER_PLIST_PATHS: list[list[str, str]] = [
+ANALYZER_PLIST_PATHS: list[list[str]] = [
     item.split(",") for item in sys.argv[4].split(";")
 ]
 LOG_FILE: str = sys.argv[3]

--- a/src/code_checker_script.py
+++ b/src/code_checker_script.py
@@ -1,0 +1,113 @@
+#!{PythonPath}
+
+# Copyright 2023 Ericsson AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+
+DATA_DIR: str = "{data_dir}"
+ANALYZER_PLIST_PATHS: list[tuple[str, str]] = {analyzer_output_list}
+LOG_FILE: str = "{log_file}"
+COMPILE_COMMANDS_JSON: str = "{compile_commands_json}"
+COMPILE_COMMANDS_ABSOLUTE: str = f"{COMPILE_COMMANDS_JSON}.abs"
+CODECHECKER_ARGS: str = "{codechecker_args}"
+
+
+def log(msg: str) -> None:
+    with open(LOG_FILE, "a") as log_file:
+        log_file.write(msg)
+
+
+with open(COMPILE_COMMANDS_JSON, "r") as original_file, open(
+    COMPILE_COMMANDS_ABSOLUTE, "w"
+) as new_file:
+    content = original_file.read()
+    # Replace '"directory":"."' with the absolute path
+    # of the current working directory
+    new_content = content.replace(
+        '"directory":".', f'"directory":"{os.getcwd()}'
+    )
+    new_file.write(new_content)
+
+with open(LOG_FILE, "w") as log_file:
+    log_file.write(
+        f"CodeChecker command: CodeChecker analyze {CODECHECKER_ARGS} \
+{COMPILE_COMMANDS_ABSOLUTE}\n"
+    )
+    log_file.write(
+        "===-----------------------------------------------------===\n"
+    )
+    log_file.write(
+        "                   CodeChecker error log                   \n"
+    )
+    log_file.write(
+        "===-----------------------------------------------------===\n"
+    )
+
+result = subprocess.run(
+    ["echo", "$PATH"],
+    shell=True,
+    env=os.environ,
+    capture_output=True,
+    text=True,
+)
+log(result.stdout)
+
+codechecker_cmd: list[str] = (
+    ["CodeChecker", "analyze"]
+    + CODECHECKER_ARGS.split()
+    + [COMPILE_COMMANDS_ABSOLUTE]
+)
+
+try:
+    with open(LOG_FILE, "a") as log_file:
+        proc = subprocess.run(
+            codechecker_cmd,
+            env=os.environ,
+            stdout=log_file,
+            stderr=log_file,
+            check=True,
+        )
+    ret_code = 0
+except subprocess.CalledProcessError as e:
+    ret_code = e.returncode
+    with open(LOG_FILE, "a") as log_file:
+        log_file.write(e.output.decode() if e.output else "")
+
+# Log and exit on error
+if ret_code == 1 or ret_code >= 128:
+    print("===-----------------------------------------------------===")
+    print(f"[ERROR]: CodeChecker returned with {ret_code}!")
+    with open(LOG_FILE, "r") as log_file:
+        print(log_file.read())
+    sys.exit(1)
+
+# NOTE: the following we do to get rid of md5 hash in plist file names
+# Copy the plist files to the specified destinations
+for file in os.listdir(DATA_DIR):
+    for analyzer_info in ANALYZER_PLIST_PATHS:
+        if re.search(
+            rf"_{analyzer_info[0]}_.*\.plist$", file
+        ) and os.path.isfile(os.path.join(DATA_DIR, file)):
+            shutil.copy(os.path.join(DATA_DIR, file), analyzer_info[1])
+
+# I have conserved this comment from the original bash script
+# The sed commands are commented out, so we won't implement them
+# # sed -i -e "s|<string>.*execroot/bazel_codechecker/|<string>|g" $CLANG_TIDY_PLIST
+# # sed -i -e "s|<string>.*execroot/bazel_codechecker/|<string>|g" $CLANGSA_PLIST


### PR DESCRIPTION
Why:
We want to produce the result plist file for all analyzer that was used. 

What:
Recreated the bash wrapper script in Python.
Changed the rule to declare output files based on the enabled checkers argument.
Added a function to merge the default and custom arguments for CodeChecker

Addresses:
Fixes: #17

Depends on:
#81 
