### PR TITLE
Add bazel specific ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ venv
 # Ignore test specific bazelversion files
 test/unit/external_repository/.bazelversion
 test/unit/external_repository/third_party/my_lib/.bazelversion
+
+# Ignore Bazel specific files
+.bazelversion
+MODULE.bazel.lock


### PR DESCRIPTION
Why:
I hate seeing all those uncommitted files

What:
- Adds `.bazelversion` to gitignore
- Adds `MODULE.bazel.lock` to gitignore

Addresses:
none
