### PR TITLE
Use python toolchain instead of python runtime

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -13,9 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-module(
-    name = "codechecker_bazel",
-)
+module(name = "codechecker_bazel")
 
 python_extension = use_extension(
     "//src:tools.bzl", "module_register_default_python_toolchain")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -21,5 +21,6 @@ load(
 )
 
 register_default_python_toolchain()
+register_toolchains("@default_python_tools//:python_toolchain")
 
 register_default_codechecker()

--- a/src/common.bzl
+++ b/src/common.bzl
@@ -42,6 +42,31 @@ def version_specific_attributes():
         )})
     return {}
 
+def python_toolchain_type():
+    """
+    Returns version specific Python toolchain type
+    """
+    if BAZEL_VERSION.split(".")[0] in "01234567":
+        return "@bazel_tools//tools/python:toolchain_type"
+    return "@rules_python//python:toolchain_type"
+
+def python_path(ctx):
+    """
+    Returns version specific Python path
+    """
+    py_toolchain = ctx.toolchains[python_toolchain_type()]
+    if hasattr(py_toolchain, "py3_runtime_info"):
+        py_runtime_info = py_toolchain.py3_runtime_info
+        python_path = py_runtime_info.interpreter
+    elif hasattr(py_toolchain, "py3_runtime"):
+        py_runtime = py_toolchain.py3_runtime
+        python_path = py_runtime.interpreter_path
+    else:
+        fail("The resolved Python toolchain does not provide a Python3 runtime.")
+    if not python_path:
+        fail("The resolved Python toolchain does not provide a Python3 interpreter.")
+    return python_path
+
 def warning(ctx, msg):
     """
     Prints message if the debug tag is enabled.

--- a/src/tools.bzl
+++ b/src/tools.bzl
@@ -88,7 +88,6 @@ default_python_tools = repository_rule(
 
 def register_default_python_toolchain(ctx = None):
     default_python_tools(name = "default_python_tools")
-    #native.register_toolchains("@default_python_tools//:python_toolchain")
 
 # Define the extension here
 module_register_default_python_toolchain = module_extension(

--- a/test/foss/templates/WORKSPACE.template
+++ b/test/foss/templates/WORKSPACE.template
@@ -14,6 +14,7 @@ load(
 )
 
 register_default_python_toolchain()
+register_toolchains("@default_python_tools//:python_toolchain")
 
 register_default_codechecker()
 


### PR DESCRIPTION
Why:
Need to make python runtime more portable
and be ready for rules_python support.

What:
- Add toolchain for python instead of _python_runtime
- Add portable functions for python
- Fix register_toolchains

Addresses:
First step for rules_python support (Bazel 8) #108