### PR TITLE
Use py_binary for script execution

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -25,11 +25,10 @@ py_binary(
     visibility = ["//visibility:public"],
 )
 
-# Build & Test script template
-exports_files(
-    [
-        "per_file_script.py",
-    ],
+py_binary(
+    name = "per_file_script",
+    srcs = ["per_file_script.py"],
+    visibility = ["//visibility:public"],
 )
 
 # The following are flags and default values for clang_tidy_aspect

--- a/src/BUILD
+++ b/src/BUILD
@@ -19,10 +19,15 @@ py_binary(
     visibility = ["//visibility:public"],
 )
 
+py_binary(
+    name = "codechecker_script",
+    srcs = ["codechecker_script.py"],
+    visibility = ["//visibility:public"],
+)
+
 # Build & Test script template
 exports_files(
     [
-        "codechecker_script.py",
         "per_file_script.py",
     ],
 )

--- a/src/BUILD
+++ b/src/BUILD
@@ -20,18 +20,12 @@ py_binary(
     visibility = ["//visibility:public"],
 )
 
-# For targets using WORKSPACE files we use our own python toolchain,
-# therefore we cannot load from rules_python.
-# buildifier: disable=native-py
 py_binary(
     name = "codechecker_script",
     srcs = ["codechecker_script.py"],
     visibility = ["//visibility:public"],
 )
 
-# For targets using WORKSPACE files we use our own python toolchain,
-# therefore we cannot load from rules_python.
-# buildifier: disable=native-py
 py_binary(
     name = "per_file_script",
     srcs = ["per_file_script.py"],

--- a/src/BUILD
+++ b/src/BUILD
@@ -20,12 +20,22 @@ py_binary(
     visibility = ["//visibility:public"],
 )
 
-# Build & Test script template
-exports_files(
-    [
-        "codechecker_script.py",
-        "per_file_script.py",
-    ],
+# For targets using WORKSPACE files we use our own python toolchain,
+# therefore we cannot load from rules_python.
+# buildifier: disable=native-py
+py_binary(
+    name = "codechecker_script",
+    srcs = ["codechecker_script.py"],
+    visibility = ["//visibility:public"],
+)
+
+# For targets using WORKSPACE files we use our own python toolchain,
+# therefore we cannot load from rules_python.
+# buildifier: disable=native-py
+py_binary(
+    name = "per_file_script",
+    srcs = ["per_file_script.py"],
+    visibility = ["//visibility:public"],
 )
 
 # The following are flags and default values for clang_tidy_aspect

--- a/src/codechecker.bzl
+++ b/src/codechecker.bzl
@@ -100,17 +100,16 @@ def _codechecker_impl(ctx):
     
     # Use environment variables instead of expand_template
     environment_variables = {
-        "RULES_CODECHECKER_Mode": "Run",
-        "RULES_CODECHECKER_Verbosity": "DEBUG",
-        "RULES_CODECHECKER_PythonPath": python_path(ctx),  # "/usr/bin/env python3",
-        "RULES_CODECHECKER_codechecker_bin": CODECHECKER_BIN_PATH,
-        "RULES_CODECHECKER_compile_commands": ctx.outputs.codechecker_commands.path,
-        "RULES_CODECHECKER_codechecker_skipfile": ctx.outputs.codechecker_skipfile.path,
-        "RULES_CODECHECKER_codechecker_config": config_file.path,
-        "RULES_CODECHECKER_codechecker_analyze": " ".join(ctx.attr.analyze),
-        "RULES_CODECHECKER_codechecker_files": codechecker_files.path,
-        "RULES_CODECHECKER_codechecker_log": ctx.outputs.codechecker_log.path,
-        "RULES_CODECHECKER_codechecker_env": codechecker_env,
+        "RULES_CODECHECKER_MODE": "Run",
+        "RULES_CODECHECKER_VERBOSITY": "DEBUG",
+        "RULES_CODECHECKER_CODECHECKER_BIN": CODECHECKER_BIN_PATH,
+        "RULES_CODECHECKER_COMPILE_COMMANDS": ctx.outputs.codechecker_commands.path,
+        "RULES_CODECHECKER_CODECHECKER_SKIPFILE": ctx.outputs.codechecker_skipfile.path,
+        "RULES_CODECHECKER_CODECHECKER_CONFIG": config_file.path,
+        "RULES_CODECHECKER_CODECHECKER_ANALYZE": " ".join(ctx.attr.analyze),
+        "RULES_CODECHECKER_CODECHECKER_FILES": codechecker_files.path,
+        "RULES_CODECHECKER_CODECHECKER_LOG": ctx.outputs.codechecker_log.path,
+        "RULES_CODECHECKER_CODECHECKER_ENV": codechecker_env,
     }
     codechecker_script = ctx.actions.declare_file(ctx.label.name + "/codechecker_script")
     ctx.actions.symlink(
@@ -230,12 +229,12 @@ def _codechecker_test_impl(ctx):
 
     # Use environment variables instead of expand_template
     environment_variables = {
-        "RULES_CODECHECKER_Mode": "Test",
-        "RULES_CODECHECKER_Verbosity": "INFO",
-        "RULES_CODECHECKER_PythonPath": python_path(ctx),  # "/usr/bin/env python3",
-        "RULES_CODECHECKER_codechecker_bin": CODECHECKER_BIN_PATH,
-        "RULES_CODECHECKER_codechecker_files": codechecker_files.short_path,
-        "RULES_CODECHECKER_Severities": " ".join(ctx.attr.severities),
+        "RULES_CODECHECKER_MODE": "Test",
+        "RULES_CODECHECKER_VERBOSITY": "INFO",
+        "RULES_CODECHECKER_PYTHONPATH": python_path(ctx),  # "/usr/bin/env python3",
+        "RULES_CODECHECKER_CODECHECKER_BIN": CODECHECKER_BIN_PATH,
+        "RULES_CODECHECKER_CODECHECKER_FILES": codechecker_files.short_path,
+        "RULES_CODECHECKER_SEVERITIES": " ".join(ctx.attr.severities),
     }
 
     # Create test script

--- a/src/codechecker.bzl
+++ b/src/codechecker.bzl
@@ -27,7 +27,6 @@ load(
 )
 load(
     "common.bzl",
-    "python_path",
     "python_toolchain_type",
     "version_specific_attributes",
 )
@@ -231,7 +230,6 @@ def _codechecker_test_impl(ctx):
     environment_variables = {
         "RULES_CODECHECKER_MODE": "Test",
         "RULES_CODECHECKER_VERBOSITY": "INFO",
-        "RULES_CODECHECKER_PYTHONPATH": python_path(ctx),  # "/usr/bin/env python3",
         "RULES_CODECHECKER_CODECHECKER_BIN": CODECHECKER_BIN_PATH,
         "RULES_CODECHECKER_CODECHECKER_FILES": codechecker_files.short_path,
         "RULES_CODECHECKER_SEVERITIES": " ".join(ctx.attr.severities),

--- a/src/codechecker.bzl
+++ b/src/codechecker.bzl
@@ -224,15 +224,6 @@ def _codechecker_test_impl(ctx):
     if not codechecker_files:
         fail("Execution results required for codechecker test are not available")
 
-    # Use environment variables instead of expand_template
-    environment_variables = {
-        "RULES_CODECHECKER_MODE": "Test",
-        "RULES_CODECHECKER_VERBOSITY": "INFO",
-        "RULES_CODECHECKER_CODECHECKER_BIN": CODECHECKER_BIN_PATH,
-        "RULES_CODECHECKER_CODECHECKER_FILES": codechecker_files.short_path,
-        "RULES_CODECHECKER_SEVERITIES": " ".join(ctx.attr.severities),
-    }
-
     # Create test script
     codechecker_test_script = ctx.actions.declare_file(ctx.label.name + "/codechecker_test_script")
     ctx.actions.symlink(
@@ -251,7 +242,7 @@ def _codechecker_test_impl(ctx):
             tool = ctx.outputs.codechecker_test_script.short_path,
             codechecker_path = CODECHECKER_BIN_PATH,
             codechecker_files = codechecker_files.short_path,
-            severities = " ".join(ctx.attr.severities)
+            severities = " ".join(ctx.attr.severities),
         ),
         is_executable = True,
     )
@@ -259,6 +250,7 @@ def _codechecker_test_impl(ctx):
     # Return test script and all required files
     run_files = default_runfiles + [ctx.outputs.codechecker_test_script, launcher]
     all_runfiles = ctx.runfiles(files = run_files)
+
     # Add runfiles from the py_binary target:
     all_runfiles = all_runfiles.merge(ctx.attr._codechecker_script[DefaultInfo].default_runfiles)
     return [
@@ -267,9 +259,6 @@ def _codechecker_test_impl(ctx):
             runfiles = all_runfiles,
             executable = launcher,
         ),
-        RunEnvironmentInfo(
-            environment = environment_variables,
-        )
     ]
 
 _codechecker_test = rule(

--- a/src/codechecker.bzl
+++ b/src/codechecker.bzl
@@ -96,25 +96,24 @@ def _codechecker_impl(ctx):
     config_file, codechecker_env = get_config_file(ctx)
 
     codechecker_files = ctx.actions.declare_directory(ctx.label.name + "/codechecker-files")
-    
-    # Use environment variables instead of expand_template
-    environment_variables = {
-        "RULES_CODECHECKER_MODE": "Run",
-        "RULES_CODECHECKER_VERBOSITY": "DEBUG",
-        "RULES_CODECHECKER_CODECHECKER_BIN": CODECHECKER_BIN_PATH,
-        "RULES_CODECHECKER_COMPILE_COMMANDS": ctx.outputs.codechecker_commands.path,
-        "RULES_CODECHECKER_CODECHECKER_SKIPFILE": ctx.outputs.codechecker_skipfile.path,
-        "RULES_CODECHECKER_CODECHECKER_CONFIG": config_file.path,
-        "RULES_CODECHECKER_CODECHECKER_ANALYZE": " ".join(ctx.attr.analyze),
-        "RULES_CODECHECKER_CODECHECKER_FILES": codechecker_files.path,
-        "RULES_CODECHECKER_CODECHECKER_LOG": ctx.outputs.codechecker_log.path,
-        "RULES_CODECHECKER_CODECHECKER_ENV": codechecker_env,
-    }
+
     codechecker_script = ctx.actions.declare_file(ctx.label.name + "/codechecker_script")
     ctx.actions.symlink(
         output = codechecker_script,
         target_file = ctx.executable._codechecker_script,
     )
+    cmd_args = ctx.actions.args()
+    cmd_args.add("--mode", "Run")
+    cmd_args.add("--verbosity", "DEBUG")
+    cmd_args.add("--codechecker_path", CODECHECKER_BIN_PATH)
+    cmd_args.add("--commands", ctx.outputs.codechecker_commands.path)
+    cmd_args.add("--skip", ctx.outputs.codechecker_skipfile.path)
+    cmd_args.add("--config", config_file.path)
+    if len(ctx.attr.analyze) != 0:
+        cmd_args.add("--analyze", "'" + " ".join(ctx.attr.analyze) + "'")
+    cmd_args.add("--files", codechecker_files.path)
+    cmd_args.add("--log", ctx.outputs.codechecker_log.path)
+    cmd_args.add("--env", codechecker_env)
     ctx.actions.run(
         inputs = depset(
             [
@@ -130,8 +129,7 @@ def _codechecker_impl(ctx):
         ],
         executable = codechecker_script,
         tools = [ctx.attr._codechecker_script[DefaultInfo].files_to_run],
-        arguments = [],
-        env = environment_variables,
+        arguments = [cmd_args],
         mnemonic = "CodeChecker",
         progress_message = "CodeChecker %s" % str(ctx.label),
         # use_default_shell_env = True,
@@ -242,8 +240,24 @@ def _codechecker_test_impl(ctx):
         target_file = ctx.executable._codechecker_script,
     )
 
+    launcher = ctx.actions.declare_file(ctx.label.name + "_launcher.sh")
+    ctx.actions.write(
+        output = launcher,
+        content = """#!/bin/bash
+            exec {tool} --mode=Test --verbosity=INFO \
+            --codechecker_path '{codechecker_path}' \
+            --files '{codechecker_files}' --severities '{severities}'
+            """.format(
+            tool = ctx.outputs.codechecker_test_script.short_path,
+            codechecker_path = CODECHECKER_BIN_PATH,
+            codechecker_files = codechecker_files.short_path,
+            severities = " ".join(ctx.attr.severities)
+        ),
+        is_executable = True,
+    )
+
     # Return test script and all required files
-    run_files = default_runfiles + [ctx.outputs.codechecker_test_script]
+    run_files = default_runfiles + [ctx.outputs.codechecker_test_script, launcher]
     all_runfiles = ctx.runfiles(files = run_files)
     # Add runfiles from the py_binary target:
     all_runfiles = all_runfiles.merge(ctx.attr._codechecker_script[DefaultInfo].default_runfiles)
@@ -251,7 +265,7 @@ def _codechecker_test_impl(ctx):
         DefaultInfo(
             files = depset(all_files),
             runfiles = all_runfiles,
-            executable = ctx.outputs.codechecker_test_script,
+            executable = launcher,
         ),
         RunEnvironmentInfo(
             environment = environment_variables,

--- a/src/codechecker.bzl
+++ b/src/codechecker.bzl
@@ -95,44 +95,44 @@ def _codechecker_impl(ctx):
     info = ctx.toolchains["//:toolchain_type"].codecheckerinfo
 
     codechecker_files = ctx.actions.declare_directory(ctx.label.name + "/codechecker-files")
-    ctx.actions.expand_template(
-        template = ctx.file._codechecker_script_template,
-        output = ctx.outputs.codechecker_script,
-        is_executable = True,
-        substitutions = {
-            "{Mode}": "Run",
-            "{Verbosity}": "DEBUG",
-            "{clang_bin}": info.clangsa.path,
-            "{clang_tidy_bin}": info.clang_tidy.path,
-            "{codechecker_analyze}": " ".join(ctx.attr.analyze),
-            "{codechecker_bin}": info.codechecker.path,
-            "{codechecker_config}": config_file.path,
-            "{codechecker_env}": codechecker_env,
-            "{codechecker_files}": codechecker_files.path,
-            "{codechecker_log}": ctx.outputs.codechecker_log.path,
-            "{codechecker_skipfile}": ctx.outputs.codechecker_skipfile.path,
-            "{compile_commands}": ctx.outputs.codechecker_commands.path,
-        },
-    )
 
+    codechecker_script = ctx.actions.declare_file(ctx.label.name + "/codechecker_script")
+    ctx.actions.symlink(
+        output = codechecker_script,
+        target_file = ctx.executable._codechecker_script,
+    )
+    cmd_args = ctx.actions.args()
+    cmd_args.add("--mode", "Run")
+    cmd_args.add("--verbosity", "DEBUG")
+    cmd_args.add("--codechecker_path", info.codechecker.path)
+    cmd_args.add("--clang_tidy", info.clang_tidy.path)
+    cmd_args.add("--clang", info.clangsa.path)
+    cmd_args.add("--commands", ctx.outputs.codechecker_commands.path)
+    cmd_args.add("--skip", ctx.outputs.codechecker_skipfile.path)
+    cmd_args.add("--config", config_file.path)
+    if len(ctx.attr.analyze) != 0:
+        cmd_args.add("--analyze", "'" + " ".join(ctx.attr.analyze) + "'")
+    cmd_args.add("--files", codechecker_files.path)
+    cmd_args.add("--log", ctx.outputs.codechecker_log.path)
+    cmd_args.add("--env", codechecker_env)
     ctx.actions.run(
         inputs = depset(
             [
-                ctx.outputs.codechecker_script,
                 ctx.outputs.codechecker_commands,
                 ctx.outputs.codechecker_skipfile,
                 config_file,
             ] + source_files,
         ),
-        tools = [info.runfiles],
+        tools = [
+            info.runfiles,
+            ctx.attr._codechecker_script[DefaultInfo].files_to_run,
+        ],
         outputs = [
             codechecker_files,
             ctx.outputs.codechecker_log,
         ],
-        executable = ctx.outputs.codechecker_script,
-        arguments = [],
-        # executable = python_path(ctx),
-        # arguments = [ctx.outputs.codechecker_script.path],
+        executable = codechecker_script,
+        arguments = [cmd_args],
         mnemonic = "CodeChecker",
         progress_message = "CodeChecker %s" % str(ctx.label),
         # use_default_shell_env = True,
@@ -145,7 +145,6 @@ def _codechecker_impl(ctx):
         ctx.outputs.codechecker_skipfile,
         config_file,
         codechecker_files,
-        ctx.outputs.codechecker_script,
         ctx.outputs.codechecker_log,
     ] + source_files
 
@@ -187,9 +186,11 @@ codechecker = rule(
             ],
             doc = "List of compilable targets which should be checked.",
         ),
-        "_codechecker_script_template": attr.label(
-            default = ":codechecker_script.py",
-            allow_single_file = True,
+        "_codechecker_script": attr.label(
+            allow_files = True,
+            executable = True,
+            cfg = "target",
+            default = ":codechecker_script",
         ),
         "_compile_commands_filter": attr.label(
             allow_files = True,
@@ -201,7 +202,6 @@ codechecker = rule(
     outputs = {
         "codechecker_commands": "%{name}/codechecker_commands.json",
         "codechecker_log": "%{name}/codechecker.log",
-        "codechecker_script": "%{name}/codechecker_script.py",
         "codechecker_skipfile": "%{name}/codechecker_skipfile.cfg",
         "compile_commands": "%{name}/compile_commands.json",
     },
@@ -229,31 +229,43 @@ def _codechecker_test_impl(ctx):
 
     info = ctx.toolchains["//:toolchain_type"].codecheckerinfo
 
-    # Create test script from template
-    ctx.actions.expand_template(
-        template = ctx.file._codechecker_script_template,
-        output = ctx.outputs.codechecker_test_script,
+    # Create test script
+    codechecker_test_script = ctx.actions.declare_file(ctx.label.name + "/codechecker_test_script")
+    ctx.actions.symlink(
+        output = codechecker_test_script,
+        target_file = ctx.executable._codechecker_script,
+    )
+
+    launcher = ctx.actions.declare_file(ctx.label.name + "_launcher.sh")
+    ctx.actions.write(
+        output = launcher,
+        content = """#!/bin/bash
+            exec {tool} --mode=Test --verbosity=INFO \
+            --codechecker_path '{codechecker_path}' \
+            --files '{codechecker_files}' --severities '{severities}'
+            """.format(
+            tool = ctx.outputs.codechecker_test_script.short_path,
+            codechecker_path = info.codechecker.path,
+            codechecker_files = codechecker_files.short_path,
+            severities = " ".join(ctx.attr.severities),
+        ),
         is_executable = True,
-        substitutions = {
-            "{Mode}": "Test",
-            "{Severities}": " ".join(ctx.attr.severities),
-            "{Verbosity}": "INFO",
-            "{clang_bin}": info.clangsa.short_path,
-            "{clang_tidy_bin}": info.clang_tidy.short_path,
-            "{codechecker_bin}": info.codechecker.short_path,
-            "{codechecker_files}": codechecker_files.short_path,
-        },
     )
 
     # Return test script and all required files
     run_files = default_runfiles + [
         ctx.outputs.codechecker_test_script,
+        launcher,
     ] + info.runfiles.to_list()
+    all_runfiles = ctx.runfiles(files = run_files)
+
+    # Add runfiles from the py_binary target:
+    all_runfiles = all_runfiles.merge(ctx.attr._codechecker_script[DefaultInfo].default_runfiles)
     return [
         DefaultInfo(
             files = depset(all_files),
-            runfiles = ctx.runfiles(files = run_files),
-            executable = ctx.outputs.codechecker_test_script,
+            runfiles = all_runfiles,
+            executable = launcher,
         ),
     ]
 
@@ -289,9 +301,11 @@ _codechecker_test = rule(
             cfg = platforms_transition,
             doc = "List of compilable targets which should be checked.",
         ),
-        "_codechecker_script_template": attr.label(
-            default = ":codechecker_script.py",
-            allow_single_file = True,
+        "_codechecker_script": attr.label(
+            allow_files = True,
+            executable = True,
+            cfg = "target",
+            default = ":codechecker_script",
         ),
         "_compile_commands_filter": attr.label(
             allow_files = True,
@@ -303,9 +317,8 @@ _codechecker_test = rule(
     outputs = {
         "codechecker_commands": "%{name}/codechecker_commands.json",
         "codechecker_log": "%{name}/codechecker.log",
-        "codechecker_script": "%{name}/codechecker_script.py",
         "codechecker_skipfile": "%{name}/codechecker_skipfile.cfg",
-        "codechecker_test_script": "%{name}/codechecker_test_script.py",
+        "codechecker_test_script": "%{name}/codechecker_test_script",
         "compile_commands": "%{name}/compile_commands.json",
     },
     toolchains = [

--- a/src/codechecker_script.py
+++ b/src/codechecker_script.py
@@ -1,5 +1,3 @@
-#!{PythonPath}
-
 # Copyright 2023 Ericsson AB
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,17 +26,35 @@ import subprocess
 import sys
 
 
-EXECUTION_MODE = "{Mode}"
-VERBOSITY = "{Verbosity}"
-CODECHECKER_PATH = "{codechecker_bin}"
-CODECHECKER_SKIPFILE = "{codechecker_skipfile}"
-CODECHECKER_CONFIG = "{codechecker_config}"
-CODECHECKER_ANALYZE = "{codechecker_analyze}"
-CODECHECKER_FILES = "{codechecker_files}"
-CODECHECKER_LOG = "{codechecker_log}"
-CODECHECKER_SEVERITIES = "{Severities}"
-CODECHECKER_ENV = "{codechecker_env}"
-COMPILE_COMMANDS = "{compile_commands}"
+EXECUTION_MODE = os.environ.get("RULES_CODECHECKER_Mode", "{Mode}")
+VERBOSITY = os.environ.get("RULES_CODECHECKER_Verbosity", "{Verbosity}")
+CODECHECKER_PATH = os.environ.get(
+    "RULES_CODECHECKER_codechecker_bin", "{codechecker_bin}"
+)
+CODECHECKER_SKIPFILE = os.environ.get(
+    "RULES_CODECHECKER_codechecker_skipfile", "{codechecker_skipfile}"
+)
+CODECHECKER_CONFIG = os.environ.get(
+    "RULES_CODECHECKER_codechecker_config", "{codechecker_config}"
+)
+CODECHECKER_ANALYZE = os.environ.get(
+    "RULES_CODECHECKER_codechecker_analyze", "{codechecker_analyze}"
+)
+CODECHECKER_FILES = os.environ.get(
+    "RULES_CODECHECKER_codechecker_files", "{codechecker_files}"
+)
+CODECHECKER_LOG = os.environ.get(
+    "RULES_CODECHECKER_codechecker_log", "{codechecker_log}"
+)
+CODECHECKER_SEVERITIES = os.environ.get(
+    "RULES_CODECHECKER_Severities", "{Severities}"
+)
+CODECHECKER_ENV = os.environ.get(
+    "RULES_CODECHECKER_codechecker_env", "{codechecker_env}"
+)
+COMPILE_COMMANDS = os.environ.get(
+    "RULES_CODECHECKER_compile_commands", "{compile_commands}"
+)
 
 START_PATH = r"\/(?:(?!\.\s+)\S)+"
 BAZEL_PATHS = {

--- a/src/codechecker_script.py
+++ b/src/codechecker_script.py
@@ -26,34 +26,34 @@ import subprocess
 import sys
 
 
-EXECUTION_MODE = os.environ.get("RULES_CODECHECKER_Mode", "{Mode}")
-VERBOSITY = os.environ.get("RULES_CODECHECKER_Verbosity", "{Verbosity}")
+EXECUTION_MODE = os.environ.get("RULES_CODECHECKER_MODE", "{Mode}")
+VERBOSITY = os.environ.get("RULES_CODECHECKER_VERBOSITY", "{Verbosity}")
 CODECHECKER_PATH = os.environ.get(
-    "RULES_CODECHECKER_codechecker_bin", "{codechecker_bin}"
+    "RULES_CODECHECKER_CODECHECKER_BIN", "{codechecker_bin}"
 )
 CODECHECKER_SKIPFILE = os.environ.get(
-    "RULES_CODECHECKER_codechecker_skipfile", "{codechecker_skipfile}"
+    "RULES_CODECHECKER_CODECHECKER_SKIPFILE", "{codechecker_skipfile}"
 )
 CODECHECKER_CONFIG = os.environ.get(
-    "RULES_CODECHECKER_codechecker_config", "{codechecker_config}"
+    "RULES_CODECHECKER_CODECHECKER_CONFIG", "{codechecker_config}"
 )
 CODECHECKER_ANALYZE = os.environ.get(
-    "RULES_CODECHECKER_codechecker_analyze", "{codechecker_analyze}"
+    "RULES_CODECHECKER_CODECHECKER_ANALYZE", "{codechecker_analyze}"
 )
 CODECHECKER_FILES = os.environ.get(
-    "RULES_CODECHECKER_codechecker_files", "{codechecker_files}"
+    "RULES_CODECHECKER_CODECHECKER_FILES", "{codechecker_files}"
 )
 CODECHECKER_LOG = os.environ.get(
-    "RULES_CODECHECKER_codechecker_log", "{codechecker_log}"
+    "RULES_CODECHECKER_CODECHECKER_LOG", "{codechecker_log}"
 )
 CODECHECKER_SEVERITIES = os.environ.get(
-    "RULES_CODECHECKER_Severities", "{Severities}"
+    "RULES_CODECHECKER_SEVERITIES", "{Severities}"
 )
 CODECHECKER_ENV = os.environ.get(
-    "RULES_CODECHECKER_codechecker_env", "{codechecker_env}"
+    "RULES_CODECHECKER_CODECHECKER_ENV", "{codechecker_env}"
 )
 COMPILE_COMMANDS = os.environ.get(
-    "RULES_CODECHECKER_compile_commands", "{compile_commands}"
+    "RULES_CODECHECKER_COMPILE_COMMANDS", "{compile_commands}"
 )
 
 START_PATH = r"\/(?:(?!\.\s+)\S)+"

--- a/src/codechecker_script.py
+++ b/src/codechecker_script.py
@@ -24,37 +24,39 @@ import re
 import shlex
 import subprocess
 import sys
+import argparse
 
+parser = argparse.ArgumentParser(description="CodeChecker Bazel Wrapper")
 
-EXECUTION_MODE = os.environ.get("RULES_CODECHECKER_MODE", "{Mode}")
-VERBOSITY = os.environ.get("RULES_CODECHECKER_VERBOSITY", "{Verbosity}")
-CODECHECKER_PATH = os.environ.get(
-    "RULES_CODECHECKER_CODECHECKER_BIN", "{codechecker_bin}"
+parser.add_argument("--mode", required=True, help="Execution mode")
+parser.add_argument("--verbosity", default="INFO", help="Log level")
+parser.add_argument(
+    "--codechecker_path", required=True, help="CodeChecker path"
 )
-CODECHECKER_SKIPFILE = os.environ.get(
-    "RULES_CODECHECKER_CODECHECKER_SKIPFILE", "{codechecker_skipfile}"
+parser.add_argument("--commands", help="Compile commands json")
+parser.add_argument("--skip", help="Skipfile path")
+parser.add_argument("--config", help="Config file path")
+parser.add_argument("--analyze", default="", help="Analysis options")
+parser.add_argument(
+    "--files", help="Folder where CodeChecker will store its results"
 )
-CODECHECKER_CONFIG = os.environ.get(
-    "RULES_CODECHECKER_CODECHECKER_CONFIG", "{codechecker_config}"
-)
-CODECHECKER_ANALYZE = os.environ.get(
-    "RULES_CODECHECKER_CODECHECKER_ANALYZE", "{codechecker_analyze}"
-)
-CODECHECKER_FILES = os.environ.get(
-    "RULES_CODECHECKER_CODECHECKER_FILES", "{codechecker_files}"
-)
-CODECHECKER_LOG = os.environ.get(
-    "RULES_CODECHECKER_CODECHECKER_LOG", "{codechecker_log}"
-)
-CODECHECKER_SEVERITIES = os.environ.get(
-    "RULES_CODECHECKER_SEVERITIES", "{Severities}"
-)
-CODECHECKER_ENV = os.environ.get(
-    "RULES_CODECHECKER_CODECHECKER_ENV", "{codechecker_env}"
-)
-COMPILE_COMMANDS = os.environ.get(
-    "RULES_CODECHECKER_COMPILE_COMMANDS", "{compile_commands}"
-)
+parser.add_argument("--log", help="Log file path")
+parser.add_argument("--env", help="Environment for CodeChecker")
+parser.add_argument("--severities", help="List of severities to fail on")
+
+args = parser.parse_args()
+
+EXECUTION_MODE = args.mode
+VERBOSITY = args.verbosity
+CODECHECKER_PATH = args.codechecker_path
+COMPILE_COMMANDS = args.commands
+CODECHECKER_SKIPFILE = args.skip
+CODECHECKER_CONFIG = args.config
+CODECHECKER_ANALYZE = args.analyze
+CODECHECKER_FILES = args.files
+CODECHECKER_LOG = args.log
+CODECHECKER_ENV = args.env
+CODECHECKER_SEVERITIES = args.severities
 
 START_PATH = r"\/(?:(?!\.\s+)\S)+"
 BAZEL_PATHS = {
@@ -65,7 +67,7 @@ BAZEL_PATHS = {
 
 
 def fail(message, exit_code=1):
-    """ Print error message and return exit code """
+    """Print error message and return exit code"""
     logging.error(message)
     print()
     print("*" * 50)
@@ -86,7 +88,7 @@ def fail(message, exit_code=1):
 
 
 def read_file(filename):
-    """ Read text file and return its contents """
+    """Read text file and return its contents"""
     if not os.path.isfile(filename):
         fail(f"File not found: {filename}")
     with open(filename, encoding="utf-8") as handle:
@@ -94,19 +96,19 @@ def read_file(filename):
 
 
 def separator(method="info"):
-    """ Print log separator line to logging.info() or other logging methods """
+    """Print log separator line to logging.info() or other logging methods"""
     getattr(logging, method)("#" * 23)
 
 
 def stage(title, method="info"):
-    """ Print stage title into log """
+    """Print stage title into log"""
     separator(method)
     getattr(logging, method)("### " + title)
     separator(method)
 
 
 def valid_parameter(parameter):
-    """ Check if external parameter is defined and valid """
+    """Check if external parameter is defined and valid"""
     if parameter is None:
         return False
     if parameter and parameter[0] == "{":
@@ -115,14 +117,14 @@ def valid_parameter(parameter):
 
 
 def log_file_name():
-    """ Check and return log file name """
+    """Check and return log file name"""
     if valid_parameter(CODECHECKER_LOG):
         return CODECHECKER_LOG
     return None
 
 
 def setup():
-    """ Setup logging parameters for execution session """
+    """Setup logging parameters for execution session"""
     if VERBOSITY == "INFO":
         log_level = logging.INFO
     elif VERBOSITY == "WARN":
@@ -140,7 +142,7 @@ def setup():
 
 
 def input_data():
-    """ Print out input (external) parameters """
+    """Print out input (external) parameters"""
     stage("CodeChecker input data:", "debug")
     logging.debug("EXECUTION_MODE       : %s", str(EXECUTION_MODE))
     logging.debug("VERBOSITY            : %s", str(VERBOSITY))
@@ -156,7 +158,7 @@ def input_data():
 
 
 def execute(cmd, env=None, codes=None):
-    """ Execute CodeChecker commands """
+    """Execute CodeChecker commands"""
     if codes is None:
         codes = [0]
     with subprocess.Popen(
@@ -178,20 +180,20 @@ def execute(cmd, env=None, codes=None):
 
 
 def create_folder(path):
-    """ Create folder structure for CodeChecker data files and reports """
+    """Create folder structure for CodeChecker data files and reports"""
     if not os.path.exists(path):
         os.makedirs(path)
 
 
 def prepare():
-    """ Prepare CodeChecker execution environment """
+    """Prepare CodeChecker execution environment"""
     stage("CodeChecker files:")
     logging.info("Creating folder: %s", CODECHECKER_FILES)
     create_folder(CODECHECKER_FILES)
 
 
 def analyze():
-    """ Run CodeChecker analyze command """
+    """Run CodeChecker analyze command"""
     stage("CodeChecker analyze:")
 
     env = os.environ
@@ -207,9 +209,11 @@ def analyze():
     output = execute(f"{CODECHECKER_PATH} analyzers --details", env=env)
     logging.debug("Analyzers:\n\n%s", output)
 
-    command = f"{CODECHECKER_PATH} analyze --skip={CODECHECKER_SKIPFILE} " \
-              f"{COMPILE_COMMANDS} --output={CODECHECKER_FILES}/data " \
-              f"--config {CODECHECKER_CONFIG} {CODECHECKER_ANALYZE}"
+    command = (
+        f"{CODECHECKER_PATH} analyze --skip={CODECHECKER_SKIPFILE} "
+        f"{COMPILE_COMMANDS} --output={CODECHECKER_FILES}/data "
+        f"--config {CODECHECKER_CONFIG} {CODECHECKER_ANALYZE}"
+    )
     # FIXME: Workaround "CodeChecker simply remove compiler-rt include path".
     # This can be removed once codechecker 6.16.0 is used.
     # command += " --keep-gcc-intrin"
@@ -222,7 +226,7 @@ def analyze():
 
 
 def fix_bazel_paths():
-    """ Remove Bazel leading paths in all files """
+    """Remove Bazel leading paths in all files"""
     stage("Fix CodeChecker output:")
     folder = CODECHECKER_FILES
     logging.info("Fixing Bazel paths in %s", folder)
@@ -241,7 +245,7 @@ def fix_bazel_paths():
 
 
 def realpath(filename):
-    """ Return real full absolute path for given filename """
+    """Return real full absolute path for given filename"""
     if os.path.exists(filename):
         real_file_name = os.path.abspath(os.path.realpath(filename))
         logging.debug("Updating %s -> %s", filename, real_file_name)
@@ -250,7 +254,7 @@ def realpath(filename):
 
 
 def resolve_plist_symlinks(filepath):
-    """ Resolve the symbolic links in plist files to real file paths """
+    """Resolve the symbolic links in plist files to real file paths"""
     # plistlib replaced readPlist/writePlist with load/dump in Python 3.9.
     # Since Pylint analyzes every line,
     # it flags the methods missing in the current environment.
@@ -274,7 +278,7 @@ def resolve_plist_symlinks(filepath):
 
 
 def resolve_yaml_symlinks(filepath):
-    """ Resolve the symbolic links in YAML files to real file paths """
+    """Resolve the symbolic links in YAML files to real file paths"""
     logging.info("Processing YAML file: %s", filepath)
     fields = [
         r"MainSourceFile:\s*",
@@ -305,7 +309,7 @@ def resolve_yaml_symlinks(filepath):
 
 
 def resolve_symlinks():
-    """ Change ".../execroot/apps" paths to absolute paths in data/* files """
+    """Change ".../execroot/apps" paths to absolute paths in data/* files"""
     stage("Resolve file paths in CodeChecker analyze output:")
     analyze_outdir = CODECHECKER_FILES + "/data"
     logging.info(
@@ -335,14 +339,18 @@ def update_file_paths():
 
 
 def parse():
-    """ Run CodeChecker parse commands """
+    """Run CodeChecker parse commands"""
     stage("CodeChecker parse:")
     logging.info("CodeChecker parse -e json")
-    codechecker_parse = f"{CODECHECKER_PATH} parse --config " \
-                        f"{CODECHECKER_CONFIG} {CODECHECKER_FILES}/data"
+    codechecker_parse = (
+        f"{CODECHECKER_PATH} parse --config "
+        f"{CODECHECKER_CONFIG} {CODECHECKER_FILES}/data"
+    )
     # Save results to JSON file
-    command = f"{codechecker_parse} --export=json > " \
-              f"{CODECHECKER_FILES}/result.json"
+    command = (
+        f"{codechecker_parse} --export=json > "
+        f"{CODECHECKER_FILES}/result.json"
+    )
     execute(command, codes=[0, 2])
     # logging.debug(
     #     "JSON:\n\n%s\n", read_file(CODECHECKER_FILES + "/result.json")
@@ -366,7 +374,7 @@ def parse():
 
 
 def run():
-    """ Perform all steps for "bazel build" phase """
+    """Perform all steps for "bazel build" phase"""
     prepare()
     analyze()
     parse()
@@ -374,7 +382,7 @@ def run():
 
 
 def check_results():
-    """ Check/verify CodeChecker results """
+    """Check/verify CodeChecker results"""
     stage("Checking result:")
     # Get results file and read it
     result_file = CODECHECKER_FILES + "/result.txt"
@@ -421,12 +429,12 @@ def check_results():
 
 
 def test():
-    """ Perform all steps for "bazel test" phase """
+    """Perform all steps for "bazel test" phase"""
     check_results()
 
 
 def main():
-    """ Main function """
+    """Main function"""
     setup()
     input_data()
     try:

--- a/src/codechecker_script.py
+++ b/src/codechecker_script.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Copyright 2023 Ericsson AB
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,20 +24,47 @@ import re
 import shlex
 import subprocess
 import sys
+import argparse
 
-EXECUTION_MODE = "{Mode}"
-VERBOSITY = "{Verbosity}"
-CODECHECKER_PATH = os.path.realpath("{codechecker_bin}")
-CLANG_PATH = os.path.realpath("{clang_bin}")
-CLANG_TIDY_PATH = os.path.realpath("{clang_tidy_bin}")
-CODECHECKER_SKIPFILE = "{codechecker_skipfile}"
-CODECHECKER_CONFIG = "{codechecker_config}"
-CODECHECKER_ANALYZE = "{codechecker_analyze}"
-CODECHECKER_FILES = "{codechecker_files}"
-CODECHECKER_LOG = "{codechecker_log}"
-CODECHECKER_SEVERITIES = "{Severities}"
-CODECHECKER_ENV = "{codechecker_env}"
-COMPILE_COMMANDS = "{compile_commands}"
+parser = argparse.ArgumentParser(description="CodeChecker Bazel Wrapper")
+
+parser.add_argument("--mode", required=True, help="Execution mode")
+parser.add_argument("--verbosity", default="INFO", help="Log level")
+parser.add_argument(
+    "--codechecker_path", required=True, help="CodeChecker path"
+)
+parser.add_argument("--clang_tidy", required=False, help="CodeChecker path")
+parser.add_argument("--clang", required=False, help="CodeChecker path")
+parser.add_argument("--commands", help="Compile commands json")
+parser.add_argument("--skip", help="Skipfile path")
+parser.add_argument("--config", help="Config file path")
+parser.add_argument("--analyze", default="", help="Analysis options")
+parser.add_argument(
+    "--files", help="Folder where CodeChecker will store its results"
+)
+parser.add_argument("--log", help="Log file path")
+parser.add_argument("--env", help="Environment for CodeChecker")
+parser.add_argument("--severities", help="List of severities to fail on")
+
+if __name__ == "__main__":
+    # Arguments should only be parsed, if this script is the entry point
+    args = parser.parse_args()
+
+    EXECUTION_MODE = args.mode
+    VERBOSITY = args.verbosity
+    CODECHECKER_PATH = os.path.realpath(args.codechecker_path)
+    COMPILE_COMMANDS = args.commands
+    CLANG_PATH = os.path.realpath(args.clang) if args.clang else None
+    CLANG_TIDY_PATH = (
+        os.path.realpath(args.clang_tidy) if args.clang_tidy else None
+    )
+    CODECHECKER_SKIPFILE = args.skip
+    CODECHECKER_CONFIG = args.config
+    CODECHECKER_ANALYZE = args.analyze
+    CODECHECKER_FILES = args.files
+    CODECHECKER_LOG = args.log
+    CODECHECKER_ENV = args.env
+    CODECHECKER_SEVERITIES = args.severities
 
 START_PATH = r"\/(?:(?!\.\s+)\S)+"
 BAZEL_PATHS = {

--- a/src/codechecker_script.py
+++ b/src/codechecker_script.py
@@ -17,6 +17,7 @@ CodeChecker Bazel build & test wrapper script
 """
 
 from __future__ import print_function
+from dataclasses import dataclass
 import logging
 import os
 import plistlib
@@ -26,45 +27,25 @@ import subprocess
 import sys
 import argparse
 
-parser = argparse.ArgumentParser(description="CodeChecker Bazel Wrapper")
 
-parser.add_argument("--mode", required=True, help="Execution mode")
-parser.add_argument("--verbosity", default="INFO", help="Log level")
-parser.add_argument(
-    "--codechecker_path", required=True, help="CodeChecker path"
-)
-parser.add_argument("--clang_tidy", required=False, help="CodeChecker path")
-parser.add_argument("--clang", required=False, help="CodeChecker path")
-parser.add_argument("--commands", help="Compile commands json")
-parser.add_argument("--skip", help="Skipfile path")
-parser.add_argument("--config", help="Config file path")
-parser.add_argument("--analyze", default="", help="Analysis options")
-parser.add_argument(
-    "--files", help="Folder where CodeChecker will store its results"
-)
-parser.add_argument("--log", help="Log file path")
-parser.add_argument("--env", help="Environment for CodeChecker")
-parser.add_argument("--severities", help="List of severities to fail on")
+@dataclass
+class Config:  # pylint: disable=too-many-instance-attributes
+    """Configuration parsed from command-line arguments."""
 
-if __name__ == "__main__":
-    # Arguments should only be parsed, if this script is the entry point
-    args = parser.parse_args()
+    execution_mode: str
+    verbosity: str
+    codechecker_path: str
+    compile_commands: str
+    clang_path: str
+    clang_tidy_path: str
+    codechecker_skipfile: str
+    codechecker_config: str
+    codechecker_analyze: str
+    codechecker_files: str
+    codechecker_log: str
+    codechecker_env: str
+    codechecker_severities: str
 
-    EXECUTION_MODE = args.mode
-    VERBOSITY = args.verbosity
-    CODECHECKER_PATH = os.path.realpath(args.codechecker_path)
-    COMPILE_COMMANDS = args.commands
-    CLANG_PATH = os.path.realpath(args.clang) if args.clang else None
-    CLANG_TIDY_PATH = (
-        os.path.realpath(args.clang_tidy) if args.clang_tidy else None
-    )
-    CODECHECKER_SKIPFILE = args.skip
-    CODECHECKER_CONFIG = args.config
-    CODECHECKER_ANALYZE = args.analyze
-    CODECHECKER_FILES = args.files
-    CODECHECKER_LOG = args.log
-    CODECHECKER_ENV = args.env
-    CODECHECKER_SEVERITIES = args.severities
 
 START_PATH = r"\/(?:(?!\.\s+)\S)+"
 BAZEL_PATHS = {
@@ -74,17 +55,62 @@ BAZEL_PATHS = {
 }
 
 
-def fail(message, exit_code=1):
+def parse_args(argv=None):
+    """Parse command-line arguments and return a Config instance."""
+    parser = argparse.ArgumentParser(description="CodeChecker Bazel Wrapper")
+
+    parser.add_argument("--mode", required=True, help="Execution mode")
+    parser.add_argument("--verbosity", default="INFO", help="Log level")
+    parser.add_argument(
+        "--codechecker_path", required=True, help="CodeChecker path"
+    )
+    parser.add_argument("--clang_tidy", required=False, help="clang-tidy path")
+    parser.add_argument("--clang", required=False, help="clang path")
+    parser.add_argument("--commands", help="Compile commands json")
+    parser.add_argument("--skip", help="Skipfile path")
+    parser.add_argument("--config", help="Config file path")
+    parser.add_argument("--analyze", default="", help="Analysis options")
+    parser.add_argument(
+        "--files", help="Folder where CodeChecker will store its results"
+    )
+    parser.add_argument("--log", help="Log file path")
+    parser.add_argument("--env", help="Environment for CodeChecker")
+    parser.add_argument("--severities", help="List of severities to fail on")
+
+    args = parser.parse_args(argv)
+
+    return Config(
+        execution_mode=args.mode,
+        verbosity=args.verbosity,
+        codechecker_path=os.path.realpath(args.codechecker_path),
+        compile_commands=args.commands,
+        clang_path=os.path.realpath(args.clang) if args.clang else None,
+        clang_tidy_path=(
+            os.path.realpath(args.clang_tidy) if args.clang_tidy else None
+        ),
+        codechecker_skipfile=args.skip,
+        codechecker_config=args.config,
+        codechecker_analyze=args.analyze,
+        codechecker_files=args.files,
+        codechecker_log=args.log,
+        codechecker_env=args.env,
+        codechecker_severities=args.severities,
+    )
+
+
+def fail(codechecker_log, message, exit_code=1):
     """Print error message and return exit code"""
     logging.error(message)
     print()
     print("*" * 50)
     print("codechecker script execution FAILED!")
-    if log_file_name():
-        print(f"See: {log_file_name()}")
+    if log_file_name(codechecker_log):
+        print(f"See: {log_file_name(codechecker_log)}")
         print("*" * 50)
         try:
-            with open(log_file_name(), encoding="utf-8") as log_file:
+            with open(
+                log_file_name(codechecker_log), encoding="utf-8"
+            ) as log_file:
                 print(log_file.read())
         except IOError:
             print("File not accessible")
@@ -95,10 +121,10 @@ def fail(message, exit_code=1):
     sys.exit(exit_code)
 
 
-def read_file(filename):
+def read_file(codechecker_log, filename):
     """Read text file and return its contents"""
     if not os.path.isfile(filename):
-        fail(f"File not found: {filename}")
+        fail(codechecker_log, f"File not found: {filename}")
     with open(filename, encoding="utf-8") as handle:
         return handle.read()
 
@@ -124,48 +150,50 @@ def valid_parameter(parameter):
     return True
 
 
-def log_file_name():
+def log_file_name(codechecker_log):
     """Check and return log file name"""
-    if valid_parameter(CODECHECKER_LOG):
-        return CODECHECKER_LOG
+    if valid_parameter(codechecker_log):
+        return codechecker_log
     return None
 
 
-def setup():
+def setup(verbosity, codechecker_log):
     """Setup logging parameters for execution session"""
-    if VERBOSITY == "INFO":
+    if verbosity == "INFO":
         log_level = logging.INFO
-    elif VERBOSITY == "WARN":
+    elif verbosity == "WARN":
         log_level = logging.WARN
     else:
         log_level = logging.DEBUG
     log_format = "[codechecker] %(levelname)5s: %(message)s"
 
-    if log_file_name():
+    if log_file_name(codechecker_log):
         logging.basicConfig(
-            filename=log_file_name(), level=log_level, format=log_format
+            filename=log_file_name(codechecker_log),
+            level=log_level,
+            format=log_format,
         )
     else:
         logging.basicConfig(level=log_level, format=log_format)
 
 
-def input_data():
+def input_data(cfg):
     """Print out input (external) parameters"""
     stage("CodeChecker input data:", "debug")
-    logging.debug("EXECUTION_MODE       : %s", str(EXECUTION_MODE))
-    logging.debug("VERBOSITY            : %s", str(VERBOSITY))
-    logging.debug("CODECHECKER_PATH     : %s", str(CODECHECKER_PATH))
-    logging.debug("CODECHECKER_SKIPFILE : %s", str(CODECHECKER_SKIPFILE))
-    logging.debug("CODECHECKER_CONFIG   : %s", str(CODECHECKER_CONFIG))
-    logging.debug("CODECHECKER_ANALYZE  : %s", str(CODECHECKER_ANALYZE))
-    logging.debug("CODECHECKER_FILES    : %s", str(CODECHECKER_FILES))
-    logging.debug("CODECHECKER_LOG      : %s", str(CODECHECKER_LOG))
-    logging.debug("CODECHECKER_ENV      : %s", str(CODECHECKER_ENV))
-    logging.debug("COMPILE_COMMANDS     : %s", str(COMPILE_COMMANDS))
+    logging.debug("EXECUTION_MODE       : %s", str(cfg.execution_mode))
+    logging.debug("VERBOSITY            : %s", str(cfg.verbosity))
+    logging.debug("CODECHECKER_PATH     : %s", str(cfg.codechecker_path))
+    logging.debug("CODECHECKER_SKIPFILE : %s", str(cfg.codechecker_skipfile))
+    logging.debug("CODECHECKER_CONFIG   : %s", str(cfg.codechecker_config))
+    logging.debug("CODECHECKER_ANALYZE  : %s", str(cfg.codechecker_analyze))
+    logging.debug("CODECHECKER_FILES    : %s", str(cfg.codechecker_files))
+    logging.debug("CODECHECKER_LOG      : %s", str(cfg.codechecker_log))
+    logging.debug("CODECHECKER_ENV      : %s", str(cfg.codechecker_env))
+    logging.debug("COMPILE_COMMANDS     : %s", str(cfg.compile_commands))
     logging.debug("")
 
 
-def execute(cmd, env=None, codes=None):
+def execute(codechecker_log, cmd, env=None, codes=None):
     """Execute CodeChecker commands"""
     if codes is None:
         codes = [0]
@@ -181,7 +209,10 @@ def execute(cmd, env=None, codes=None):
         stdout = stdout.decode("utf-8")
         stderr = stderr.decode("utf-8")
         if process.returncode not in codes:
-            fail(f"\ncommand: {cmd}\nstdout: {stdout}\nstderr: {stderr}\n")
+            fail(
+                codechecker_log,
+                f"\ncommand: {cmd}\nstdout: {stdout}\nstderr: {stderr}\n",
+            )
         logging.debug("Executing: %s", cmd)
         # logging.debug("Output:\n\n%s\n", stdout)
     return stdout
@@ -193,53 +224,61 @@ def create_folder(path):
         os.makedirs(path)
 
 
-def prepare():
+def prepare(codechecker_files):
     """Prepare CodeChecker execution environment"""
     stage("CodeChecker files:")
-    logging.info("Creating folder: %s", CODECHECKER_FILES)
-    create_folder(CODECHECKER_FILES)
+    logging.info("Creating folder: %s", codechecker_files)
+    create_folder(codechecker_files)
 
 
-def generate_analyzer_executables():
+def generate_analyzer_executables(cfg):
     """
     Generates the value for the CC_ANALYZER_BIN environment variable
     """
-    analyzer_executables = f"clangsa:{CLANG_PATH};clang-tidy:{CLANG_TIDY_PATH}"
+    analyzer_executables = (
+        f"clangsa:{cfg.clang_path};clang-tidy:{cfg.clang_tidy_path}"
+    )
     return analyzer_executables
 
 
-def analyze():
+def analyze(cfg):
     """Run CodeChecker analyze command"""
     stage("CodeChecker analyze:")
 
     env = os.environ
-    if CODECHECKER_ENV:
-        env_list = CODECHECKER_ENV.split("; ")
+    if cfg.codechecker_env:
+        env_list = cfg.codechecker_env.split("; ")
         if env_list:
             codechecker_env = dict(item.split("=", 1) for item in env_list)
             env.update(codechecker_env)
     if "PATH" not in env:
         env["PATH"] = "/bin"  # NOTE: this is workaround for CodeChecker 6.24.4
-    env["CC_ANALYZER_BIN"] = generate_analyzer_executables()
+    env["CC_ANALYZER_BIN"] = generate_analyzer_executables(cfg)
     logging.debug("env: %s", str(env))
 
-    output = execute(f"{CODECHECKER_PATH} analyzers --details", env=env)
+    output = execute(
+        cfg.codechecker_log,
+        f"{cfg.codechecker_path} analyzers --details",
+        env=env,
+    )
     logging.debug("Analyzers:\n\n%s", output)
 
     command = (
-        f"{CODECHECKER_PATH} analyze --skip={CODECHECKER_SKIPFILE} "
-        f"{COMPILE_COMMANDS} --output={CODECHECKER_FILES}/data "
-        f"--config {CODECHECKER_CONFIG} {CODECHECKER_ANALYZE}"
+        f"{cfg.codechecker_path} analyze --skip={cfg.codechecker_skipfile} "
+        f"{cfg.compile_commands} --output={cfg.codechecker_files}/data "
+        f"--config {cfg.codechecker_config} {cfg.codechecker_analyze}"
     )
     # FIXME: Workaround "CodeChecker simply remove compiler-rt include path".
     # This can be removed once codechecker 6.16.0 is used.
     # command += " --keep-gcc-intrin"
     logging.info("Running CodeChecker analyze...")
-    output = execute(command, env=env)
+    output = execute(cfg.codechecker_log, command, env=env)
     logging.info("Output:\n\n%s\n", output)
     if output.find("- Failed to analyze") != -1:
         logging.error("CodeChecker failed to analyze some files")
-        fail("Make sure that the target can be built first")
+        fail(
+            cfg.codechecker_log, "Make sure that the target can be built first"
+        )
 
 
 def fix_path_with_regex(data: str) -> str:
@@ -256,10 +295,10 @@ def fix_path_with_regex(data: str) -> str:
     return data
 
 
-def fix_bazel_paths():
+def fix_bazel_paths(codechecker_files):
     """Remove Bazel leading paths in all files"""
     stage("Fix CodeChecker output:")
-    folder = CODECHECKER_FILES
+    folder = codechecker_files
     logging.info("Fixing Bazel paths in %s", folder)
     counter = 0
     for root, _, files in os.walk(folder):
@@ -337,10 +376,10 @@ def resolve_yaml_symlinks(filepath):
             output_file.writelines(line_to_write)
 
 
-def resolve_symlinks():
+def resolve_symlinks(codechecker_files):
     """Change ".../execroot/apps" paths to absolute paths in data/* files"""
     stage("Resolve file paths in CodeChecker analyze output:")
-    analyze_outdir = CODECHECKER_FILES + "/data"
+    analyze_outdir = codechecker_files + "/data"
     logging.info(
         "Resolving file paths in CodeChecker analyze output at: %s",
         analyze_outdir,
@@ -358,76 +397,77 @@ def resolve_symlinks():
     logging.info("Processed file paths in %d files", files_processed)
 
 
-def update_file_paths():
+def update_file_paths(codechecker_files):
     """
     Fix bazel sandbox paths and resolve symbolic links
     in generated files to real paths
     """
-    fix_bazel_paths()
-    resolve_symlinks()
+    fix_bazel_paths(codechecker_files)
+    resolve_symlinks(codechecker_files)
 
 
-def parse():
+def parse(cfg):
     """Run CodeChecker parse commands"""
     stage("CodeChecker parse:")
     logging.info("CodeChecker parse -e json")
     codechecker_parse = (
-        f"{CODECHECKER_PATH} parse --config "
-        f"{CODECHECKER_CONFIG} {CODECHECKER_FILES}/data"
+        f"{cfg.codechecker_path} parse --config "
+        f"{cfg.codechecker_config} {cfg.codechecker_files}/data"
     )
     # Save results to JSON file
     command = (
         f"{codechecker_parse} --export=json > "
-        f"{CODECHECKER_FILES}/result.json"
+        f"{cfg.codechecker_files}/result.json"
     )
-    execute(command, codes=[0, 2])
-    # logging.debug(
-    #     "JSON:\n\n%s\n", read_file(CODECHECKER_FILES + "/result.json")
-    # )
+    execute(cfg.codechecker_log, command, codes=[0, 2])
     # Save results as HTML report
     logging.info("CodeChecker parse -e html")
     command = (
         codechecker_parse
         + " --export=html --output="
-        + CODECHECKER_FILES
+        + cfg.codechecker_files
         + "/report"
     )
-    execute(command, codes=[0, 2])
+    execute(cfg.codechecker_log, command, codes=[0, 2])
     # Save results to text file
     logging.info("CodeChecker parse to text result")
-    command = codechecker_parse + " > " + CODECHECKER_FILES + "/result.txt"
-    execute(command, codes=[0, 2])
+    command = codechecker_parse + " > " + cfg.codechecker_files + "/result.txt"
+    execute(cfg.codechecker_log, command, codes=[0, 2])
     logging.info(
-        "Result:\n\n%s\n", read_file(CODECHECKER_FILES + "/result.txt")
+        "Result:\n\n%s\n",
+        read_file(cfg.codechecker_log, cfg.codechecker_files + "/result.txt"),
     )
 
 
-def run():
+def run(cfg):
     """Perform all steps for "bazel build" phase"""
-    prepare()
-    analyze()
-    parse()
-    update_file_paths()
+    prepare(cfg.codechecker_files)
+    analyze(cfg)
+    parse(cfg)
+    update_file_paths(cfg.codechecker_files)
 
 
-def check_results():
+def check_results(cfg):
     """Check/verify CodeChecker results"""
     stage("Checking result:")
     # Get results file and read it
-    result_file = CODECHECKER_FILES + "/result.txt"
+    result_file = cfg.codechecker_files + "/result.txt"
     logging.info("Find CodeChecker results in bazel-out")
-    logging.info("      all artifacts: %s/", CODECHECKER_FILES)
-    logging.info("      HTML report:   %s/report/index.html", CODECHECKER_FILES)
+    logging.info("      all artifacts: %s/", cfg.codechecker_files)
+    logging.info(
+        "      HTML report:   %s/report/index.html", cfg.codechecker_files
+    )
     logging.info("      result file:   %s", result_file)
-    results = read_file(result_file)
+    results = read_file(cfg.codechecker_log, result_file)
     logging.info("Results: \n\n%s\n", results)
     # Collect defect severities to detect
-    if not valid_parameter(CODECHECKER_SEVERITIES):
+    if not valid_parameter(cfg.codechecker_severities):
         fail(
+            cfg.codechecker_log,
             "CodeChecker defect severities are invalid: "
-            f"{str(CODECHECKER_SEVERITIES)}"
+            f"{str(cfg.codechecker_severities)}",
         )
-    severities = shlex.split(CODECHECKER_SEVERITIES)
+    severities = shlex.split(cfg.codechecker_severities)
     # Add HIGH severity by default
     if not severities:
         severities.append("HIGH")
@@ -454,30 +494,34 @@ def check_results():
     if passed:
         logging.info("No defects found by CodeChecker")
     else:
-        fail(f"CodeChecker found defects:\n{conclusion}")
+        fail(cfg.codechecker_log, f"CodeChecker found defects:\n{conclusion}")
 
 
-def test():
+def test(cfg):
     """Perform all steps for "bazel test" phase"""
-    check_results()
+    check_results(cfg)
 
 
 def main():
     """Main function"""
-    setup()
-    input_data()
+    cfg = parse_args()
+    setup(cfg.verbosity, cfg.codechecker_log)
+    input_data(cfg)
     try:
-        if EXECUTION_MODE == "Run":
-            run()
-        elif EXECUTION_MODE == "Test":
-            test()
+        if cfg.execution_mode == "Run":
+            run(cfg)
+        elif cfg.execution_mode == "Test":
+            test(cfg)
         else:
-            fail(f"Wrong codechecker script mode: {EXECUTION_MODE}")
+            fail(
+                cfg.codechecker_log,
+                f"Wrong codechecker script mode: {cfg.execution_mode}",
+            )
     # We want to fail explicitly here
     # pylint: disable=broad-exception-caught
     except Exception as error:
         logging.exception(error)
-        fail("Caught Exception. Terminated")
+        fail(cfg.codechecker_log, "Caught Exception. Terminated")
 
 
 if __name__ == "__main__":

--- a/src/common.bzl
+++ b/src/common.bzl
@@ -50,23 +50,6 @@ def python_toolchain_type():
         return "@bazel_tools//tools/python:toolchain_type"
     return "@rules_python//python:toolchain_type"
 
-def python_path(ctx):
-    """
-    Returns version specific Python path
-    """
-    py_toolchain = ctx.toolchains[python_toolchain_type()]
-    if hasattr(py_toolchain, "py3_runtime_info"):
-        py_runtime_info = py_toolchain.py3_runtime_info
-        python_path = py_runtime_info.interpreter
-    elif hasattr(py_toolchain, "py3_runtime"):
-        py_runtime = py_toolchain.py3_runtime
-        python_path = py_runtime.interpreter_path
-    else:
-        fail("The resolved Python toolchain does not provide a Python3 runtime.")
-    if not python_path:
-        fail("The resolved Python toolchain does not provide a Python3 interpreter.")
-    return python_path
-
 def warning(ctx, msg):
     """
     Prints message if the debug tag is enabled.

--- a/src/per_file.bzl
+++ b/src/per_file.bzl
@@ -75,7 +75,7 @@ def _run_code_checker(
         executable = per_file_script,
         arguments = [
             compile_commands_json.path,
-            ' '.join(options),
+            " ".join(options),
             config_file.path,
             data_dir,
             src.path,
@@ -124,21 +124,6 @@ def _collect_all_sources_and_headers(ctx):
                 all_files += headers
     return all_files
 
-def _update_env_vars(
-    ctx,
-    options,
-    compile_commands_json,
-    config_file,
-    env_vars):
-    options_str = " ".join(options)
-    if not env_vars:
-        env_vars = {}
-    return (env_vars | {
-        "RULES_CODECHECKER_COMPILE_COMMANDS_JSON": compile_commands_json.path,
-        "RULES_CODECHECKER_CODECHECKER_ARGS": options_str,
-        "RULES_CODECHECKER_CONFIG_FILE": config_file.path,
-    })
-
 def _per_file_impl(ctx):
     compile_commands = None
     for output in compile_commands_impl(ctx):
@@ -152,7 +137,7 @@ def _per_file_impl(ctx):
     options = ctx.attr.default_options + ctx.attr.options
     all_files = [compile_commands]
     config_file, env_vars = get_config_file(ctx)
-    env_vars =_update_env_vars(ctx, options, compile_commands, config_file, env_vars)
+
     # Create per_file_script
     per_file_script = ctx.actions.declare_file(ctx.label.name + "/per_file_script")
     ctx.actions.symlink(

--- a/src/per_file.bzl
+++ b/src/per_file.bzl
@@ -29,6 +29,7 @@ load(
 # buildifier: disable=unused-variable
 def _run_code_checker(
         ctx,
+        per_file_script,
         src,
         arguments,
         info,
@@ -94,13 +95,21 @@ def _run_code_checker(
                            ";clang-tidy:" + info.clang_tidy.path
 
     # Action to run CodeChecker for a file
+    # env_vars are unused for now, since
+    # use_default_shell_env and env are incompatible
     ctx.actions.run(
         inputs = inputs,
         outputs = outputs,
-        executable = ctx.outputs.per_file_script,
-        tools = [info.runfiles],
+        executable = per_file_script,
+        tools = [
+            info.runfiles,
+            ctx.attr._per_file_script[DefaultInfo].files_to_run,
+        ],
         arguments = [
             info.codechecker.path,
+            compile_commands_json.path,
+            " ".join(options),
+            config_file.path,
             data_dir,
             src.path,
             codechecker_log.path,
@@ -156,21 +165,6 @@ def _collect_all_sources_and_headers(ctx):
                 all_files += headers
     return all_files
 
-def _create_wrapper_script(ctx, options, compile_commands_json, config_file):
-    options_str = ""
-    for item in options:
-        options_str += item + " "
-    ctx.actions.expand_template(
-        template = ctx.file._per_file_script_template,
-        output = ctx.outputs.per_file_script,
-        is_executable = True,
-        substitutions = {
-            "{codechecker_args}": options_str,
-            "{compile_commands_json}": compile_commands_json.path,
-            "{config_file}": config_file.path,
-        },
-    )
-
 def _per_file_impl(ctx):
     info = ctx.toolchains["//:toolchain_type"].codecheckerinfo
     compile_commands = None
@@ -185,7 +179,13 @@ def _per_file_impl(ctx):
     options = ctx.attr.default_options + ctx.attr.options
     config_file, env_vars = get_config_file(ctx)
     all_files = [compile_commands, config_file]
-    _create_wrapper_script(ctx, options, compile_commands, config_file)
+
+    # Create per_file_script
+    per_file_script = ctx.actions.declare_file(ctx.label.name + "/per_file_script")
+    ctx.actions.symlink(
+        output = per_file_script,
+        target_file = ctx.executable._per_file_script,
+    )
 
     info = ctx.toolchains["//:toolchain_type"].codecheckerinfo
     for target in ctx.attr.targets:
@@ -202,6 +202,7 @@ def _per_file_impl(ctx):
                     args = target[SourceFilesInfo].compilation_db.to_list()
                     outputs = _run_code_checker(
                         ctx,
+                        per_file_script,
                         src,
                         args,
                         info,
@@ -270,14 +271,15 @@ per_file_test = rule(
             ],
             doc = "List of compilable targets which should be checked.",
         ),
-        "_per_file_script_template": attr.label(
-            default = ":per_file_script.py",
-            allow_single_file = True,
+        "_per_file_script": attr.label(
+            allow_files = True,
+            executable = True,
+            cfg = "target",
+            default = ":per_file_script",
         ),
     },
     outputs = {
         "compile_commands": "%{name}/compile_commands.json",
-        "per_file_script": "%{name}/per_file_script.py",
         "test_script": "%{name}/test_script.sh",
     },
     test = True,

--- a/src/per_file_script.py
+++ b/src/per_file_script.py
@@ -1,5 +1,3 @@
-#!{PythonPath}
-
 # Copyright 2023 Ericsson AB
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -32,14 +30,14 @@ FILE_PATH: Optional[str] = None
 # List of pairs of analyzers and their plist files
 ANALYZER_PLIST_PATHS: Optional[list[list[str]]] = None
 LOG_FILE: Optional[str] = None
-COMPILE_COMMANDS_JSON: str = "{compile_commands_json}"
+COMPILE_COMMANDS_JSON: str = sys.argv[1]
 COMPILE_COMMANDS_ABSOLUTE: str = f"{COMPILE_COMMANDS_JSON}.abs"
-CODECHECKER_ARGS: str = "{codechecker_args}"
-CONFIG_FILE: str = "{config_file}"
-DATA_DIR = sys.argv[1]
-FILE_PATH = sys.argv[2]
-LOG_FILE = sys.argv[3]
-ANALYZER_PLIST_PATHS = [item.split(",") for item in sys.argv[4].split(";")]
+CODECHECKER_ARGS: str = sys.argv[2]
+CONFIG_FILE: str = sys.argv[3]
+DATA_DIR = sys.argv[4]
+FILE_PATH = sys.argv[5]
+LOG_FILE = sys.argv[6]
+ANALYZER_PLIST_PATHS = [item.split(",") for item in sys.argv[7].split(";")]
 
 
 def log(msg: str) -> None:
@@ -147,7 +145,7 @@ def main():
     """
     Main function of CodeChecker wrapper
     """
-    if len(sys.argv) != 5:
+    if len(sys.argv) != 8:
         print("Wrong amount of arguments")
         sys.exit(1)
     _create_compile_commands_json_with_absolute_paths()

--- a/src/per_file_script.py
+++ b/src/per_file_script.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Copyright 2023 Ericsson AB
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,24 +22,24 @@ import shutil
 import subprocess
 import sys
 
-COMPILE_COMMANDS_JSON: str = "{compile_commands_json}"
+COMPILE_COMMANDS_JSON: str = sys.argv[2]
 COMPILE_COMMANDS_ABSOLUTE: str = f"{COMPILE_COMMANDS_JSON}.abs"
-CODECHECKER_ARGS: str = "{codechecker_args}"
-CONFIG_FILE: str = "{config_file}"
-SKIP_FILE: str = sys.argv[5]
+CODECHECKER_ARGS: str = sys.argv[3]
+CONFIG_FILE: str = sys.argv[4]
+SKIP_FILE: str = sys.argv[8]
 CODECHECKER_BIN = os.path.realpath(sys.argv[1])
 # The output directory for CodeChecker
-DATA_DIR = sys.argv[2]
+DATA_DIR = sys.argv[5]
 # The file to be analyzed
-FILE_PATH = sys.argv[3]
-LOG_FILE = sys.argv[4]
-METADATA_FILE = sys.argv[6]
+FILE_PATH = sys.argv[6]
+LOG_FILE = sys.argv[7]
+METADATA_FILE = sys.argv[9]
 # List of pairs of analyzers and their plist files
-ANALYZER_PLIST_PATHS = [item.split(",") for item in sys.argv[7].split(";")]
+ANALYZER_PLIST_PATHS = [item.split(",") for item in sys.argv[10].split(";")]
 ANALYZER_EXECUTABLES_ENV_VAR = ";".join(
     f"{name}:{os.path.realpath(path)}"
     for name, path in [
-        pair.split(":", 1) for pair in sys.argv[8].split(";") if pair
+        pair.split(":", 1) for pair in sys.argv[11].split(";") if pair
     ]
 )
 
@@ -217,7 +215,7 @@ def main():
     """
     Main function of CodeChecker wrapper
     """
-    if len(sys.argv) != 9:
+    if len(sys.argv) != 12:
         print("Wrong amount of arguments")
         sys.exit(1)
     _create_compile_commands_json_with_absolute_paths()


### PR DESCRIPTION
Why:
We should rely on Bazel to run Python scripts and not hack them together ourselves.

What:
- Created a py_binary target for `codechecker_script.py`
- Created a py_binary target for `per_file_script.py`
- Replaced `expand_template` with environment variables in codechecker rule
- Replaced `expand_template` with arguments in per_file rule (`use_default_shell_env = True,` does not allow us to define env variables)
- Refactored `codechecker_script.py` to not use global variables anymore. 

Addresses:
none
