### PR TITLE
Create a convenience function for interacting with compile_commands_impl

### DIFF
--- a/src/codechecker.bzl
+++ b/src/codechecker.bzl
@@ -19,7 +19,7 @@ Rulesets for running codechecker in a single Bazel job.
 load(
     "compile_commands.bzl",
     "compile_commands_aspect",
-    "compile_commands_impl",
+    "get_compile_commands_json_and_srcs",
     "platforms_transition",
 )
 load(
@@ -58,19 +58,7 @@ def _codechecker_impl(ctx):
     py_runtime_info = ctx.attr._python_runtime[PyRuntimeInfo]
     python_path = py_runtime_info.interpreter_path
 
-    # Get compile_commands.json file and source files
-    compile_commands = None
-    source_files = None
-    for output in compile_commands_impl(ctx):
-        if type(output) == "DefaultInfo":
-            compile_commands = output.files.to_list()[0]
-            source_files = output.default_runfiles.files.to_list()
-    if not compile_commands:
-        fail("Failed to generate compile_commands.json file!")
-    if not source_files:
-        fail("Failed to collect source files!")
-    if compile_commands != ctx.outputs.compile_commands:
-        fail("Seems compile_commands.json file is incorrect!")
+    compile_commands, source_files = get_compile_commands_json_and_srcs(ctx)
 
     # Convert flacc calls to clang in compile_commands.json
     # and save to codechecker_commands.json

--- a/src/compile_commands.bzl
+++ b/src/compile_commands.bzl
@@ -418,6 +418,29 @@ def compile_commands_impl(ctx):
         ),
     ]
 
+def get_compile_commands_json_and_srcs(ctx):
+    """ Creates the compilation database for internal use.
+
+    Returns:
+      compile_commands - location of the compilation database file
+      source_files - files to analyze
+    """
+    # Get compile_commands.json file and source files
+    compile_commands = None
+    source_files = None
+    for output in compile_commands_impl(ctx):
+        if type(output) == "DefaultInfo":
+            compile_commands = output.files.to_list()[0]
+            source_files = output.default_runfiles.files.to_list()
+    if not compile_commands:
+        fail("Failed to generate compile_commands.json file!")
+    if not source_files:
+        fail("Failed to collect source files!")
+    if compile_commands != ctx.outputs.compile_commands:
+        fail("Seems compile_commands.json file is incorrect!")
+
+    return compile_commands, source_files
+
 _compile_commands = rule(
     implementation = compile_commands_impl,
     attrs = {


### PR DESCRIPTION
Why:
In anticipation of #98, where we remove the compilation database generation from per_file analysis and reuse compile_commands.bzl, we identified that the best point of entry might not be `compile_commands_impl()`, because we still need to check and parse the return values. Since we need the exact same ~20 lines of code that codechecker.bzl already uses, lets just turn that into a convenience function.

What:
Turn the handling/parsing of compile_commands_impl into a function.

Addresses:
Accessory to #98.
