### PR TITLE
Fix jenkins testing

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,1 @@
+common --experimental_cc_implementation_deps


### PR DESCRIPTION
Why:
Get rid of configuration error emails from Jenkins

What:
Added the `--experimental_cc_implementation_deps` flag to `.bazelrc`.
This is fine since Bazel only looks for `.bazelrc` files in the main workspace, not in external repositories.

Addresses:
#123 
