### PR TITLE
Show case *most* unittest running through bazel test ...

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,36 @@
+filegroup(
+    name = "all_sources",
+    srcs = glob(
+        ["**/*"],
+        exclude = [
+            "bazel-*/**",       # Exclude bazel symlinks
+            ".git/**",
+            "**/__pycache__/**",
+        ],
+    ),
+    visibility = ["//visibility:public"],
+)
+
+sh_test(
+    name = "integration_tests",
+    srcs = ["test/test_runner.sh"],
+    data = [
+        ":all_sources",
+        "//src:all_src_sources",
+        "//test/unit/legacy:all_files",
+        "//test/unit/parse:all_files",
+        "//test/unit/implementation_deps:all_files",
+        "//test/unit/generated_files:all_files",
+        "//test/unit/config:all_files",
+        "//test/unit/compile_flags:all_files",
+        "//test/unit/caching:all_files",
+        "//test/unit/argument_merge:all_files",
+        "//test/unit/virtual_include:all_files",
+    ],
+    tags = [
+        "local",
+        "exclusive",
+    ],
+    size = "large",
+    timeout = "long",
+)

--- a/src/BUILD
+++ b/src/BUILD
@@ -12,6 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+filegroup(
+    name = "all_src_sources",
+    srcs = glob(
+        ["**/*"],
+        exclude = [
+            "bazel-*/**",       # Exclude bazel symlinks
+            ".git/**",
+            "**/__pycache__/**",
+        ],
+    ),
+    visibility = ["//visibility:public"],
+)
+
 # Tool filter compile_commands.json file
 py_binary(
     name = "compile_commands_filter",

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
+# This file is tied to a CI job and thus can't be changed
 python3 -m unittest discover unit $@

--- a/test/test_runner.sh
+++ b/test/test_runner.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+python3 -m unittest discover -t . -s test/unit $@

--- a/test/unit/argument_merge/BUILD
+++ b/test/unit/argument_merge/BUILD
@@ -23,6 +23,19 @@ load(
     "cc_library",
 )
 
+filegroup(
+    name = "all_files",
+    srcs = glob(
+        ["**/*"],
+        exclude = [
+            "bazel-*/**",       # Exclude bazel symlinks
+            ".git/**",
+            "**/__pycache__/**",
+        ],
+    ),
+    visibility = ["//visibility:public"],
+)
+
 cc_library(
     name = "main",
     srcs = ["main.cc"],

--- a/test/unit/caching/BUILD
+++ b/test/unit/caching/BUILD
@@ -24,6 +24,19 @@ load(
     "cc_library",
 )
 
+filegroup(
+    name = "all_files",
+    srcs = glob(
+        ["**/*"],
+        exclude = [
+            "bazel-*/**",       # Exclude bazel symlinks
+            ".git/**",
+            "**/__pycache__/**",
+        ],
+    ),
+    visibility = ["//visibility:public"],
+)
+
 # We are not interested in finding bugs, we are only interested in whether the
 # analysis re-runs after the files have been modified. As such, these files emit no
 # warnings.

--- a/test/unit/compile_flags/BUILD
+++ b/test/unit/compile_flags/BUILD
@@ -29,6 +29,19 @@ load(
     "cc_library",
 )
 
+filegroup(
+    name = "all_files",
+    srcs = glob(
+        ["**/*"],
+        exclude = [
+            "bazel-*/**",       # Exclude bazel symlinks
+            ".git/**",
+            "**/__pycache__/**",
+        ],
+    ),
+    visibility = ["//visibility:public"],
+)
+
 cc_library(
     name = "target_with_both_extension",
     srcs = [

--- a/test/unit/config/BUILD
+++ b/test/unit/config/BUILD
@@ -26,6 +26,19 @@ load(
     "cc_binary",
 )
 
+filegroup(
+    name = "all_files",
+    srcs = glob(
+        ["**/*"],
+        exclude = [
+            "bazel-*/**",       # Exclude bazel symlinks
+            ".git/**",
+            "**/__pycache__/**",
+        ],
+    ),
+    visibility = ["//visibility:public"],
+)
+
 # C++ binary containing a division by zero bug
 cc_binary(
     name = "test_zero",

--- a/test/unit/generated_files/BUILD
+++ b/test/unit/generated_files/BUILD
@@ -27,6 +27,19 @@ load(
     "cc_binary",
 )
 
+filegroup(
+    name = "all_files",
+    srcs = glob(
+        ["**/*"],
+        exclude = [
+            "bazel-*/**",       # Exclude bazel symlinks
+            ".git/**",
+            "**/__pycache__/**",
+        ],
+    ),
+    visibility = ["//visibility:public"],
+)
+
 # First, define the rule that generates our file.
 genrule(
     name = "generate_header",

--- a/test/unit/implementation_deps/BUILD
+++ b/test/unit/implementation_deps/BUILD
@@ -21,6 +21,19 @@ load(
     "compile_commands",
 )
 
+filegroup(
+    name = "all_files",
+    srcs = glob(
+        ["**/*"],
+        exclude = [
+            "bazel-*/**",       # Exclude bazel symlinks
+            ".git/**",
+            "**/__pycache__/**",
+        ],
+    ),
+    visibility = ["//visibility:public"],
+)
+
 cc_library(
     name = "dep_lib",
     srcs = [

--- a/test/unit/legacy/BUILD
+++ b/test/unit/legacy/BUILD
@@ -33,6 +33,19 @@ load(
     "cc_library",
 )
 
+filegroup(
+    name = "all_files",
+    srcs = glob(
+        ["**/*"],
+        exclude = [
+            "bazel-*/**",       # Exclude bazel symlinks
+            ".git/**",
+            "**/__pycache__/**",
+        ],
+    ),
+    visibility = ["//visibility:public"],
+)
+
 # Test for strip_include_prefix
 cc_library(
     name = "test_inc",

--- a/test/unit/parse/BUILD
+++ b/test/unit/parse/BUILD
@@ -23,6 +23,19 @@ load(
     "cc_library",
 )
 
+filegroup(
+    name = "all_files",
+    srcs = glob(
+        ["**/*"],
+        exclude = [
+            "bazel-*/**",       # Exclude bazel symlinks
+            ".git/**",
+            "**/__pycache__/**",
+        ],
+    ),
+    visibility = ["//visibility:public"],
+)
+
 cc_library(
     name = "c_target",
     srcs = ["simple.c"],

--- a/test/unit/virtual_include/BUILD
+++ b/test/unit/virtual_include/BUILD
@@ -24,6 +24,19 @@ load(
     "cc_library",
 )
 
+filegroup(
+    name = "all_files",
+    srcs = glob(
+        ["**/*"],
+        exclude = [
+            "bazel-*/**",       # Exclude bazel symlinks
+            ".git/**",
+            "**/__pycache__/**",
+        ],
+    ),
+    visibility = ["//visibility:public"],
+)
+
 # Test for strip_include_prefix
 cc_library(
     name = "test_inc",


### PR DESCRIPTION
Why:
We want all test to be run through `bazel test ...`

What:
- Created a filegroup in all packages that exports all files inside the package.
- Created a target that runs the Python unittests on the copy inside the sandbox.

Addresses:
none

Note:
This is a proof-of-concept patch.
**The question is: Is this a good way to run tests that cannot be completely integrated into Bazel?**
This solution does not speed up the time it takes to run tests.
It seems like the external test cannot be added in this way. (But it can take FOSS tests **too**