### PR TITLE
Implement support for `virtual_include` in `implementation_deps` for monolithic analysis

### DIFF
--- a/src/compile_commands.bzl
+++ b/src/compile_commands.bzl
@@ -110,16 +110,22 @@ def get_compile_flags(ctx, dep):
         options.append(QUOTE_INCLUDE + quote_include)
 
     for attr in source_attr:
-        if hasattr(ctx.rule.attr, attr):
-            deps = getattr(ctx.rule.attr, attr)
-            if type(deps) == "list":
-                for dep in deps:
-                    if CcInfo in dep:
-                        compilation_context = dep[CcInfo].compilation_context
-                        for include in compilation_context.includes.to_list():
-                            if len(include) == 0:
-                                include = "."
-                            options.append("-I{}".format(include))
+        if not hasattr(ctx.rule.attr, attr):
+            continue
+
+        deps = getattr(ctx.rule.attr, attr)
+        if not type(deps) == "list":
+            continue
+
+        for dep in deps:
+            if CcInfo not in dep:
+                continue
+
+            compilation_context = dep[CcInfo].compilation_context
+            for include in compilation_context.includes.to_list():
+                if len(include) == 0:
+                    include = "."
+                options.append("-I{}".format(include))
 
     return options
 

--- a/src/compile_commands.bzl
+++ b/src/compile_commands.bzl
@@ -79,7 +79,7 @@ QUOTE_INCLUDE = "-iquote "
 
 # Function copied from https://gist.github.com/oquenchil/7e2c2bd761aa1341b458cc25608da50c
 # NOTE: added local_defines
-def get_compile_flags(dep):
+def get_compile_flags(ctx, dep):
     """ Return a list of compile options
 
     Returns:
@@ -108,6 +108,18 @@ def get_compile_flags(dep):
         if len(quote_include) == 0:
             quote_include = "."
         options.append(QUOTE_INCLUDE + quote_include)
+
+    for attr in source_attr:
+        if hasattr(ctx.rule.attr, attr):
+            deps = getattr(ctx.rule.attr, attr)
+            if type(deps) == "list":
+                for dep in deps:
+                    if CcInfo in dep:
+                        compilation_context = dep[CcInfo].compilation_context
+                        for include in compilation_context.includes.to_list():
+                            if len(include) == 0:
+                                include = "."
+                            options.append("-I{}".format(include))
 
     return options
 
@@ -174,7 +186,7 @@ def _cc_compiler_info(ctx, target, src, feature_configuration, cc_toolchain):
     )
 
     compile_flags = (compiler_options +
-                     get_compile_flags(target) +
+                     get_compile_flags(ctx, target) +
                      (ctx.rule.attr.copts if "copts" in dir(ctx.rule.attr) else []))
 
     return struct(

--- a/test/unit/virtual_include/test_virtual_include.py
+++ b/test/unit/virtual_include/test_virtual_include.py
@@ -120,7 +120,7 @@ class TestVirtualInclude(TestBase):
         ret, _, _ = self.run_command(
             "bazel build //test/unit/virtual_include:per_file_impl_deps_include"
         )
-        # TODO: set to 0
+        # TODO: change to 0, CodeChecker should finish analysis successfully
         self.assertEqual(ret, 1)
 
 

--- a/test/unit/virtual_include/test_virtual_include.py
+++ b/test/unit/virtual_include/test_virtual_include.py
@@ -113,15 +113,14 @@ class TestVirtualInclude(TestBase):
         ret, _, _ = self.run_command(
             "bazel build //test/unit/virtual_include:codechecker_impl_deps_include"
         )
-        # TODO: change to 0, CodeChecker should finish analysis successfully
-        self.assertEqual(ret, 1)
+        self.assertEqual(ret, 0)
 
     def test_bazel_per_file_implementation_deps_virtual_include(self):
         """Test: bazel build :per_file_impl_deps_include"""
         ret, _, _ = self.run_command(
             "bazel build //test/unit/virtual_include:per_file_impl_deps_include"
         )
-        # TODO: change to 0, CodeChecker should finish analysis successfully
+        # TODO: set to 0
         self.assertEqual(ret, 1)
 
 


### PR DESCRIPTION
Why:
Using `virtual_includes` with `implementation_deps` is a common practice. We should support it. 

What:
In monolithic rule, explored `-I` includes transitively.
In `per_file` rule, imported the source file collector aspect from compile_commands.bzl (`implementation_deps` files can only be collected in aspect rules), and expanded the flag collector aspect to collect `-I` includes transitively. 

Addresses:
Fixes: #120 