### PR TITLE
Add tests for generated file compile commands generation

### DIFF
--- a/test/unit/generated_files/BUILD
+++ b/test/unit/generated_files/BUILD
@@ -23,6 +23,11 @@ load(
     "codechecker_test",
 )
 
+load(
+    "@bazel_codechecker//src:compile_commands.bzl",
+    "compile_commands",
+)
+
 # First, define the rule that generates our file.
 genrule(
     name = "generate_header",
@@ -94,5 +99,19 @@ codechecker_test(
     per_file = True,
     tags = [
         "manual",
+    ],
+)
+
+compile_commands(
+    name = "compile_commands_genrule_header",
+    targets = [
+        ":genrule_header_cpp",
+    ],
+)
+
+compile_commands(
+    name = "compile_commands_genrule_source",
+    targets = [
+        ":genrule_source_cpp",
     ],
 )

--- a/test/unit/generated_files/test_generated_files.py
+++ b/test/unit/generated_files/test_generated_files.py
@@ -104,6 +104,54 @@ class TestGeneratedFiles(TestBase):
             )
         )
 
+    def test_genrule_source_compile_commands(self):
+        """
+        Test:
+        bazel build //test/unit/generated_files:compile_commands_genrule_source
+        """
+        target = "genrule_source"
+        ret, _, _ = self.run_command(
+            "bazel build " +
+            f"//test/unit/generated_files:compile_commands_{target}"
+        )
+        self.assertEqual(ret, 0)
+        compile_commands = os.path.join(
+            self.BAZEL_BIN_DIR, # type: ignore
+            f"compile_commands_{target}",
+            "compile_commands.json"
+        )
+        print(compile_commands)
+        self.assertTrue(os.path.exists(compile_commands))
+        self.assertTrue(
+            self.contains_regex_in_file(
+                compile_commands, fr"\"file\":.*{target}.cc"
+            )
+        )
+
+    def test_genrule_header_compile_commands(self):
+        """
+        Test:
+        bazel build //test/unit/generated_files:compile_commands_genrule_header
+        """
+        target = "genrule_header"
+        ret, _, _ = self.run_command(
+            "bazel build " +
+            f"//test/unit/generated_files:compile_commands_{target}"
+        )
+        self.assertEqual(ret, 0)
+        compile_commands = os.path.join(
+            self.BAZEL_BIN_DIR, # type: ignore
+            f"compile_commands_{target}",
+            "compile_commands.json"
+        )
+        print(compile_commands)
+        self.assertTrue(os.path.exists(compile_commands))
+        self.assertTrue(
+            self.contains_regex_in_file(
+                compile_commands, fr"\"file\":.*{target}_consumer.cc"
+            )
+        )
+
 
 if __name__ == "__main__":
     unittest.main(buffer=True)


### PR DESCRIPTION
Why:

In the midsts of proving of our outstanding compile commands generation facilities and generated file support, we forgot to test the two together.

What:

Add a test that checks whether we generated files are present in the compile_commands.json generator rule.

Addresses:
Complements #101.