### PR TITLE
Rename bazel_codechecker to codechecker_bazel

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 module(
-    name = "bazel_codechecker",
+    name = "codechecker_bazel",
 )
 
 python_extension = use_extension(

--- a/README.md
+++ b/README.md
@@ -125,13 +125,13 @@ Using the legacy `WORKSPACE` system:
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 git_repository(
-    name = "bazel_codechecker",
+    name = "codechecker_bazel",
     remote = "https://github.com/Ericsson/codechecker_bazel.git",
     branch = "main",
 )
 
 load(
-    "@bazel_codechecker//src:tools.bzl",
+    "@codechecker_bazel//src:tools.bzl",
     "register_default_codechecker",
     "register_default_python_toolchain",
 )
@@ -147,11 +147,11 @@ TODO: update this part when we have an actual release-->
 In Bazel 6, to activate the MODULE system, add `--enable_bzlmod` to the `.bazelrc` file
 ```
 git_override(
-    module_name = "bazel_codechecker",
+    module_name = "codechecker_bazel",
     remote = "https://github.com/Ericsson/codechecker_bazel.git",
     commit = "a32e9d75df4fb453c8bbfdf0fdf6a767797ae53d", # Update to latest
 )
-bazel_dep(name = "bazel_codechecker")
+bazel_dep(name = "codechecker_bazel")
 
 ```
 ## CodeChecker
@@ -172,7 +172,7 @@ To use `codechecker_test()` include it to your BUILD file:
 
 ```python
 load(
-    "@bazel_codechecker//src:codechecker.bzl",
+    "@codechecker_bazel//src:codechecker.bzl",
     "codechecker_test",
 )
 ```
@@ -241,7 +241,7 @@ You can include and use it similarly as well:
 
 ```python
 load(
-    "@bazel_codechecker//src:codechecker.bzl",
+    "@codechecker_bazel//src:codechecker.bzl",
     "codechecker"
 )
 ```
@@ -256,7 +256,7 @@ You can include and use it similarly as well:
 
 ```python
 load(
-    "@bazel_codechecker//src:codechecker.bzl",
+    "@codechecker_bazel//src:codechecker.bzl",
     "codechecker_suite"
 )
 ```
@@ -269,7 +269,7 @@ First, include the rule in your BUILD file:
 
 ```python
 load(
-    "@bazel_codechecker//src:codechecker.bzl",
+    "@codechecker_bazel//src:codechecker.bzl",
     "codechecker_config"
 )
 ```
@@ -319,7 +319,7 @@ The Bazel rule `clang_tidy_test()` runs clang-tidy natively without CodeChecker.
 
 ```python
 load(
-    "@bazel_codechecker//src:clang.bzl",
+    "@codechecker_bazel//src:clang.bzl",
     "clang_tidy_test",
 )
 
@@ -331,10 +331,10 @@ clang_tidy_test(
 )
 ```
 
-You can also run clang-tidy via the Bazel aspect `clang_tidy_aspect()` that can be invoked from the command line by passing the following parameter to Bazel build/test: `--aspects @bazel_codechecker//src:clang.bzl%clang_tidy_aspect`:
+You can also run clang-tidy via the Bazel aspect `clang_tidy_aspect()` that can be invoked from the command line by passing the following parameter to Bazel build/test: `--aspects @codechecker_bazel//src:clang.bzl%clang_tidy_aspect`:
 
 ```bash
-bazel build ... --aspects @bazel_codechecker//src:clang.bzl%clang_tidy_aspect --output_groups=report
+bazel build ... --aspects @codechecker_bazel//src:clang.bzl%clang_tidy_aspect --output_groups=report
 ```
 
 ### Clang Static Analyzer: `clang_analyze_test()`
@@ -343,7 +343,7 @@ The Bazel rule `clang_analyze_test()` runs The Clang Static Analyzer natively wi
 
 ```python
 load(
-    "@bazel_codechecker//src:clang.bzl",
+    "@codechecker_bazel//src:clang.bzl",
     "clang_analyze_test",
 )
 
@@ -361,7 +361,7 @@ As generating a compilation database for C/C++ is a known pain point for bazel, 
 
 ```python
 load(
-    "@bazel_codechecker//src:compile_commands.bzl",
+    "@codechecker_bazel//src:compile_commands.bzl",
     "compile_commands",
 )
 ```
@@ -389,7 +389,7 @@ The Bazel rule `clang_analyze_test()` runs The Clang Static Analyzer with [cross
 
 ```python
 load(
-    "@bazel_codechecker//src:clang_ctu.bzl",
+    "@codechecker_bazel//src:clang_ctu.bzl",
     "clang_ctu_test",
 )
 
@@ -423,4 +423,4 @@ After that you can find all artifacts in `bazel-bin` directory:
 
 To run `clang_tidy_aspect()` on all C/C++ code:
 
-    bazel build ... --aspects @bazel_codechecker//src:clang.bzl%clang_tidy_aspect --output_groups=report
+    bazel build ... --aspects @codechecker_bazel//src:clang.bzl%clang_tidy_aspect --output_groups=report

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,7 +1,7 @@
-workspace(name = "bazel_codechecker")
+workspace(name = "codechecker_bazel")
 
 load(
-    "@bazel_codechecker//src:tools.bzl",
+    "@codechecker_bazel//src:tools.bzl",
     "register_default_codechecker",
     "register_default_python_toolchain",
 )

--- a/src/clang.bzl
+++ b/src/clang.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load(
-    "@bazel_codechecker//src:tools.bzl",
+    "@codechecker_bazel//src:tools.bzl",
     "source_attr"
 )
 
@@ -334,9 +334,9 @@ clang_tidy_aspect = aspect(
     fragments = ["cpp"],
     attrs = {
         "_cc_toolchain": attr.label(default = Label("@bazel_tools//tools/cpp:current_cc_toolchain")),
-        "_clang_tidy_executable": attr.label(default = Label("@bazel_codechecker//src:clang_tidy_executable")),
-        "_clang_tidy_additional_deps": attr.label(default = Label("@bazel_codechecker//src:clang_tidy_additional_deps")),
-        "_clang_tidy_config": attr.label(default = Label("@bazel_codechecker//src:clang_tidy_config")),
+        "_clang_tidy_executable": attr.label(default = Label("@codechecker_bazel//src:clang_tidy_executable")),
+        "_clang_tidy_additional_deps": attr.label(default = Label("@codechecker_bazel//src:clang_tidy_additional_deps")),
+        "_clang_tidy_config": attr.label(default = Label("@codechecker_bazel//src:clang_tidy_config")),
         "_default_options": attr.string_list(default = ["--use-color", "--warnings-as-errors=*"]),
     },
     toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],

--- a/src/clang_ctu.bzl
+++ b/src/clang_ctu.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load(
-    "@bazel_codechecker//src:tools.bzl",
+    "@codechecker_bazel//src:tools.bzl",
     "source_attr"
 )
 

--- a/src/codechecker.bzl
+++ b/src/codechecker.bzl
@@ -19,7 +19,7 @@ load(
     "warning"
 )
 load(
-    "@bazel_codechecker//src:codechecker_config.bzl",
+    "@codechecker_bazel//src:codechecker_config.bzl",
     "get_config_file",
     "codechecker_config_internal",
 )

--- a/src/compile_commands.bzl
+++ b/src/compile_commands.bzl
@@ -41,7 +41,7 @@ load(
 )
 
 load(
-    "@bazel_codechecker//src:tools.bzl",
+    "@codechecker_bazel//src:tools.bzl",
     "source_attr"
 )
 

--- a/src/per_file.bzl
+++ b/src/per_file.bzl
@@ -3,7 +3,7 @@
 
 load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
-load("@bazel_codechecker//src:tools.bzl", "warning", "source_attr")
+load("@codechecker_bazel//src:tools.bzl", "warning", "source_attr")
 
 def _run_code_checker(
         ctx,
@@ -309,7 +309,7 @@ def _per_file_impl(ctx):
         content = """
             DATA_DIR=$(dirname {})
             # ls -la $DATA_DIR/data
-            # find $DATA_DIR/data -name *.plist -exec sed -i -e "s|<string>.*execroot/bazel_codechecker/|<string>|g" {{}} \\;
+            # find $DATA_DIR/data -name *.plist -exec sed -i -e "s|<string>.*execroot/codechecker_bazel/|<string>|g" {{}} \\;
             # cat $DATA_DIR/data/test-src-lib.cc_clangsa.plist
             echo "Running: CodeChecker parse $DATA_DIR/data"
             CodeChecker parse $DATA_DIR/data

--- a/test/foss/templates/MODULE.template
+++ b/test/foss/templates/MODULE.template
@@ -1,5 +1,5 @@
 local_path_override(
-    module_name = "bazel_codechecker",
+    module_name = "codechecker_bazel",
     path = "../../../../",
 )
-bazel_dep(name = "bazel_codechecker")
+bazel_dep(name = "codechecker_bazel")

--- a/test/foss/templates/WORKSPACE.template
+++ b/test/foss/templates/WORKSPACE.template
@@ -3,12 +3,12 @@
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 local_repository(
-    name = "bazel_codechecker",
+    name = "codechecker_bazel",
     path = "../../../../",
 )
 
 load(
-    "@bazel_codechecker//src:tools.bzl",
+    "@codechecker_bazel//src:tools.bzl",
     "register_default_codechecker",
     "register_default_python_toolchain",
 )

--- a/test/foss/yaml-cpp/init.sh
+++ b/test/foss/yaml-cpp/init.sh
@@ -27,7 +27,7 @@ cat <<EOF >> BUILD.bazel
 
 # codechecker rules
 load(
-    "@bazel_codechecker//src:codechecker.bzl",
+    "@codechecker_bazel//src:codechecker.bzl",
     "codechecker_test",
 )
 

--- a/test/foss/zlib-module/init.sh
+++ b/test/foss/zlib-module/init.sh
@@ -26,7 +26,7 @@ cat <<EOF >> BUILD.bazel
 
 # codechecker rules
 load(
-    "@bazel_codechecker//src:codechecker.bzl",
+    "@codechecker_bazel//src:codechecker.bzl",
     "codechecker_test",
 )
 codechecker_test(

--- a/test/foss/zlib/init.sh
+++ b/test/foss/zlib/init.sh
@@ -27,7 +27,7 @@ cat <<EOF >> BUILD.bazel
 
 # codechecker rules
 load(
-    "@bazel_codechecker//src:codechecker.bzl",
+    "@codechecker_bazel//src:codechecker.bzl",
     "codechecker_test",
 )
 

--- a/test/unit/argument_merge/BUILD
+++ b/test/unit/argument_merge/BUILD
@@ -19,7 +19,7 @@ load(
 )
 
 load(
-    "@bazel_codechecker//src:codechecker.bzl",
+    "@codechecker_bazel//src:codechecker.bzl",
     "codechecker_test",
 )
 

--- a/test/unit/caching/BUILD
+++ b/test/unit/caching/BUILD
@@ -20,7 +20,7 @@ load(
 )
 
 load(
-    "@bazel_codechecker//src:codechecker.bzl",
+    "@codechecker_bazel//src:codechecker.bzl",
     "codechecker_test",
 )
 

--- a/test/unit/compile_flags/BUILD
+++ b/test/unit/compile_flags/BUILD
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 load(
-    "@bazel_codechecker//src:codechecker.bzl",
+    "@codechecker_bazel//src:codechecker.bzl",
     "codechecker_test",
 )
 
 # compile_commands rule
 load(
-    "@bazel_codechecker//src:compile_commands.bzl",
+    "@codechecker_bazel//src:compile_commands.bzl",
     "compile_commands",
 )
 

--- a/test/unit/config/BUILD
+++ b/test/unit/config/BUILD
@@ -20,7 +20,7 @@ load(
 
 # codechecker rules
 load(
-    "@bazel_codechecker//src:codechecker.bzl",
+    "@codechecker_bazel//src:codechecker.bzl",
     "codechecker",
     "codechecker_test",
     "codechecker_config",

--- a/test/unit/external_repository/BUILD
+++ b/test/unit/external_repository/BUILD
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 load(
-    "@bazel_codechecker//src:compile_commands.bzl",
+    "@codechecker_bazel//src:compile_commands.bzl",
     "compile_commands",
 )
 
 load(
-    "@bazel_codechecker//src:codechecker.bzl",
+    "@codechecker_bazel//src:codechecker.bzl",
     "codechecker_test",
 )
 

--- a/test/unit/external_repository/MODULE.bazel
+++ b/test/unit/external_repository/MODULE.bazel
@@ -17,10 +17,10 @@ Test project for using headers thought implementation_deps,
 from external repositories
 """
 local_path_override(
-    module_name = "bazel_codechecker",
+    module_name = "codechecker_bazel",
     path = "../../../",
 )
-bazel_dep(name = "bazel_codechecker")
+bazel_dep(name = "codechecker_bazel")
 local_path_override(
     module_name = "external_lib",
     path = "third_party/my_lib",

--- a/test/unit/generated_files/BUILD
+++ b/test/unit/generated_files/BUILD
@@ -19,12 +19,12 @@ load(
 )
 
 load(
-    "@bazel_codechecker//src:codechecker.bzl",
+    "@codechecker_bazel//src:codechecker.bzl",
     "codechecker_test",
 )
 
 load(
-    "@bazel_codechecker//src:compile_commands.bzl",
+    "@codechecker_bazel//src:compile_commands.bzl",
     "compile_commands",
 )
 

--- a/test/unit/implementation_deps/BUILD
+++ b/test/unit/implementation_deps/BUILD
@@ -13,11 +13,11 @@
 # limitations under the License.
 
 load(
-    "@bazel_codechecker//src:codechecker.bzl",
+    "@codechecker_bazel//src:codechecker.bzl",
     "codechecker_test",
 )
 load(
-    "@bazel_codechecker//src:compile_commands.bzl",
+    "@codechecker_bazel//src:compile_commands.bzl",
     "compile_commands",
 )
 

--- a/test/unit/legacy/BUILD
+++ b/test/unit/legacy/BUILD
@@ -7,13 +7,13 @@ load(
 
 # compile_commands rule
 load(
-    "@bazel_codechecker//src:compile_commands.bzl",
+    "@codechecker_bazel//src:compile_commands.bzl",
     "compile_commands",
 )
 
 # codechecker rules
 load(
-    "@bazel_codechecker//src:codechecker.bzl",
+    "@codechecker_bazel//src:codechecker.bzl",
     "codechecker",
     "codechecker_config",
     "codechecker_suite",
@@ -22,14 +22,14 @@ load(
 
 # clang-tidy and clang -analyze rules
 load(
-    "@bazel_codechecker//src:clang.bzl",
+    "@codechecker_bazel//src:clang.bzl",
     "clang_analyze_test",
     "clang_tidy_test",
 )
 
 # clang -analyze + CTU rule
 load(
-    "@bazel_codechecker//src:clang_ctu.bzl",
+    "@codechecker_bazel//src:clang_ctu.bzl",
     "clang_ctu_test",
 )
 

--- a/test/unit/legacy/test_legacy.py
+++ b/test/unit/legacy/test_legacy.py
@@ -133,7 +133,7 @@ class TestBasic(TestBase):
     def test_bazel_aspect_clang_tidy_pass(self):
         """Test: bazel build :test_pass --aspects"""
         command = "bazel build :test_pass " + \
-            "--aspects @bazel_codechecker//src:clang.bzl%clang_tidy_aspect" + \
+            "--aspects @codechecker_bazel//src:clang.bzl%clang_tidy_aspect" + \
             " --output_groups=report"
         self.check_command(command, exit_code=0)
 
@@ -142,7 +142,7 @@ class TestBasic(TestBase):
         # NOTE: we should use :test_fail but transitive dependencies do not
         # work
         command = "bazel build :test_lib " + \
-            "--aspects @bazel_codechecker//src:clang.bzl%clang_tidy_aspect" + \
+            "--aspects @codechecker_bazel//src:clang.bzl%clang_tidy_aspect" + \
             " --output_groups=report"
         self.check_command(command, exit_code=1)
 

--- a/test/unit/parse/BUILD
+++ b/test/unit/parse/BUILD
@@ -19,7 +19,7 @@ load(
 )
 
 load(
-    "@bazel_codechecker//src:codechecker.bzl",
+    "@codechecker_bazel//src:codechecker.bzl",
     "codechecker_test",
 )
 

--- a/test/unit/virtual_include/BUILD
+++ b/test/unit/virtual_include/BUILD
@@ -20,7 +20,7 @@ load(
 
 # codechecker rules
 load(
-    "@bazel_codechecker//src:codechecker.bzl",
+    "@codechecker_bazel//src:codechecker.bzl",
     "codechecker_test",
 )
 


### PR DESCRIPTION
Why:
We want the rule name to be consistent with the repository name

What:
Replaced most occurrences of `bazel_codechecker` with `codechecker_bazel` (notable exceptions are test names)

Addresses:
Fixes: #124
