### PR TITLE
Fix unittest: `caching`

### DIFF
--- a/test/unit/caching/test_caching.py
+++ b/test/unit/caching/test_caching.py
@@ -44,6 +44,8 @@ class TestCaching(TestBase):
     def setUp(self):
         """Before every test: clean Bazel cache"""
         super().setUp()
+        # If the test was unexpectedly stopped, we need to
+        # cleanup from the previous run.
         if os.path.exists("tmp"):
             try:
                 shutil.rmtree("tmp")


### PR DESCRIPTION
Why:
This unittest, if interrupted by the user while running, leaves its tmp directory behind, causing future runs of the test to fail.

What:
Added a clause to remove the folder during setup if present

Addresses:
fixes: #96 