### PR TITLE
Showcase Bazel 8 support

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,20 @@
+"""
+Module docs string
+"""
+module(
+    name = "bazel_codechecker",
+    version = "0.0.0",  # Update this to your release version
+)
+ext = use_extension("//src:extensions.bzl", "initialize_tools")
+use_repo(ext, "default_codechecker_tools")
+bazel_dep(name = "rules_cc", version = "0.1.1")
+bazel_dep(name = "rules_python", version = "0.40.0")
+python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+python.toolchain(
+    configure_coverage_tool = True,
+    python_version = "3.11",
+)
+use_repo(python, "python_3_11", "python_versions")
+register_toolchains(
+    "@python_3_11//:all",
+)

--- a/src/compile_commands.bzl
+++ b/src/compile_commands.bzl
@@ -345,11 +345,11 @@ def _check_source_files(source_files, compilation_db):
             fail("File: %s\nNot available in collected source files" % src)
 
 def _compile_commands_json(compilation_db):
-    json = "[\n"
-    entries = [entry.to_json() for entry in compilation_db]
-    json += ",\n".join(entries)
-    json += "]\n"
-    return json
+    json_cont = "[\n"
+    entries = [json.encode(entry) for entry in compilation_db]
+    json_cont += ",\n".join(entries)
+    json_cont += "]\n"
+    return json_cont
 
 def compile_commands_impl(ctx):
     """ Creates compile_commands.json file for given targets and platform

--- a/src/extensions.bzl
+++ b/src/extensions.bzl
@@ -1,0 +1,16 @@
+# src/extensions.bzl
+load(
+    "//src:tools.bzl",
+    "register_default_codechecker",
+    "register_default_python_toolchain",
+)
+
+def _initialize_tools_impl(ctx):
+    # WARNING: See note below about legacy macros!
+    register_default_python_toolchain()
+    register_default_codechecker()
+
+# Define the extension here
+initialize_tools = module_extension(
+    implementation = _initialize_tools_impl,
+)

--- a/src/tools.bzl
+++ b/src/tools.bzl
@@ -69,7 +69,7 @@ default_python_tools = repository_rule(
 
 def register_default_python_toolchain():
     default_python_tools(name = "default_python_tools")
-    native.register_toolchains("@default_python_tools//:python_toolchain")
+    #native.register_toolchains("@default_python_tools//:python_toolchain")
 
 def _codechecker_local_repository_impl(repository_ctx):
     repository_ctx.file(


### PR DESCRIPTION
Why:
We want to support the latest bazel version

What:
Waaaay too much.
Only the codechecker_test rule have been updated to support bazel 8
Note: the MODULE.bazel is based on an older implementation of #110, this is why files like: extensions.bzl exists

Addresses:
#108 
