### PR TITLE
Apply buildifier linter suggestions

### DIFF
--- a/src/clang.bzl
+++ b/src/clang.bzl
@@ -215,8 +215,14 @@ def _run_analyzer(
 
 def check_valid_file_type(src):
     """
+    Checks if the file is a cpp related file.
+
     Returns True if the file type matches one of the permitted
     srcs file types for C and C++ header/source files.
+    Args:
+        src: Path of a single source file.
+    Returns:
+        Boolean value.
     """
     permitted_file_types = [
         ".c",
@@ -326,6 +332,8 @@ CompileInfo = provider(
     },
 )
 
+# buildifier: disable=unused-variable
+# The headers variable is used: headers += dep[CompileInfo].headers.to_list()
 def _process_all_deps(ctx, arguments, headers):
     for attr in SOURCE_ATTR:
         if hasattr(ctx.rule.attr, attr):
@@ -391,7 +399,7 @@ compile_info_aspect = aspect(
 
 def _clang_test(ctx, tool):
     all_files = []
-    all_headers = depset()
+    all_headers_list = []
     for target in ctx.attr.targets:
         if CompileInfo in target:
             if hasattr(target[CompileInfo], "arguments"):
@@ -411,8 +419,9 @@ def _clang_test(ctx, tool):
                         ctx.attr.name,
                     )
                     all_files.append(report)
-                    all_headers = depset(transitive = [all_headers, headers])
+                    all_headers_list.extend(headers.to_list())
 
+    all_headers = depset(all_headers_list)
     ctx.actions.write(
         output = ctx.outputs.test_script,
         is_executable = True,

--- a/src/clang.bzl
+++ b/src/clang.bzl
@@ -333,7 +333,7 @@ CompileInfo = provider(
 )
 
 # buildifier: disable=unused-variable
-# The headers variable is used: headers += dep[CompileInfo].headers.to_list()
+# The headers variable is used in the alternative implementation
 def _process_all_deps(ctx, arguments, headers):
     for attr in SOURCE_ATTR:
         if hasattr(ctx.rule.attr, attr):

--- a/src/codechecker.bzl
+++ b/src/codechecker.bzl
@@ -45,6 +45,8 @@ def get_platform_alias(platform):
     """
     Get platform alias for full platform names being used
 
+    Args:
+        platform: A string containing the platform
     Returns:
     string: If the full platform name is consistent with
     valid syntax, returns the short alias to represent it.
@@ -188,7 +190,7 @@ codechecker = rule(
         "_compile_commands_filter": attr.label(
             allow_files = True,
             executable = True,
-            cfg = "host",
+            cfg = "exec",
             default = ":compile_commands_filter",
         ),
         "_codechecker_script_template": attr.label(
@@ -264,7 +266,7 @@ _codechecker_test = rule(
         "_compile_commands_filter": attr.label(
             allow_files = True,
             executable = True,
-            cfg = "host",
+            cfg = "exec",
             default = ":compile_commands_filter",
         ),
         "_codechecker_script_template": attr.label(
@@ -313,7 +315,24 @@ def codechecker_test(
         tags = [],
         per_file = False,
         **kwargs):
-    """ Bazel test to run CodeChecker """
+    """
+    Macro to choose the appropriate codechecker rule
+
+    Args:
+        name: Name of the target invoking CodeChecker.
+        targets: List of targets to be analyzed by CodeChecker.
+        platform: Platform to be analyzed on.
+        severities: List of warning levels that should be considered failing.
+        skip: Skip patterns for CodeChecker.
+        config: Config target for CodeChecker.
+        analyze: List of analyze command arguments.
+        tags: Bazel tags
+        per_file: Boolean value, toggles wether to run the analysis
+                  with the experimental per_file rule.
+        **kwargs: Other miscellaneous arguments.
+    Returns:
+        none
+    """
     codechecker_tags = [] + tags
     if "codechecker" not in tags:
         codechecker_tags.append("codechecker")
@@ -349,7 +368,22 @@ def codechecker_suite(
         analyze = [],
         tags = [],
         **kwargs):
-    """ Bazel test suite to run CodeChecker for different platforms """
+    """
+    Bazel test suite to run CodeChecker for different platforms
+
+    Args:
+        name: Name of the target invoking CodeChecker.
+        targets: List of targets to be analyzed by CodeChecker.
+        platforms: List of platform to be analyzed on.
+        severities: List of warning levels that should be considered failing.
+        skip: Skip patterns for CodeChecker.
+        config: Config target for CodeChecker.
+        analyze: List of analyze command arguments.
+        tags: Bazel tags
+        **kwargs: Other miscellaneous arguments.
+    Returns:
+        none
+    """
     tests = []
     for platform in platforms:
         shortname = get_platform_alias(platform)

--- a/src/codechecker_config.bzl
+++ b/src/codechecker_config.bzl
@@ -18,9 +18,15 @@ Ruleset for configuring codechecker.
 
 def _get_config_file_name(ctx):
     """
+    Get the name of the config file.
+
     Returns the name of the config file to be used, with correct extension
     If no config file is given, we write the configuration options into a
     config.json file.
+    Args:
+        ctx: The context variable
+    Returns:
+        Path of the config file
     """
     if ctx.attr.config:
         if type(ctx.attr.config) == "list":
@@ -37,8 +43,13 @@ def _get_config_file_name(ctx):
 
 def get_config_file(ctx):
     """
-    Returns (config_file, environment_variables)
-    config_file is a file object that is readable during Codechecker execution
+    Create config file for analysis
+
+    Args:
+        ctx: The context variable
+    Returns:
+        A tuple: (config_file, environment_variables)
+        config_file is the file object to be read by Codechecker
     """
 
     # Declare config file to use during analysis

--- a/src/common.bzl
+++ b/src/common.bzl
@@ -57,4 +57,5 @@ def warning(ctx, msg):
     NOTE: "debug" in tags works only for rules, not aspects
     """
     if hasattr(ctx.attr, "tags") and "debug" in ctx.attr.tags:
+        # buildifier: disable=print
         print(msg)

--- a/src/compile_commands.bzl
+++ b/src/compile_commands.bzl
@@ -82,6 +82,9 @@ QUOTE_INCLUDE = "-iquote "
 def get_compile_flags(ctx, dep):
     """ Return a list of compile options
 
+    Args:
+        ctx: The context variable.
+        dep: A target with CcInfo.
     Returns:
       List of compile options.
     """
@@ -137,6 +140,8 @@ def get_compile_flags(ctx, dep):
 def get_sources(ctx):
     """ Return a list of source files
 
+    Args:
+        ctx: The context variable.
     Returns:
       List of source files.
     """
@@ -211,6 +216,9 @@ def _cc_compiler_info(ctx, target, src, feature_configuration, cc_toolchain):
 def get_compilation_database(target, ctx):
     """ Return a "compilation database" or "compile commands" ready to create a JSON file
 
+    Args:
+        ctx: The context variable.
+        target: Target to create the compilation database for.
     Returns:
       List of struct(file, command, directory).
     """
@@ -262,6 +270,9 @@ def get_compilation_database(target, ctx):
 def collect_headers(target, ctx):
     """ Return list of required header files
 
+    Args:
+        ctx: The context variable.
+        target: Target which headers should be collected
     Returns:
       depset of header files
     """
@@ -375,6 +386,8 @@ def _compile_commands_json(compilation_db):
 def compile_commands_impl(ctx):
     """ Creates compile_commands.json file for given targets and platform
 
+    Args:
+        ctx: The context variable.
     Returns:
       DefaultInfo(
         files,     # as compile_commands.json
@@ -448,7 +461,18 @@ def compile_commands(
         platform = "",  #"@platforms//os:linux",
         tags = [],
         **kwargs):
-    """ Bazel rule to generate compile_commands.json file """
+    """
+    Bazel rule to generate compile_commands.json file
+
+    Args:
+        name: Name of the target.
+        targets: List of targets to generate compile_commands.json for.
+        platform: Platform to consider during compile database creation.
+        tags: Bazel tags
+        **kwargs: Other miscellaneous arguments.
+    Returns:
+        None
+    """
     compile_commands_tags = [] + tags
     if "compile_commands" not in tags:
         compile_commands_tags.append("compile_commands")
@@ -457,4 +481,5 @@ def compile_commands(
         platform = platform,
         targets = targets,
         tags = compile_commands_tags,
+        **kwargs
     )

--- a/src/per_file.bzl
+++ b/src/per_file.bzl
@@ -17,16 +17,12 @@ Rulesets for running codechecker in a different Bazel action
 for each translation unit.
 """
 
-load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
-load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load("codechecker_config.bzl", "get_config_file")
-load("common.bzl", "SOURCE_ATTR")
 load(
     "compile_commands.bzl",
     "SourceFilesInfo",
     "compile_commands_aspect",
     "compile_commands_impl",
-    "platforms_transition",
 )
 
 def _run_code_checker(
@@ -84,8 +80,14 @@ def _run_code_checker(
 
 def check_valid_file_type(src):
     """
+    Checks if the file is a cpp related file.
+
     Returns True if the file type matches one of the permitted
     srcs file types for C and C++ source files.
+    Args:
+        src: Path of a single source file.
+    Returns:
+        Boolean value.
     """
     permitted_file_types = [
         ".c",

--- a/src/tools.bzl
+++ b/src/tools.bzl
@@ -86,6 +86,8 @@ default_python_tools = repository_rule(
     implementation = _python_local_repository_impl,
 )
 
+# buildifier: disable=unused-variable
+# This parameter is provided, regardless if we use it or not
 def register_default_python_toolchain(ctx = None):
     default_python_tools(name = "default_python_tools")
 
@@ -120,6 +122,8 @@ default_codechecker_tools = repository_rule(
     implementation = _codechecker_local_repository_impl,
 )
 
+# buildifier: disable=unused-variable
+# This parameter is provided, regardless if we use it or not
 def register_default_codechecker(ctx = None):
     default_codechecker_tools(name = "default_codechecker_tools")
 

--- a/test/unit/argument_merge/BUILD
+++ b/test/unit/argument_merge/BUILD
@@ -12,15 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load(
-    "//src:codechecker.bzl",
-    "codechecker_test",
-)
-
 # cc_binary for simple C++ tests
 load(
     "@rules_cc//cc:defs.bzl",
     "cc_library",
+)
+load(
+    "//src:codechecker.bzl",
+    "codechecker_test",
 )
 
 cc_library(

--- a/test/unit/caching/BUILD
+++ b/test/unit/caching/BUILD
@@ -12,16 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load(
-    "//src:codechecker.bzl",
-    "codechecker_test",
-)
-
 # cc_binary for simple C++ tests
 load(
     "@rules_cc//cc:defs.bzl",
     "cc_binary",
     "cc_library",
+)
+load(
+    "//src:codechecker.bzl",
+    "codechecker_test",
 )
 
 # We are not interested in finding bugs, we are only interested in whether the

--- a/test/unit/compile_flags/BUILD
+++ b/test/unit/compile_flags/BUILD
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# cc_binary for simple C++ tests
+load(
+    "@rules_cc//cc:defs.bzl",
+    "cc_library",
+)
 load(
     "//src:codechecker.bzl",
     "codechecker_test",
@@ -21,12 +26,6 @@ load(
 load(
     "//src:compile_commands.bzl",
     "compile_commands",
-)
-
-# cc_binary for simple C++ tests
-load(
-    "@rules_cc//cc:defs.bzl",
-    "cc_library",
 )
 
 cc_library(

--- a/test/unit/config/BUILD
+++ b/test/unit/config/BUILD
@@ -12,18 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# cc_binary for simple C++ tests
+load(
+    "@rules_cc//cc:defs.bzl",
+    "cc_binary",
+)
+
 # codechecker rules
 load(
     "//src:codechecker.bzl",
     "codechecker",
     "codechecker_config",
     "codechecker_test",
-)
-
-# cc_binary for simple C++ tests
-load(
-    "@rules_cc//cc:defs.bzl",
-    "cc_binary",
 )
 
 # C++ binary containing a division by zero bug

--- a/test/unit/generated_files/BUILD
+++ b/test/unit/generated_files/BUILD
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# cc_binary for simple C++ tests
+load(
+    "@rules_cc//cc:defs.bzl",
+    "cc_binary",
+)
 load(
     "//src:codechecker.bzl",
     "codechecker_test",
@@ -19,12 +24,6 @@ load(
 load(
     "//src:compile_commands.bzl",
     "compile_commands",
-)
-
-# cc_binary for simple C++ tests
-load(
-    "@rules_cc//cc:defs.bzl",
-    "cc_binary",
 )
 
 # First, define the rule that generates our file.

--- a/test/unit/legacy/BUILD
+++ b/test/unit/legacy/BUILD
@@ -1,3 +1,10 @@
+# cc_binary for simple C++ tests
+load(
+    "@rules_cc//cc:defs.bzl",
+    "cc_binary",
+    "cc_library",
+)
+
 # clang-tidy and clang -analyze rules
 load(
     "//src:clang.bzl",
@@ -24,13 +31,6 @@ load(
 load(
     "//src:compile_commands.bzl",
     "compile_commands",
-)
-
-# cc_binary for simple C++ tests
-load(
-    "@rules_cc//cc:defs.bzl",
-    "cc_binary",
-    "cc_library",
 )
 
 # Test for strip_include_prefix

--- a/test/unit/parse/BUILD
+++ b/test/unit/parse/BUILD
@@ -12,15 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load(
-    "//src:codechecker.bzl",
-    "codechecker_test",
-)
-
 # cc_binary for simple C++ tests
 load(
     "@rules_cc//cc:defs.bzl",
     "cc_library",
+)
+load(
+    "//src:codechecker.bzl",
+    "codechecker_test",
 )
 
 cc_library(

--- a/test/unit/virtual_include/BUILD
+++ b/test/unit/virtual_include/BUILD
@@ -12,16 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# codechecker rules
-load(
-    "//src:codechecker.bzl",
-    "codechecker_test",
-)
-
 # cc_binary for simple C++ tests
 load(
     "@rules_cc//cc:defs.bzl",
     "cc_library",
+)
+
+# codechecker rules
+load(
+    "//src:codechecker.bzl",
+    "codechecker_test",
 )
 
 # Test for strip_include_prefix


### PR DESCRIPTION
Why:
We want to produce high-quality Bazel code. To do this, we use buildifier to both format and lint our files.

What:
- Applied all\* linter suggestions to bzl files
- Formatted BUILD files with buildifier

\*: In per_file.bzl in the `run_code_checker` function I puposefully ignored the unused variable errors. This function is still in early development, and the unused variables (arguments, label, env_vars, compilation_context) may be necessary in the future.

Addresses:
#155 
