### PR TITLE
Add test for CodeChecker argument merging

### DIFF
--- a/test/unit/argument_merge/BUILD
+++ b/test/unit/argument_merge/BUILD
@@ -1,0 +1,40 @@
+# Copyright 2023 Ericsson AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# cc_binary for simple C++ tests
+load(
+    "@rules_cc//cc:defs.bzl",
+    "cc_library",
+)
+
+load(
+    "@bazel_codechecker//src:code_checker.bzl",
+    "code_checker_test",
+)
+
+cc_library(
+    name = "main",
+    srcs = ["main.cc"],
+)
+
+# Test with overwriting analyzers argument
+code_checker_test(
+    name = "code_checker_argument_merge",
+    targets = [
+        "main",
+    ],
+    options = [
+        "--analyzers clangsa clang-tidy",
+    ],
+)

--- a/test/unit/argument_merge/BUILD
+++ b/test/unit/argument_merge/BUILD
@@ -19,8 +19,8 @@ load(
 )
 
 load(
-    "@bazel_codechecker//src:code_checker.bzl",
-    "code_checker_test",
+    "@bazel_codechecker//src:codechecker.bzl",
+    "codechecker_test",
 )
 
 cc_library(
@@ -29,12 +29,13 @@ cc_library(
 )
 
 # Test with overwriting analyzers argument
-code_checker_test(
-    name = "code_checker_argument_merge",
+codechecker_test(
+    name = "per_file_argument_merge",
     targets = [
         "main",
     ],
-    options = [
+    analyze = [
         "--analyzers clangsa clang-tidy",
     ],
+    per_file = True,
 )

--- a/test/unit/argument_merge/BUILD
+++ b/test/unit/argument_merge/BUILD
@@ -29,6 +29,8 @@ cc_library(
 )
 
 # Test with overwriting analyzers argument
+# Testing on the regular rule isn't necessary,
+# there are no default options to be merged.
 codechecker_test(
     name = "per_file_argument_merge",
     targets = [

--- a/test/unit/argument_merge/main.cc
+++ b/test/unit/argument_merge/main.cc
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2023 Ericsson AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// We are only curious about the codechecker.log file, no need for a warning.
+int main(){
+    return 0;
+}

--- a/test/unit/argument_merge/test_argument_merge.py
+++ b/test/unit/argument_merge/test_argument_merge.py
@@ -34,15 +34,15 @@ class TestTemplate(TestBase):
         "../../..", "bazel-testlogs", "test", "unit", "argument_merge"
     )
 
-    def test_code_checker_argument_merge(self):
+    def test_per_file_argument_merge(self):
         """Test: Whether default options gets override"""
         code, _, _ = self.run_command(
-            "bazel build //test/unit/argument_merge:code_checker_argument_merge"
+            "bazel build //test/unit/argument_merge:per_file_argument_merge"
         )
         self.assertEqual(code, 0)
         matched_lines: list[str] = self.grep_file(
             self.BAZEL_BIN_DIR
-            + "/code_checker_argument_merge/data/"
+            + "/per_file_argument_merge/data/"
             + "test-unit-argument_merge-main.cc_codechecker.log",
             r"--analyzers",
         )

--- a/test/unit/argument_merge/test_argument_merge.py
+++ b/test/unit/argument_merge/test_argument_merge.py
@@ -1,0 +1,55 @@
+# Copyright 2023 Ericsson AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests wether default argument options and
+user given arguments are merged correctly
+"""
+import os
+import re
+import unittest
+from common.base import TestBase
+
+
+class TestTemplate(TestBase):
+    """Argument merging Tests"""
+
+    # Set working directory
+    __test_path__ = os.path.dirname(os.path.abspath(__file__))
+    BAZEL_BIN_DIR = os.path.join(
+        "../../..", "bazel-bin", "test", "unit", "argument_merge"
+    )
+    BAZEL_TESTLOGS_DIR = os.path.join(
+        "../../..", "bazel-testlogs", "test", "unit", "argument_merge"
+    )
+
+    def test_code_checker_argument_merge(self):
+        """Test: Whether default options gets override"""
+        code, _, _ = self.run_command(
+            "bazel build //test/unit/argument_merge:code_checker_argument_merge"
+        )
+        self.assertEqual(code, 0)
+        matched_lines: list[str] = self.grep_file(
+            self.BAZEL_BIN_DIR
+            + "/code_checker_argument_merge/data/"
+            + "test-unit-argument_merge-main.cc_codechecker.log",
+            r"--analyzers",
+        )
+        # FIXME: Change to '1'
+        # Should only have this argument set once
+        self.assertEqual(len(re.findall("--analyzers", matched_lines[0])), 2)
+
+
+if __name__ == "__main__":
+    unittest.main(buffer=True)


### PR DESCRIPTION
Why:
The default options and the user-defined ones don't get merged; they are just mashed together.

What:
Added a test that counts how many times --analyzers is defined

Addresses:
#86 
