### PR TITLE
Merge CodeChecker default and user defined arguments

### DIFF
--- a/src/per_file.bzl
+++ b/src/per_file.bzl
@@ -314,10 +314,24 @@ def _collect_all_sources_and_headers(ctx):
     sources_and_headers = all_files + headers.to_list()
     return sources_and_headers
 
+def _merge_options(default, custom):
+    """
+    Merge command line arguments so that default options can be overridden
+    """
+    final = []
+    args_set = []
+    for item in custom:
+        args_set.append(item.split(" ")[0].split("=")[0])
+        final.append(item)
+    for option in default:
+        if option.split(" ")[0].split("=")[0] not in args_set:
+            final.append(option)
+    return final
+
 def _per_file_impl(ctx):
     compile_commands_json = _compile_commands_impl(ctx)
     sources_and_headers = _collect_all_sources_and_headers(ctx)
-    options = ctx.attr.default_options + ctx.attr.options
+    options = _merge_options(ctx.attr.default_options, ctx.attr.options)
     all_files = [compile_commands_json]
     for target in ctx.attr.targets:
         if not CcInfo in target:

--- a/src/per_file.bzl
+++ b/src/per_file.bzl
@@ -314,6 +314,9 @@ def _collect_all_sources_and_headers(ctx):
     sources_and_headers = all_files + headers.to_list()
     return sources_and_headers
 
+def _get_argument_name(argument):
+    return argument.split(" ")[0].split("=")[0]
+
 def _merge_options(default, custom):
     """
     Merge command line arguments so that default options can be overridden
@@ -321,10 +324,10 @@ def _merge_options(default, custom):
     final = []
     args_set = []
     for item in custom:
-        args_set.append(item.split(" ")[0].split("=")[0])
+        args_set.append(_get_argument_name(item))
         final.append(item)
     for option in default:
-        if option.split(" ")[0].split("=")[0] not in args_set:
+        if _get_argument_name(option) not in args_set:
             final.append(option)
     return final
 

--- a/test/unit/argument_merge/test_argument_merge.py
+++ b/test/unit/argument_merge/test_argument_merge.py
@@ -46,9 +46,7 @@ class TestTemplate(TestBase):
             + "test-unit-argument_merge-main.cc_codechecker.log",
             r"--analyzers",
         )
-        # FIXME: Change to '1'
-        # Should only have this argument set once
-        self.assertEqual(len(re.findall("--analyzers", matched_lines[0])), 2)
+        self.assertEqual(len(re.findall("--analyzers", matched_lines[0])), 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Why:
Currently, the default and user-defined arguments get mushed together.

What:
Added a function merging the default and custom rules based on the first word of the argument. Like in the case of `--analyzers clang-tidy`, I would compare whether user-defined arguments contain a "--analyzers" flag.

Addresses:
Fixes: #86 

Depends on:
#87 