### PR TITLE
Replace to_json (deprecated) with json.encode

### DIFF
--- a/src/compile_commands.bzl
+++ b/src/compile_commands.bzl
@@ -362,11 +362,11 @@ def _check_source_files(source_files, compilation_db):
             fail("File: %s\nNot available in collected source files" % src)
 
 def _compile_commands_json(compilation_db):
-    json = "[\n"
-    entries = [entry.to_json() for entry in compilation_db]
-    json += ",\n".join(entries)
-    json += "]\n"
-    return json
+    json_file = "[\n"
+    entries = [json.encode(entry) for entry in compilation_db]
+    json_file += ",\n".join(entries)
+    json_file += "]\n"
+    return json_file
 
 def compile_commands_impl(ctx):
     """ Creates compile_commands.json file for given targets and platform

--- a/src/per_file.bzl
+++ b/src/per_file.bzl
@@ -222,11 +222,11 @@ compile_info_aspect = aspect(
 )
 
 def _compile_commands_json(compile_commands):
-    json = "[\n"
-    entries = [entry.to_json() for entry in compile_commands]
-    json += ",\n".join(entries)
-    json += "]\n"
-    return json
+    json_file = "[\n"
+    entries = [json.encode(entry) for entry in compile_commands]
+    json_file += ",\n".join(entries)
+    json_file += "]\n"
+    return json_file
 
 def _compile_commands_data(ctx):
     compile_commands = []


### PR DESCRIPTION
Why:
The function `obj.to_json()` has been deprecated since [Bazel 4](https://releases.bazel.build/4.0.0/rc4/index.html#:~:text=The%20Starlark%20json%20module%20is%20now%20available%2E%20Use%20json%2Eencode%28x%29%20to%20encode%20a%20Starlark%20value%20as%20JSON%2E%20struct%2Eto%5Fjson%28x%29%20is%20deprecated%20and%20will%20be%20disabled%20by%20the%20%2D%2Dincompatible%5Fstruct%5Fhas%5Fno%5Fmethods%20flag).
Since we mainly want to support Bazel 6,7,8; we should use a non-deprecated solution (`json.encode(obj)` introduced in Bazel 4).
The biggest reason is that [Bazel 8](https://github.com/bazelbuild/bazel/releases/tag/8.0.0#:~:text=%2D%2Dincompatible%5Fstruct%5Fhas%5Fno%5Fmethods%20%28%2319465%3B%20now%20defaults%20to%20true) is removing the to_json function altogether.

What:
Replaced all uses of `to_json` with `json.encode`.

Addresses:
#108
