### PR TITLE
Update and remove redundancies from CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,33 +1,17 @@
 Contributing
 ============
 
-Thanks for your interest!
-
-Here you can find information about:
-- How to report a bug?
-- How to submit a patch?
-
 
 Reporting issues
 ----------------
 
-Please always provide the following information:
-
-1. Steps to reproduce
-2. Expected behavior
-3. Actual behavior
+Please navigate to the issues tab in GitHub, and click on "New Issue", and select and fill out the appropriate template. If any of the fields are confusing, feel free to submit and we will help you to iron out the rest.
 
 
 Development Environment
 -----------------------
 
-The following modules are needed for the development:
-
-    module add git
-    module add bazel/6
-    module add clang/16
-    module add python/3.11
-    module add codechecker/6.26
+The following additional modules the ones found in the [README](README.md) are needed for the development:
 
     # Optional modules
     module add buildifier/4
@@ -39,67 +23,30 @@ You can also add Bazel auto-completion by running the following:
     source $(dirname $(realpath $(which bazel)))/bazel-complete.bash
 
 
-Directory structure
+Directory structure overview
 -------------------
 
 Directory / File               | Description
 ------------------------------ | -----------
-CONTRIBUTING.md                | This file
-README.md                      | Main readme document
-WORKSPACE                      | Declares Bazel workspaces for CodeChecker rules
 src/                           | Rules for CodeChecker and compile_commands.json
 src/BUILD                      | Declares and exports python scripts
 src/clang.bzl                  | Clang-tidy and clang analyzer aspects and rules
 src/clang_ctu.bzl              | PoC: Clang analyzer with CTU
 src/per_file.bzl               | PoC: CodeChecker analyze --file
+src/per_file_script.py         | Wrapper around 'CodeChecker analyze --file'
 src/codechecker.bzl            | Defines codechecker rules
-src/codechecker_script.py      | CodeChecker Bazel build & test script template
+src/codechecker_script.py      | Wrapper around 'CodeChecker analyze'
 src/compile_commands.bzl       | Compile commands (compilation database) aspect
 src/compile_commands_filter.py | Filters compile_commands.json file
 src/tools.bzl                  | Default Python toolchain and CodeChecker tool
 test/                          | Tests for codechecker rules
-test/BUILD                     | Defines codechecker rules tests
-test/config.json               | Example of CodeChecker configuration
-test/test.py                   | Functional and unit test runner
-test/inc/                      | Directory for test C++ headers
-test/inc/inc.h                 | Header file to check strip_include_prefix
-test/src/                      | Directory for test C++ files
-test/src/ctu.cc                | Simple library C++ code to check CTU
-test/src/fail.cc               | Simple main() code which should FAIL
-test/src/lib.cc                | Simple library C++ code to check dependencies
-test/src/pass.cc               | Simple main() code which should PASS
+test/unit/                     | Unit tests
+test/foss/                     | Scripts for automatically running these rules on select free open source software
+test/common/                   | Collection of test base classes and convenience functions
+test/test.sh                   | Functional and unit test runner
 
 
-Testing
+Submitting a patch and testing
 -------
 
-Before submitting any change please make sure all tests and checks are passed.
-
-For a quick sanity check you can just run:
-
-    python3 test/test.py
-
-
-### Functional tests
-
-Run functional tests in `test` directory:
-
-    python3 test.py
-
-For test debugging use `-vvv` option:
-
-    python3 test.py -vvv
-
-### Bazel tests
-
-To run all bazel tests:
-
-    bazel test ...
-
-See CodeChecker output:
-
-    bazel test ... --test_output=all
-
-To check simple C++ example in `test` directory:
-
-    bazel test :codechecker_pass --test_output=all
+Before submitting any changes please make sure all tests and checks are passed, and fill out the Pull Request template. If you are a new contributor, and the template is confusing, feel free to submit the PR and we will help you iron it out! On how to run or add a new test, please see [test/README.md](test/README.md).


### PR DESCRIPTION
Why:
The CONTRIBUTING.md got a little out of date, and was also a little too verbose. It is impractical and IMO unrealistic to list each and every file manually as the project grows, it is more important to give an initial idea about what the important files are about. Also, many parts are now redundant with other README files.

What:
* I removed text that is now explained by the main or the test README files, or issue/PR templates.
* I removed the most miscellaneous entries from the file listing, instead leaving in only the important files.

Addresses:
Fixes #122 
