### PR TITLE
Add test for missing header bug, under implementation_deps targets

### DIFF
--- a/test/unit/virtual_include/BUILD
+++ b/test/unit/virtual_include/BUILD
@@ -58,3 +58,30 @@ codechecker_test(
     ],
     per_file = True,
 )
+
+cc_library(
+    name = "virtual_implementation_deps_include",
+    srcs = ["source.cc"],
+    implementation_deps = ["test_inc"],
+)
+
+codechecker_test(
+    name = "codechecker_impl_deps_include",
+    tags = [
+        "manual",
+    ],
+    targets = [
+        "virtual_implementation_deps_include",
+    ],
+)
+
+codechecker_test(
+    name = "per_file_impl_deps_include",
+    tags = [
+        "manual",
+    ],
+    targets = [
+        "virtual_implementation_deps_include",
+    ],
+    per_file = True,
+)

--- a/test/unit/virtual_include/test_virtual_include.py
+++ b/test/unit/virtual_include/test_virtual_include.py
@@ -108,6 +108,22 @@ class TestVirtualInclude(TestBase):
             self.contains_in_files(r"/_virtual_includes/", plist_files), []
         )
 
+    def test_bazel_codechecker_implementation_deps_virtual_include(self):
+        """Test: bazel build :codechecker_impl_deps_include"""
+        ret, _, _ = self.run_command(
+            "bazel build //test/unit/virtual_include:codechecker_impl_deps_include"
+        )
+        # TODO: change to 0, CodeChecker should finish analysis successfully
+        self.assertEqual(ret, 1)
+
+    def test_bazel_per_file_implementation_deps_virtual_include(self):
+        """Test: bazel build :per_file_impl_deps_include"""
+        ret, _, _ = self.run_command(
+            "bazel build //test/unit/virtual_include:per_file_impl_deps_include"
+        )
+        # TODO: change to 0, CodeChecker should finish analysis successfully
+        self.assertEqual(ret, 1)
+
 
 if __name__ == "__main__":
     unittest.main(buffer=True)


### PR DESCRIPTION
Why:
Header files under `implementation_deps` dependencies are hidden if the dependency library uses `strip_include_prefix`.

What:
Added tests to validate whether the bug has been fixed. 

Addresses:
#120 
