### PR TITLE
Reactivate passing of config parameter to per_file rule

### DIFF
--- a/src/codechecker.bzl
+++ b/src/codechecker.bzl
@@ -335,10 +335,7 @@ def codechecker_test(
             name = name,
             targets = targets,
             options = analyze,
-            # Bazel 7 recognizes that the per_file_rule does not yet have a
-            # config attribute, and fails. TODO: uncomment when config files
-            # are supported in per_file rule
-            #config = config,
+            config = config,
             tags = tags,
             **kwargs
         )


### PR DESCRIPTION
Why:
We forgot to activate this when merging Bazel 7 support.

What:
Uncomments the passing of the config parameter to the per file rule, through the codechecker_test macro. 

Addresses:
none
