### PR TITLE
Rename rule to rules_codechecker

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -11,7 +11,7 @@ A clear and concise description of what the bug is.
 Versions of `CodeChecker`, `bazel` and this repo. You can get version info via:
 * `CodeChecker version`
 * `bazel --version`
-* Inspecting the WORKSPACE file where you added `codechecker_bazel`.
+* Inspecting the WORKSPACE file where you added `rules_codechecker`.
 
 **To Reproduce**
 Steps to reproduce the behaviour:

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-module(name = "codechecker_bazel")
+module(name = "rules_codechecker")
 
 python_extension = use_extension(
     "//src:tools.bzl",

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Alternatively follow the official guide at: https://bazel.build/install
 How to use
 ----------
 
-To use these rules you should first add `codechecker_bazel` as an
+To use these rules you should first add `rules_codechecker` as an
 [external dependency](https://bazel.build/versions/6.5.0/external/overview#workspace-system)
 
 Using the legacy `WORKSPACE` system:
@@ -125,13 +125,13 @@ Using the legacy `WORKSPACE` system:
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 git_repository(
-    name = "codechecker_bazel",
-    remote = "https://github.com/Ericsson/codechecker_bazel.git",
+    name = "rules_codechecker",
+    remote = "https://github.com/Ericsson/rules_codechecker.git",
     branch = "main",
 )
 
 load(
-    "@codechecker_bazel//src:tools.bzl",
+    "@rules_codechecker//src:tools.bzl",
     "register_default_codechecker",
     "register_default_python_toolchain",
 )
@@ -147,11 +147,11 @@ TODO: update this part when we have an actual release-->
 In Bazel 6, to activate the MODULE system, add `--enable_bzlmod` to the `.bazelrc` file
 ```
 git_override(
-    module_name = "codechecker_bazel",
-    remote = "https://github.com/Ericsson/codechecker_bazel.git",
+    module_name = "rules_codechecker",
+    remote = "https://github.com/Ericsson/rules_codechecker.git",
     commit = "a32e9d75df4fb453c8bbfdf0fdf6a767797ae53d", # Update to latest
 )
-bazel_dep(name = "codechecker_bazel")
+bazel_dep(name = "rules_codechecker")
 
 ```
 ## CodeChecker
@@ -172,7 +172,7 @@ To use `codechecker_test()` include it to your BUILD file:
 
 ```python
 load(
-    "@codechecker_bazel//src:codechecker.bzl",
+    "@rules_codechecker//src:codechecker.bzl",
     "codechecker_test",
 )
 ```
@@ -191,7 +191,7 @@ codechecker_test(
 
 #### Per-file CodeChecker analysis:
 > [!IMPORTANT]
-> The option is still in prototype status and is subject to changes or removal without notice. See [#31](https://github.com/Ericsson/codechecker_bazel/issues/31).
+> The option is still in prototype status and is subject to changes or removal without notice. See [#31](https://github.com/Ericsson/rules_codechecker/issues/31).
 > You are free to experiment and report issues however!
 
 Instead of a single CodeChecker call, adding `per_file = True,` parameter to codechecker_test bazel rule invokes
@@ -241,7 +241,7 @@ You can include and use it similarly as well:
 
 ```python
 load(
-    "@codechecker_bazel//src:codechecker.bzl",
+    "@rules_codechecker//src:codechecker.bzl",
     "codechecker"
 )
 ```
@@ -249,14 +249,14 @@ load(
 -->
 
 ### Multi-platform CodeChecker analysis: `codechecker_suite()`
-_TODO: Describe this rule: see issue [#44](https://github.com/Ericsson/codechecker_bazel/issues/44)._
+_TODO: Describe this rule: see issue [#44](https://github.com/Ericsson/rules_codechecker/issues/44)._
 <!--
 This rule is functionally equivalent to `codechecker_test()` but allows for running on multiple platforms via the `platforms` parameter.
 You can include and use it similarly as well:
 
 ```python
 load(
-    "@codechecker_bazel//src:codechecker.bzl",
+    "@rules_codechecker//src:codechecker.bzl",
     "codechecker_suite"
 )
 ```
@@ -269,7 +269,7 @@ First, include the rule in your BUILD file:
 
 ```python
 load(
-    "@codechecker_bazel//src:codechecker.bzl",
+    "@rules_codechecker//src:codechecker.bzl",
     "codechecker_config"
 )
 ```
@@ -320,7 +320,7 @@ To use it, add the following to your BUILD file:
 
 ```python
 load(
-    "@codechecker_bazel//src:clang.bzl",
+    "@rules_codechecker//src:clang.bzl",
     "clang_tidy_test",
 )
 
@@ -340,7 +340,7 @@ To use it, add the following to your BUILD file:
 
 ```python
 load(
-    "@codechecker_bazel//src:clang.bzl",
+    "@rules_codechecker//src:clang.bzl",
     "clang_analyze_test",
 )
 
@@ -361,7 +361,7 @@ As generating a compilation database for C/C++ is a known pain point for bazel, 
 
 ```python
 load(
-    "@codechecker_bazel//src:compile_commands.bzl",
+    "@rules_codechecker//src:compile_commands.bzl",
     "compile_commands",
 )
 ```
@@ -382,14 +382,14 @@ You can find the generated `compile_commands.json` under `bazel-bin/`.
 
 ### Cross-translation unit analysis via the Clang Static Analyzer: `clang_ctu_test()`
 > [!IMPORTANT]
-> The rule is still in prototype status and is subject to changes or removal without notice. See [#32](https://github.com/Ericsson/codechecker_bazel/issues/32).
+> The rule is still in prototype status and is subject to changes or removal without notice. See [#32](https://github.com/Ericsson/rules_codechecker/issues/32).
 > We are also actively pursuing better CTU support _using_ CodeChecker.
 
 The Bazel rule `clang_analyze_test()` runs The Clang Static Analyzer with [cross translation unit analysis](https://clang.llvm.org/docs/analyzer/user-docs/CrossTranslationUnit.html) analysis without CodeChecker. To use it, add the following to your BUILD file:
 
 ```python
 load(
-    "@codechecker_bazel//src:clang_ctu.bzl",
+    "@rules_codechecker//src:clang_ctu.bzl",
     "clang_ctu_test",
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-workspace(name = "codechecker_bazel")
+workspace(name = "rules_codechecker")
 
 load(
-    "@codechecker_bazel//src:tools.bzl",
+    "@rules_codechecker//src:tools.bzl",
     "register_default_codechecker",
     "register_default_python_toolchain",
 )

--- a/test/foss/templates/MODULE.template
+++ b/test/foss/templates/MODULE.template
@@ -1,5 +1,5 @@
 local_path_override(
-    module_name = "codechecker_bazel",
+    module_name = "rules_codechecker",
     path = "../../../../",
 )
-bazel_dep(name = "codechecker_bazel")
+bazel_dep(name = "rules_codechecker")

--- a/test/foss/templates/WORKSPACE.template
+++ b/test/foss/templates/WORKSPACE.template
@@ -3,12 +3,12 @@
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 local_repository(
-    name = "codechecker_bazel",
+    name = "rules_codechecker",
     path = "../../../../",
 )
 
 load(
-    "@codechecker_bazel//src:tools.bzl",
+    "@rules_codechecker//src:tools.bzl",
     "register_default_codechecker",
     "register_default_python_toolchain",
 )

--- a/test/foss/yaml-cpp/init.sh
+++ b/test/foss/yaml-cpp/init.sh
@@ -27,7 +27,7 @@ cat <<EOF >> BUILD.bazel
 
 # codechecker rules
 load(
-    "@codechecker_bazel//src:codechecker.bzl",
+    "@rules_codechecker//src:codechecker.bzl",
     "codechecker_test",
 )
 
@@ -50,5 +50,5 @@ codechecker_test(
 #-------------------------------------------------------
 EOF
 
-# Add codechecker_bazel repo to WORKSPACE
+# Add rules_codechecker repo to WORKSPACE
 cat ../../templates/WORKSPACE.template >> WORKSPACE

--- a/test/foss/zlib-module/init.sh
+++ b/test/foss/zlib-module/init.sh
@@ -26,7 +26,7 @@ cat <<EOF >> BUILD.bazel
 
 # codechecker rules
 load(
-    "@codechecker_bazel//src:codechecker.bzl",
+    "@rules_codechecker//src:codechecker.bzl",
     "codechecker_test",
 )
 codechecker_test(
@@ -49,5 +49,5 @@ EOF
 
 # Enable MODULE.bazel (in Bazel 6)
 echo "common --enable_bzlmod" > .bazelrc
-# Add codechecker_bazel repo MODULE.bazel
+# Add rules_codechecker repo MODULE.bazel
 cat ../../templates/MODULE.template >> MODULE.bazel

--- a/test/foss/zlib/init.sh
+++ b/test/foss/zlib/init.sh
@@ -27,7 +27,7 @@ cat <<EOF >> BUILD.bazel
 
 # codechecker rules
 load(
-    "@codechecker_bazel//src:codechecker.bzl",
+    "@rules_codechecker//src:codechecker.bzl",
     "codechecker_test",
 )
 
@@ -50,5 +50,5 @@ codechecker_test(
 #-------------------------------------------------------
 EOF
 
-# Add codechecker_bazel repo to WORKSPACE
+# Add rules_codechecker repo to WORKSPACE
 cat ../../templates/WORKSPACE.template >> WORKSPACE

--- a/test/unit/argument_merge/BUILD
+++ b/test/unit/argument_merge/BUILD
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load(
-    "@codechecker_bazel//src:codechecker.bzl",
+    "//src:codechecker.bzl",
     "codechecker_test",
 )
 

--- a/test/unit/caching/BUILD
+++ b/test/unit/caching/BUILD
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load(
-    "@codechecker_bazel//src:codechecker.bzl",
+    "//src:codechecker.bzl",
     "codechecker_test",
 )
 

--- a/test/unit/compile_flags/BUILD
+++ b/test/unit/compile_flags/BUILD
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 load(
-    "@codechecker_bazel//src:codechecker.bzl",
+    "//src:codechecker.bzl",
     "codechecker_test",
 )
 
 # compile_commands rule
 load(
-    "@codechecker_bazel//src:compile_commands.bzl",
+    "//src:compile_commands.bzl",
     "compile_commands",
 )
 

--- a/test/unit/config/BUILD
+++ b/test/unit/config/BUILD
@@ -14,7 +14,7 @@
 
 # codechecker rules
 load(
-    "@codechecker_bazel//src:codechecker.bzl",
+    "//src:codechecker.bzl",
     "codechecker",
     "codechecker_config",
     "codechecker_test",

--- a/test/unit/external_repository/BUILD
+++ b/test/unit/external_repository/BUILD
@@ -13,11 +13,11 @@
 # limitations under the License.
 
 load(
-    "@codechecker_bazel//src:codechecker.bzl",
+    "@rules_codechecker//src:codechecker.bzl",
     "codechecker_test",
 )
 load(
-    "@codechecker_bazel//src:compile_commands.bzl",
+    "@rules_codechecker//src:compile_commands.bzl",
     "compile_commands",
 )
 

--- a/test/unit/external_repository/MODULE.bazel
+++ b/test/unit/external_repository/MODULE.bazel
@@ -18,11 +18,11 @@ from external repositories
 """
 
 local_path_override(
-    module_name = "codechecker_bazel",
+    module_name = "rules_codechecker",
     path = "../../../",
 )
 
-bazel_dep(name = "codechecker_bazel")
+bazel_dep(name = "rules_codechecker")
 
 local_path_override(
     module_name = "external_lib",

--- a/test/unit/generated_files/BUILD
+++ b/test/unit/generated_files/BUILD
@@ -13,11 +13,11 @@
 # limitations under the License.
 
 load(
-    "@codechecker_bazel//src:codechecker.bzl",
+    "//src:codechecker.bzl",
     "codechecker_test",
 )
 load(
-    "@codechecker_bazel//src:compile_commands.bzl",
+    "//src:compile_commands.bzl",
     "compile_commands",
 )
 

--- a/test/unit/implementation_deps/BUILD
+++ b/test/unit/implementation_deps/BUILD
@@ -13,11 +13,11 @@
 # limitations under the License.
 
 load(
-    "@codechecker_bazel//src:codechecker.bzl",
+    "//src:codechecker.bzl",
     "codechecker_test",
 )
 load(
-    "@codechecker_bazel//src:compile_commands.bzl",
+    "//src:compile_commands.bzl",
     "compile_commands",
 )
 

--- a/test/unit/legacy/BUILD
+++ b/test/unit/legacy/BUILD
@@ -1,19 +1,19 @@
 # clang-tidy and clang -analyze rules
 load(
-    "@codechecker_bazel//src:clang.bzl",
+    "//src:clang.bzl",
     "clang_analyze_test",
     "clang_tidy_test",
 )
 
 # clang -analyze + CTU rule
 load(
-    "@codechecker_bazel//src:clang_ctu.bzl",
+    "//src:clang_ctu.bzl",
     "clang_ctu_test",
 )
 
 # codechecker rules
 load(
-    "@codechecker_bazel//src:codechecker.bzl",
+    "//src:codechecker.bzl",
     "codechecker",
     "codechecker_config",
     "codechecker_suite",
@@ -22,7 +22,7 @@ load(
 
 # compile_commands rule
 load(
-    "@codechecker_bazel//src:compile_commands.bzl",
+    "//src:compile_commands.bzl",
     "compile_commands",
 )
 

--- a/test/unit/parse/BUILD
+++ b/test/unit/parse/BUILD
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load(
-    "@codechecker_bazel//src:codechecker.bzl",
+    "//src:codechecker.bzl",
     "codechecker_test",
 )
 

--- a/test/unit/virtual_include/BUILD
+++ b/test/unit/virtual_include/BUILD
@@ -14,7 +14,7 @@
 
 # codechecker rules
 load(
-    "@codechecker_bazel//src:codechecker.bzl",
+    "//src:codechecker.bzl",
     "codechecker_test",
 )
 


### PR DESCRIPTION
Why:
We want to rename the rule to follow Bazel's naming guidelines.

What:
- replaced _all_ occurrences of codechecker_bazel with rules_codechecker

Addresses:
Fixes: #173 