### PR TITLE
Provide necessary debug infromation in non-verbose test runs.

### DIFF
--- a/test/foss/test_foss.py
+++ b/test/foss/test_foss.py
@@ -71,14 +71,14 @@ def create_test_method(directory_name: str) -> FunctionType:
         if not os.path.exists(project_working_dir):
             ret, _, _ = self.run_command("sh init.sh", project_root)
         self.assertTrue(os.path.exists(project_working_dir))
-        ret, _, _ = self.run_command(
+        ret, _, stderr = self.run_command(
             "bazel build :codechecker_test", project_working_dir
         )
-        self.assertEqual(ret, 0)
-        ret, _, _ = self.run_command(
+        self.assertEqual(ret, 0, stderr)
+        ret, _, stderr = self.run_command(
             "bazel build :per_file_test", project_working_dir
         )
-        self.assertEqual(ret, 0)
+        self.assertEqual(ret, 0, stderr)
 
     return test_runner
 

--- a/test/unit/argument_merge/test_argument_merge.py
+++ b/test/unit/argument_merge/test_argument_merge.py
@@ -36,10 +36,10 @@ class TestTemplate(TestBase):
 
     def test_per_file_argument_merge(self):
         """Test: Whether default options gets override"""
-        code, _, _ = self.run_command(
+        code, _, stderr = self.run_command(
             "bazel build //test/unit/argument_merge:per_file_argument_merge"
         )
-        self.assertEqual(code, 0)
+        self.assertEqual(code, 0, stderr)
         matched_lines: list[str] = self.grep_file(
             self.BAZEL_BIN_DIR
             + "/per_file_argument_merge/data/"

--- a/test/unit/caching/test_caching.py
+++ b/test/unit/caching/test_caching.py
@@ -72,15 +72,15 @@ class TestCaching(TestBase):
         the monolithic rule, as expected from architectural constrains.
         """
         target = "//test/unit/caching/tmp:codechecker_caching"
-        ret, _, _ = self.run_command(f"bazel build {target}")
-        self.assertEqual(ret, 0)
+        ret, _, stderr = self.run_command(f"bazel build {target}")
+        self.assertEqual(ret, 0, stderr)
         try:
             with open("tmp/secondary.cc", "a", encoding="utf-8") as f:
                 f.write("//test")
         except FileNotFoundError:
             self.fail("File not found!")
         ret, _, stderr = self.run_command(f"bazel build {target} --subcommands")
-        self.assertEqual(ret, 0)
+        self.assertEqual(ret, 0, stderr)
         # Since everything in the monolithic rule is a single action,
         # we expect that action to rerun for any modified file.
         self.assertEqual(
@@ -93,15 +93,15 @@ class TestCaching(TestBase):
         results for unchanged input files.
         """
         target = "//test/unit/caching/tmp:per_file_caching"
-        ret, _, _ = self.run_command(f"bazel build {target}")
-        self.assertEqual(ret, 0)
+        ret, _, stderr = self.run_command(f"bazel build {target}")
+        self.assertEqual(ret, 0, stderr)
         try:
             with open("tmp/secondary.cc", "a", encoding="utf-8") as f:
                 f.write("//test")
         except FileNotFoundError:
             self.fail("File not found!")
         ret, _, stderr = self.run_command(f"bazel build {target} --subcommands")
-        self.assertEqual(ret, 0)
+        self.assertEqual(ret, 0, stderr)
         self.assertEqual(
             stderr.count(f"SUBCOMMAND: # {target} [action 'CodeChecker"), 1
         )
@@ -112,15 +112,15 @@ class TestCaching(TestBase):
         the whole project when CTU is enabled
         """
         target = "//test/unit/caching/tmp:per_file_caching_ctu"
-        ret, _, _ = self.run_command(f"bazel build {target}")
-        self.assertEqual(ret, 0)
+        ret, _, stderr = self.run_command(f"bazel build {target}")
+        self.assertEqual(ret, 0, stderr)
         try:
             with open("tmp/secondary.cc", "a", encoding="utf-8") as f:
                 f.write("//test")
         except FileNotFoundError:
             self.fail("File not found!")
         ret, _, stderr = self.run_command(f"bazel build {target} --subcommands")
-        self.assertEqual(ret, 0)
+        self.assertEqual(ret, 0, stderr)
         # We expect both files to be reanalyzed, since there is no caching
         # implemented for CTU analysis
         self.assertEqual(

--- a/test/unit/compile_flags/test_compile_flags.py
+++ b/test/unit/compile_flags/test_compile_flags.py
@@ -43,8 +43,8 @@ class TestBasic(TestBase):
             + "//test/unit/compile_flags:compile_commands_filter "
             + "--cxxopt=__CXX__ --conlyopt=__CONLY__"
         )
-        exit_code, _, _ = self.run_command(build_cmd)
-        self.assertEqual(0, exit_code)
+        exit_code, _, stderr = self.run_command(build_cmd)
+        self.assertEqual(0, exit_code, stderr)
         compile_commands = os.path.join(
             self.BAZEL_BIN_DIR,  # pyright: ignore
             "compile_commands_filter",
@@ -80,8 +80,8 @@ class TestBasic(TestBase):
             + "//test/unit/compile_flags:per_file_filter "
             + "--cxxopt=__CXX__ --conlyopt=__CONLY__"
         )
-        exit_code, _, _ = self.run_command(build_cmd)
-        self.assertEqual(0, exit_code)
+        exit_code, _, stderr = self.run_command(build_cmd)
+        self.assertEqual(0, exit_code, stderr)
         compile_commands = os.path.join(
             self.BAZEL_BIN_DIR,  # pyright: ignore
             "per_file_filter",

--- a/test/unit/config/test_config.py
+++ b/test/unit/config/test_config.py
@@ -34,10 +34,10 @@ class TestConfig(TestBase):
 
     def test_codechecker_json(self):
         """Test: bazel build //test/unit/config:codechecker_json"""
-        ret, _, _ = self.run_command(
+        ret, _, stderr = self.run_command(
             "bazel build //test/unit/config:codechecker_json"
         )
-        self.assertEqual(ret, 0)
+        self.assertEqual(ret, 0, stderr)
         copied_config = os.path.join(
             self.BAZEL_BIN_DIR,  # type: ignore
             "codechecker_json",
@@ -47,10 +47,10 @@ class TestConfig(TestBase):
 
     def test_codechecker_yaml(self):
         """Test: bazel build //test/unit/config:codechecker_yaml"""
-        ret, _, _ = self.run_command(
+        ret, _, stderr = self.run_command(
             "bazel build //test/unit/config:codechecker_yaml"
         )
-        self.assertEqual(ret, 0)
+        self.assertEqual(ret, 0, stderr)
         copied_config = os.path.join(
             self.BAZEL_BIN_DIR,  # type: ignore
             "codechecker_yaml",
@@ -60,11 +60,11 @@ class TestConfig(TestBase):
 
     def test_codechecker_test_json(self):
         """Test: bazel test //test/unit/config:codechecker_test_json"""
-        ret, _, _ = self.run_command(
+        ret, _, stderr = self.run_command(
             "bazel test //test/unit/config:codechecker_test_json"
         )
         # Should not find the division by zero bug
-        self.assertEqual(ret, 0)
+        self.assertEqual(ret, 0, stderr)
         copied_config = os.path.join(
             self.BAZEL_BIN_DIR,  # type: ignore
             "codechecker_test_json",
@@ -76,11 +76,11 @@ class TestConfig(TestBase):
 
     def test_codechecker_test_yaml(self):
         """Test: bazel test //test/unit/config:codechecker_test_yaml"""
-        ret, _, _ = self.run_command(
+        ret, _, stderr = self.run_command(
             "bazel test //test/unit/config:codechecker_test_yaml"
         )
         # Should not find the division by zero bug
-        self.assertEqual(ret, 0)
+        self.assertEqual(ret, 0, stderr)
         copied_config = os.path.join(
             self.BAZEL_BIN_DIR,  # type: ignore
             "codechecker_test_yaml",
@@ -90,11 +90,11 @@ class TestConfig(TestBase):
 
     def test_per_file_test_json(self):
         """Test: bazel test //test/unit/config:per_file_test_json"""
-        ret, _, _ = self.run_command(
+        ret, _, stderr = self.run_command(
             "bazel test //test/unit/config:per_file_test_json"
         )
         # Should not find the division by zero bug
-        self.assertEqual(ret, 0)
+        self.assertEqual(ret, 0, stderr)
         copied_config = os.path.join(
             self.BAZEL_BIN_DIR,  # type: ignore
             "per_file_test_json",
@@ -104,11 +104,11 @@ class TestConfig(TestBase):
 
     def test_per_file_test_yaml(self):
         """Test: bazel test //test/unit/config:per_file_test_yaml"""
-        ret, _, _ = self.run_command(
+        ret, _, stderr = self.run_command(
             "bazel test //test/unit/config:per_file_test_yaml"
         )
         # Should not find the division by zero bug
-        self.assertEqual(ret, 0)
+        self.assertEqual(ret, 0, stderr)
         copied_config = os.path.join(
             self.BAZEL_BIN_DIR,  # type: ignore
             "per_file_test_yaml",

--- a/test/unit/external_repository/test_external_repo.py
+++ b/test/unit/external_repository/test_external_repo.py
@@ -86,11 +86,11 @@ class TestImplDepExternalDep(TestBase):
         Test: bazel build :compile_commands_isystem "
         "--experimental_cc_implementation_deps --enable_bzlmod
         """
-        ret, _, _ = self.run_command(
+        ret, _, stderr = self.run_command(
             "bazel build :compile_commands_isystem "
             "--experimental_cc_implementation_deps --enable_bzlmod"
         )
-        self.assertEqual(ret, 0)
+        self.assertEqual(ret, 0, stderr)
         comp_json_file = os.path.join(
             self.BAZEL_BIN_DIR,  # pyright: ignore
             "compile_commands_isystem",
@@ -119,20 +119,20 @@ class TestImplDepExternalDep(TestBase):
         Test: bazel build :codechecker_external_deps
         --experimental_cc_implementation_deps --enable_bzlmod
         """
-        ret, _, _ = self.run_command(
+        ret, _, stderr = self.run_command(
             "bazel build :codechecker_external_deps "
             "--experimental_cc_implementation_deps --enable_bzlmod"
         )
-        self.assertEqual(ret, 0)
+        self.assertEqual(ret, 0, stderr)
 
     def test_per_file_external_lib(self):
         """Test: bazel build :per_file_external_deps "
         "--experimental_cc_implementation_deps"""
-        ret, _, _ = self.run_command(
+        ret, _, stderr = self.run_command(
             "bazel build :per_file_external_deps "
             "--experimental_cc_implementation_deps --enable_bzlmod"
         )
-        self.assertEqual(ret, 0)
+        self.assertEqual(ret, 0, stderr)
 
 
 if __name__ == "__main__":

--- a/test/unit/generated_files/test_generated_files.py
+++ b/test/unit/generated_files/test_generated_files.py
@@ -35,10 +35,10 @@ class TestGeneratedFiles(TestBase):
         """
         Test: bazel test //test/unit/generated_files:codechecker_genrule_header
         """
-        ret, _, _ = self.run_command(
+        ret, _, stderr = self.run_command(
             "bazel test //test/unit/generated_files:codechecker_genrule_header"
         )
-        self.assertEqual(ret, 3)
+        self.assertEqual(ret, 3, stderr)
         test_log = os.path.join(
             self.BAZEL_TESTLOGS_DIR,  # type: ignore
             "codechecker_genrule_header",
@@ -55,10 +55,10 @@ class TestGeneratedFiles(TestBase):
         """
         Test: bazel test //test/unit/generated_files:codechecker_genrule_source
         """
-        ret, _, _ = self.run_command(
+        ret, _, stderr = self.run_command(
             "bazel test //test/unit/generated_files:codechecker_genrule_source"
         )
-        self.assertEqual(ret, 3)
+        self.assertEqual(ret, 3, stderr)
         test_log = os.path.join(
             self.BAZEL_TESTLOGS_DIR,  # type: ignore
             "codechecker_genrule_source",
@@ -75,10 +75,10 @@ class TestGeneratedFiles(TestBase):
         """
         Test: bazel test //test/unit/generated_files:per_file_genrule_header
         """
-        ret, _, _ = self.run_command(
+        ret, _, stderr = self.run_command(
             "bazel test //test/unit/generated_files:per_file_genrule_header"
         )
-        self.assertEqual(ret, 3)
+        self.assertEqual(ret, 3, stderr)
         test_log = os.path.join(
             self.BAZEL_TESTLOGS_DIR,  # type: ignore
             "per_file_genrule_header",
@@ -95,10 +95,10 @@ class TestGeneratedFiles(TestBase):
         """
         Test: bazel test //test/unit/generated_files:per_file_genrule_source
         """
-        ret, _, _ = self.run_command(
+        ret, _, stderr = self.run_command(
             "bazel test //test/unit/generated_files:per_file_genrule_source"
         )
-        self.assertEqual(ret, 3)
+        self.assertEqual(ret, 3, stderr)
         test_log = os.path.join(
             self.BAZEL_TESTLOGS_DIR,  # type: ignore
             "per_file_genrule_source",
@@ -117,11 +117,11 @@ class TestGeneratedFiles(TestBase):
         bazel build //test/unit/generated_files:compile_commands_genrule_source
         """
         target = "genrule_source"
-        ret, _, _ = self.run_command(
+        ret, _, stderr = self.run_command(
             "bazel build "
             + f"//test/unit/generated_files:compile_commands_{target}"
         )
-        self.assertEqual(ret, 0)
+        self.assertEqual(ret, 0, stderr)
         compile_commands = os.path.join(
             self.BAZEL_BIN_DIR,  # type: ignore
             f"compile_commands_{target}",
@@ -140,11 +140,11 @@ class TestGeneratedFiles(TestBase):
         bazel build //test/unit/generated_files:compile_commands_genrule_header
         """
         target = "genrule_header"
-        ret, _, _ = self.run_command(
+        ret, _, stderr = self.run_command(
             "bazel build "
             f"//test/unit/generated_files:compile_commands_{target}"
         )
-        self.assertEqual(ret, 0)
+        self.assertEqual(ret, 0, stderr)
         compile_commands = os.path.join(
             self.BAZEL_BIN_DIR,  # type: ignore
             f"compile_commands_{target}",

--- a/test/unit/implementation_deps/test_implementation_deps.py
+++ b/test/unit/implementation_deps/test_implementation_deps.py
@@ -37,11 +37,11 @@ class TestImplementationDeps(TestBase):
         Test: bazel test --experimental_cc_implementation_deps
         //test/unit/implementation_deps:codechecker_implementation_deps
         """
-        ret, _, _ = self.run_command(
+        ret, _, stderr = self.run_command(
             "bazel test --experimental_cc_implementation_deps "
             "//test/unit/implementation_deps:codechecker_implementation_deps"
         )
-        self.assertEqual(ret, 3)
+        self.assertEqual(ret, 3, stderr)
         test_log = os.path.join(
             self.BAZEL_TESTLOGS_DIR,  # type: ignore
             "codechecker_implementation_deps",
@@ -59,11 +59,11 @@ class TestImplementationDeps(TestBase):
         Test: bazel test --experimental_cc_implementation_deps
         //test/unit/implementation_deps:pre_file_implementation_deps
         """
-        ret, _, _ = self.run_command(
+        ret, _, stderr = self.run_command(
             "bazel test --experimental_cc_implementation_deps "
             "//test/unit/implementation_deps:per_file_implementation_deps"
         )
-        self.assertEqual(ret, 3)
+        self.assertEqual(ret, 3, stderr)
         test_log = os.path.join(
             self.BAZEL_TESTLOGS_DIR,  # type: ignore
             "per_file_implementation_deps",
@@ -81,11 +81,11 @@ class TestImplementationDeps(TestBase):
         Test: bazel build --experimental_cc_implementation_deps
         //test/unit/implementation_deps:compile_commands_implementation_deps
         """
-        ret, _, _ = self.run_command(
+        ret, _, stderr = self.run_command(
             "bazel build --experimental_cc_implementation_deps //test/unit/"
             "implementation_deps:compile_commands_implementation_deps"
         )
-        self.assertEqual(ret, 0)
+        self.assertEqual(ret, 0, stderr)
         compile_commands = os.path.join(
             self.BAZEL_BIN_DIR,  # type: ignore
             "compile_commands_implementation_deps",

--- a/test/unit/parse/test_parse.py
+++ b/test/unit/parse/test_parse.py
@@ -50,10 +50,10 @@ class TestTemplate(TestBase):
 
     def test_parse_html(self):
         """Test: Parse results into html"""
-        ret, _, _ = self.run_command(
+        ret, _, stderr = self.run_command(
             "bazel build //test/unit/parse:codechecker"
         )
-        self.assertEqual(ret, 0)
+        self.assertEqual(ret, 0, stderr)
         self.check_parse(
             f"{self.BAZEL_BIN_DIR}/codechecker/codechecker-files/data"
         )
@@ -64,11 +64,11 @@ class TestTemplate(TestBase):
         # the report folder. Bazel's output folder however is readonly.
         # Adding the flag: "--experimental_writable_outputs"
         # makes the directory writeable
-        ret, _, _ = self.run_command(
+        ret, _, stderr = self.run_command(
             "bazel build //test/unit/parse:codechecker "
             "--experimental_writable_outputs"
         )
-        self.assertEqual(ret, 0)
+        self.assertEqual(ret, 0, stderr)
         self.check_store(
             f"{self.BAZEL_BIN_DIR}/codechecker/codechecker-files/data",
             "unit_test_bazel",

--- a/test/unit/virtual_include/test_virtual_include.py
+++ b/test/unit/virtual_include/test_virtual_include.py
@@ -69,10 +69,10 @@ class TestVirtualInclude(TestBase):
 
     def test_bazel_per_file_plist_path_resolved(self):
         """Test: bazel build :per_file_virtual_include"""
-        ret, _, _ = self.run_command(
+        ret, _, stderr = self.run_command(
             "bazel build //test/unit/virtual_include:per_file_virtual_include",
         )
-        self.assertEqual(ret, 0)
+        self.assertEqual(ret, 0, stderr)
         plist_files = glob.glob(
             os.path.join(
                 self.BAZEL_BIN_DIR,  # pyright: ignore
@@ -94,11 +94,11 @@ class TestVirtualInclude(TestBase):
 
     def test_bazel_codechecker_plist_path_resolved(self):
         """Test: bazel build :codechecker_virtual_include"""
-        ret, _, _ = self.run_command(
+        ret, _, stderr = self.run_command(
             "bazel build "
             "//test/unit/virtual_include:codechecker_virtual_include"
         )
-        self.assertEqual(ret, 0)
+        self.assertEqual(ret, 0, stderr)
         plist_files = glob.glob(
             os.path.join(
                 self.BAZEL_BIN_DIR,  # pyright: ignore
@@ -120,19 +120,19 @@ class TestVirtualInclude(TestBase):
 
     def test_bazel_codechecker_implementation_deps_virtual_include(self):
         """Test: bazel build :codechecker_impl_deps_include"""
-        ret, _, _ = self.run_command(
+        ret, _, stderr = self.run_command(
             "bazel build --experimental_cc_implementation_deps "
             "//test/unit/virtual_include:codechecker_impl_deps_include"
         )
-        self.assertEqual(ret, 0)
+        self.assertEqual(ret, 0, stderr)
 
     def test_bazel_per_file_implementation_deps_virtual_include(self):
         """Test: bazel build :per_file_impl_deps_include"""
-        ret, _, _ = self.run_command(
+        ret, _, stderr = self.run_command(
             "bazel build --experimental_cc_implementation_deps "
             "//test/unit/virtual_include:per_file_impl_deps_include"
         )
-        self.assertEqual(ret, 0)
+        self.assertEqual(ret, 0, stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Why:
I want to be able to get enough information without having to scroll through pages of logs.
By default, pytest hides the current logs. I need to pass --log-cli-level=DEBUG to each run, to see them.

What:
- Add stderr as message for process asserts

Addresses:
none