### PR TITLE
Add skip option to per_file

### DIFF
--- a/src/codechecker.bzl
+++ b/src/codechecker.bzl
@@ -341,6 +341,7 @@ def codechecker_test(
             name = name,
             targets = targets,
             options = analyze,
+            skip = skip,
             config = config,
             tags = tags,
             **kwargs

--- a/src/per_file.bzl
+++ b/src/per_file.bzl
@@ -132,6 +132,7 @@ def _create_wrapper_script(ctx, options, compile_commands_json, config_file):
             "{codechecker_args}": options_str,
             "{compile_commands_json}": compile_commands_json.path,
             "{config_file}": config_file.path,
+            "[\"{skip_list}\"]": str(ctx.attr.skip)
         },
     )
 
@@ -222,6 +223,11 @@ per_file_test = rule(
                 compile_commands_aspect,
             ],
             doc = "List of compilable targets which should be checked.",
+        ),
+        "skip": attr.string_list(
+            default = [],
+            doc = "List of skip/ignore file rules. " +
+                  "See https://codechecker.readthedocs.io/en/latest/analyzer/user_guide/#skip-file",
         ),
         "_per_file_script_template": attr.label(
             default = ":per_file_script.py",

--- a/src/per_file.bzl
+++ b/src/per_file.bzl
@@ -50,12 +50,30 @@ def _run_code_checker(
     clangsa_plist = ctx.actions.declare_file(clangsa_plist_file_name)
     codechecker_log = ctx.actions.declare_file(codechecker_log_file_name)
 
+    # Create skipfile
+    config = ctx.actions.declare_file(
+        "{}/{}_skipfile".format(*file_name_params),
+    )
+    ctx.actions.write(
+        output = config,
+        content = "\n".join(ctx.attr.skip),
+    )
+
     if "--ctu" in options:
-        inputs = [compile_commands_json, config_file] + sources_and_headers
+        inputs = [
+            compile_commands_json,
+            config_file,
+            config,
+        ] + sources_and_headers
     else:
         # NOTE: we collect only headers, so CTU may not work!
         headers = depset(transitive = target[SourceFilesInfo].headers.to_list())
-        inputs = depset([compile_commands_json, config_file, src], transitive = [headers])
+        inputs = depset([
+            compile_commands_json,
+            config_file,
+            src,
+            config,
+        ], transitive = [headers])
 
     outputs = [clang_tidy_plist, clangsa_plist, codechecker_log]
 
@@ -71,6 +89,7 @@ def _run_code_checker(
             data_dir,
             src.path,
             codechecker_log.path,
+            config.path,
             analyzer_output_paths,
         ],
         mnemonic = "CodeChecker",
@@ -132,7 +151,6 @@ def _create_wrapper_script(ctx, options, compile_commands_json, config_file):
             "{codechecker_args}": options_str,
             "{compile_commands_json}": compile_commands_json.path,
             "{config_file}": config_file.path,
-            "[\"{skip_list}\"]": str(ctx.attr.skip)
         },
     )
 
@@ -218,16 +236,16 @@ per_file_test = rule(
             default = [],
             doc = "List of CodeChecker options, e.g.: --ctu",
         ),
+        "skip": attr.string_list(
+            default = [],
+            doc = "List of skip/ignore file rules. " +
+                  "See https://codechecker.readthedocs.io/en/latest/analyzer/user_guide/#skip-file",
+        ),
         "targets": attr.label_list(
             aspects = [
                 compile_commands_aspect,
             ],
             doc = "List of compilable targets which should be checked.",
-        ),
-        "skip": attr.string_list(
-            default = [],
-            doc = "List of skip/ignore file rules. " +
-                  "See https://codechecker.readthedocs.io/en/latest/analyzer/user_guide/#skip-file",
         ),
         "_per_file_script_template": attr.label(
             default = ":per_file_script.py",

--- a/src/per_file_script.py
+++ b/src/per_file_script.py
@@ -18,31 +18,24 @@
 Codechecker wrapper script for per-file analysis
 """
 
-import fnmatch
 import os
-from pathlib import Path
 import re
 import shutil
 import subprocess
 import sys
-from typing import Optional
 
-# The output directory for CodeChecker
-DATA_DIR: Optional[str] = None
-# The file to be analyzed
-FILE_PATH: str = None  # pyright: ignore
-# List of pairs of analyzers and their plist files
-ANALYZER_PLIST_PATHS: list[list[str]] = None  # pyright: ignore
-LOG_FILE: str = None  # pyright: ignore
 COMPILE_COMMANDS_JSON: str = "{compile_commands_json}"
 COMPILE_COMMANDS_ABSOLUTE: str = f"{COMPILE_COMMANDS_JSON}.abs"
 CODECHECKER_ARGS: str = "{codechecker_args}"
 CONFIG_FILE: str = "{config_file}"
-SKIP_LIST: list[str] = ["{skip_list}"]
+SKIP_FILE: str = sys.argv[4]
+# The output directory for CodeChecker
 DATA_DIR = sys.argv[1]
+# The file to be analyzed
 FILE_PATH = sys.argv[2]
 LOG_FILE = sys.argv[3]
-ANALYZER_PLIST_PATHS = [item.split(",") for item in sys.argv[4].split(";")]
+# List of pairs of analyzers and their plist files
+ANALYZER_PLIST_PATHS = [item.split(",") for item in sys.argv[5].split(";")]
 
 EMPTY_PLIST = """<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -57,34 +50,11 @@ EMPTY_PLIST = """<?xml version="1.0" encoding="UTF-8"?>
 """
 
 
-def skipped():
-    """
-    Checks if this file should be skipped.
-    Return a boolean value.
-    """
-    skip_this = False
-    positive_patterns = []
-    negative_patterns = []
-
-    for pattern in SKIP_LIST:
-        if pattern[0] == "+":
-            positive_patterns.append(fnmatch.translate(pattern[1::]))
-        else:
-            negative_patterns.append(fnmatch.translate(pattern[1::]))
-    for pattern in negative_patterns:
-        if re.search(pattern, FILE_PATH):
-            skip_this = True
-    for pattern in positive_patterns:
-        if re.search(pattern, FILE_PATH):
-            skip_this = False
-    return skip_this
-
-
 def log(msg: str) -> None:
     """
     Append message to the log file
     """
-    with open(LOG_FILE, "a", encoding="utf-8") as log_file:  # type: ignore
+    with open(LOG_FILE, "a", encoding="utf-8") as log_file:
         log_file.write(msg)
 
 
@@ -114,8 +84,9 @@ def _run_codechecker() -> None:
     codechecker_cmd: list[str] = (
         ["CodeChecker", "analyze"]
         + CODECHECKER_ARGS.split()
-        + ["--output=" + DATA_DIR]  # type: ignore
-        + ["--file=*/" + FILE_PATH]  # type: ignore
+        + ["--output=" + DATA_DIR]
+        + ["--file=*/" + FILE_PATH]
+        + ["--skip", SKIP_FILE]
         + ["--config", CONFIG_FILE]
         + [COMPILE_COMMANDS_ABSOLUTE]
     )
@@ -135,7 +106,7 @@ def _run_codechecker() -> None:
     log(result.stdout)
 
     try:
-        with open(LOG_FILE, "a", encoding="utf-8") as log_file:  # type: ignore
+        with open(LOG_FILE, "a", encoding="utf-8") as log_file:
             subprocess.run(
                 codechecker_cmd,
                 env=os.environ,
@@ -156,7 +127,7 @@ def _display_error(ret_code: int) -> None:
     # Log and exit on error
     print("===-----------------------------------------------------===")
     print(f"[ERROR]: CodeChecker returned with {ret_code}!")
-    with open(LOG_FILE, "r", encoding="utf-8") as log_file:  # type: ignore
+    with open(LOG_FILE, "r", encoding="utf-8") as log_file:
         print(log_file.read())
     sys.exit(1)
 
@@ -164,38 +135,37 @@ def _display_error(ret_code: int) -> None:
 def _move_plist_files():
     """
     Move the plist files from the temporary directory to their final destination
+    If the files doesn't exists, write an empty plist file to the target.
     """
     # NOTE: the following we do to get rid of md5 hash in plist file names
     # Copy the plist files to the specified destinations
-    for file in os.listdir(DATA_DIR):
-        for analyzer_info in ANALYZER_PLIST_PATHS:  # type: ignore
-            if re.search(
-                rf"_{analyzer_info[0]}_.*\.plist$", file
-            ) and os.path.isfile(
-                os.path.join(DATA_DIR, file)  # type: ignore
-            ):
-                shutil.move(
-                    os.path.join(DATA_DIR, file),  # type: ignore
-                    analyzer_info[1],
-                )
+    compiled_analyzers = [
+        (re.compile(rf"_{analyzer[0]}_.*\.plist$"), analyzer[1])
+        for analyzer in ANALYZER_PLIST_PATHS
+    ]
+
+    for regex, target_file in compiled_analyzers:
+        for file_path in os.listdir(DATA_DIR):
+            if not os.path.isfile(os.path.join(DATA_DIR, file_path)):
+                continue
+            if regex.search(file_path):
+                shutil.move(os.path.join(DATA_DIR, file_path), target_file)
+                break
+        else:
+            with open(target_file, "w", encoding="utf-8") as file:
+                file.write(EMPTY_PLIST)
 
 
 def main():
     """
     Main function of CodeChecker wrapper
     """
-    if len(sys.argv) != 5:
+    if len(sys.argv) != 6:
         print("Wrong amount of arguments")
         sys.exit(1)
     _create_compile_commands_json_with_absolute_paths()
-    Path(LOG_FILE).touch()
-    if skipped():
-        for analyzer_list in ANALYZER_PLIST_PATHS:
-            with open(analyzer_list[1], "w", encoding="utf-8") as file:
-                file.write(EMPTY_PLIST)
-    else:
-        _run_codechecker()
-        _move_plist_files()
+    _run_codechecker()
+    _move_plist_files()
 
 
 if __name__ == "__main__":

--- a/src/per_file_script.py
+++ b/src/per_file_script.py
@@ -56,23 +56,27 @@ EMPTY_PLIST = """<?xml version="1.0" encoding="UTF-8"?>
 </plist>
 """
 
+
 def skipped():
+    """
+    Checks if this file should be skipped.
+    Return a boolean value.
+    """
     skip_this = False
-    
     positive_patterns = []
     negative_patterns = []
-    
+
     for pattern in SKIP_LIST:
-        if pattern[0] == '+':
+        if pattern[0] == "+":
             positive_patterns.append(fnmatch.translate(pattern[1::]))
         else:
             negative_patterns.append(fnmatch.translate(pattern[1::]))
     for pattern in negative_patterns:
         if re.search(pattern, FILE_PATH):
-                skip_this = True
+            skip_this = True
     for pattern in positive_patterns:
         if re.search(pattern, FILE_PATH):
-                skip_this = False
+            skip_this = False
     return skip_this
 
 
@@ -169,12 +173,11 @@ def _move_plist_files():
                 rf"_{analyzer_info[0]}_.*\.plist$", file
             ) and os.path.isfile(
                 os.path.join(DATA_DIR, file)  # type: ignore
-
             ):
                 shutil.move(
-                    os.path.join(DATA_DIR, file),   # type: ignore
+                    os.path.join(DATA_DIR, file),  # type: ignore
                     analyzer_info[1],
-                    )
+                )
 
 
 def main():

--- a/src/per_file_script.py
+++ b/src/per_file_script.py
@@ -136,23 +136,32 @@ def _move_plist_files():
     """
     Move the plist files from the temporary directory to their final destination
     If the files doesn't exists, write an empty plist file to the target.
+    This can happen when an analysis was skipped
+    because of a CodeChecker skipfile.
+    For each analysis action we must have an output file, even if its skipped,
+    so we substitute it with an empty one.
     """
     # NOTE: the following we do to get rid of md5 hash in plist file names
     # Copy the plist files to the specified destinations
-    compiled_analyzers = [
-        (re.compile(rf"_{analyzer[0]}_.*\.plist$"), analyzer[1])
+    plist_search_mappings = [
+        (analyzer[1], re.compile(rf"_{analyzer[0]}_.*\.plist$"))
         for analyzer in ANALYZER_PLIST_PATHS
     ]
 
-    for regex, target_file in compiled_analyzers:
+    for (
+        destination_plist_path,
+        source_plist_search_pattern,
+    ) in plist_search_mappings:
         for file_path in os.listdir(DATA_DIR):
             if not os.path.isfile(os.path.join(DATA_DIR, file_path)):
                 continue
-            if regex.search(file_path):
-                shutil.move(os.path.join(DATA_DIR, file_path), target_file)
+            if source_plist_search_pattern.search(file_path):
+                shutil.move(
+                    os.path.join(DATA_DIR, file_path), destination_plist_path
+                )
                 break
         else:
-            with open(target_file, "w", encoding="utf-8") as file:
+            with open(destination_plist_path, "w", encoding="utf-8") as file:
                 file.write(EMPTY_PLIST)
 
 

--- a/src/per_file_script.py
+++ b/src/per_file_script.py
@@ -18,6 +18,7 @@
 Codechecker wrapper script for per-file analysis
 """
 
+import fnmatch
 import os
 from pathlib import Path
 import re
@@ -32,7 +33,7 @@ DATA_DIR: Optional[str] = None
 FILE_PATH: str = None  # pyright: ignore
 # List of pairs of analyzers and their plist files
 ANALYZER_PLIST_PATHS: list[list[str]] = None  # pyright: ignore
-LOG_FILE: Optional[str] = None
+LOG_FILE: str = None  # pyright: ignore
 COMPILE_COMMANDS_JSON: str = "{compile_commands_json}"
 COMPILE_COMMANDS_ABSOLUTE: str = f"{COMPILE_COMMANDS_JSON}.abs"
 CODECHECKER_ARGS: str = "{codechecker_args}"
@@ -43,12 +44,36 @@ FILE_PATH = sys.argv[2]
 LOG_FILE = sys.argv[3]
 ANALYZER_PLIST_PATHS = [item.split(",") for item in sys.argv[4].split(";")]
 
+EMPTY_PLIST = """<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>diagnostics</key>
+    <array/>
+    <key>files</key>
+    <array/>
+</dict>
+</plist>
+"""
 
 def skipped():
+    skip_this = False
+    
+    positive_patterns = []
+    negative_patterns = []
+    
     for pattern in SKIP_LIST:
+        if pattern[0] == '+':
+            positive_patterns.append(fnmatch.translate(pattern[1::]))
+        else:
+            negative_patterns.append(fnmatch.translate(pattern[1::]))
+    for pattern in negative_patterns:
         if re.search(pattern, FILE_PATH):
-            return True
-    return False
+                skip_this = True
+    for pattern in positive_patterns:
+        if re.search(pattern, FILE_PATH):
+                skip_this = False
+    return skip_this
 
 
 def log(msg: str) -> None:
@@ -160,12 +185,14 @@ def main():
         print("Wrong amount of arguments")
         sys.exit(1)
     _create_compile_commands_json_with_absolute_paths()
+    Path(LOG_FILE).touch()
     if skipped():
         for analyzer_list in ANALYZER_PLIST_PATHS:
-            Path(analyzer_list[1]).touch()
+            with open(analyzer_list[1], "w", encoding="utf-8") as file:
+                file.write(EMPTY_PLIST)
     else:
         _run_codechecker()
-    _move_plist_files()
+        _move_plist_files()
 
 
 if __name__ == "__main__":

--- a/src/per_file_script.py
+++ b/src/per_file_script.py
@@ -19,6 +19,7 @@ Codechecker wrapper script for per-file analysis
 """
 
 import os
+from pathlib import Path
 import re
 import shutil
 import subprocess
@@ -28,18 +29,26 @@ from typing import Optional
 # The output directory for CodeChecker
 DATA_DIR: Optional[str] = None
 # The file to be analyzed
-FILE_PATH: Optional[str] = None
+FILE_PATH: str = None  # pyright: ignore
 # List of pairs of analyzers and their plist files
-ANALYZER_PLIST_PATHS: Optional[list[list[str]]] = None
+ANALYZER_PLIST_PATHS: list[list[str]] = None  # pyright: ignore
 LOG_FILE: Optional[str] = None
 COMPILE_COMMANDS_JSON: str = "{compile_commands_json}"
 COMPILE_COMMANDS_ABSOLUTE: str = f"{COMPILE_COMMANDS_JSON}.abs"
 CODECHECKER_ARGS: str = "{codechecker_args}"
 CONFIG_FILE: str = "{config_file}"
+SKIP_LIST: list[str] = ["{skip_list}"]
 DATA_DIR = sys.argv[1]
 FILE_PATH = sys.argv[2]
 LOG_FILE = sys.argv[3]
 ANALYZER_PLIST_PATHS = [item.split(",") for item in sys.argv[4].split(";")]
+
+
+def skipped():
+    for pattern in SKIP_LIST:
+        if re.search(pattern, FILE_PATH):
+            return True
+    return False
 
 
 def log(msg: str) -> None:
@@ -151,7 +160,11 @@ def main():
         print("Wrong amount of arguments")
         sys.exit(1)
     _create_compile_commands_json_with_absolute_paths()
-    _run_codechecker()
+    if skipped():
+        for analyzer_list in ANALYZER_PLIST_PATHS:
+            Path(analyzer_list[1]).touch()
+    else:
+        _run_codechecker()
     _move_plist_files()
 
 

--- a/src/per_file_script.py
+++ b/src/per_file_script.py
@@ -41,10 +41,14 @@ EMPTY_PLIST = """<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>diagnostics</key>
-    <array/>
-    <key>files</key>
-    <array/>
+	<key>metadata</key>
+	<dict>
+		<key>generated_by</key>
+		<dict>
+			<key>name</key>
+			<string>CodeChecker</string>
+		</dict>
+	</dict>
 </dict>
 </plist>
 """
@@ -143,7 +147,7 @@ def _move_plist_files():
     """
     # NOTE: the following we do to get rid of md5 hash in plist file names
     # Copy the plist files to the specified destinations
-    plist_search_mappings = [
+    destination_and_source_pattern_pairs = [
         (analyzer[1], re.compile(rf"_{analyzer[0]}_.*\.plist$"))
         for analyzer in ANALYZER_PLIST_PATHS
     ]
@@ -151,7 +155,7 @@ def _move_plist_files():
     for (
         destination_plist_path,
         source_plist_search_pattern,
-    ) in plist_search_mappings:
+    ) in destination_and_source_pattern_pairs:
         for file_path in os.listdir(DATA_DIR):
             if not os.path.isfile(os.path.join(DATA_DIR, file_path)):
                 continue

--- a/test/unit/skip/BUILD
+++ b/test/unit/skip/BUILD
@@ -85,8 +85,8 @@ codechecker_test(
     name = "per_file_skipfile_both_files_except_one",
     per_file = True,
     skip = [
+        "+*test/unit/skip/skip.cc",
         "-*test/unit/skip/skip*",
-        "+*test/unit/skip/skip.cc"
     ],
     tags = ["manual"],
     targets = [

--- a/test/unit/skip/BUILD
+++ b/test/unit/skip/BUILD
@@ -76,6 +76,18 @@ codechecker_test(
     skip = [
         "-*test/unit/skip/skip*",
     ],
+    targets = [
+        "simple_target",
+    ],
+)
+
+codechecker_test(
+    name = "per_file_skipfile_both_files_except_one",
+    per_file = True,
+    skip = [
+        "-*test/unit/skip/skip*",
+        "+*test/unit/skip/skip.cc"
+    ],
     tags = ["manual"],
     targets = [
         "simple_target",

--- a/test/unit/skip/test_skip.py
+++ b/test/unit/skip/test_skip.py
@@ -41,7 +41,7 @@ class TestSkip(TestBase):
         )
         self.assertEqual(ret, 0, stderr)
 
-    def test_per_file_skipfile_full_path(self):
+    def test_per_file_skipfile_exact_file_path(self):
         """
         Test: bazel test //test/unit/skip:per_file_skipfile_exact_file_path
         """
@@ -53,8 +53,7 @@ class TestSkip(TestBase):
             f"{self.BAZEL_TESTLOGS_DIR}/"
             "per_file_skipfile_exact_file_path/test.log"
         )
-        # FIXME: change to assertFalse, this file should be skipped
-        self.assertTrue(
+        self.assertFalse(
             self.contains_regex_in_file(log_file, r"defect\(s\) in skip.cc")
         )
         self.assertTrue(
@@ -73,8 +72,7 @@ class TestSkip(TestBase):
             f"{self.BAZEL_TESTLOGS_DIR}/"
             "per_file_skipfile_folder_skip_path/test.log"
         )
-        # FIXME: change to assertFalse, this file should be skipped
-        self.assertTrue(
+        self.assertFalse(
             self.contains_regex_in_file(log_file, r"defect\(s\) in skip.cc")
         )
         # This is correct.
@@ -89,17 +87,35 @@ class TestSkip(TestBase):
         ret, _, stderr = self.run_command(
             "bazel test //test/unit/skip:per_file_skipfile_both_files"
         )
-        # FIXME: The return code here should be 0, both files should be skipped
-        self.assertEqual(ret, 3, stderr)
+        self.assertEqual(ret, 0, stderr)
         log_file = (
             f"{self.BAZEL_TESTLOGS_DIR}/per_file_skipfile_both_files/test.log"
         )
-        # FIXME: Change to assertFalse after fix, should have been skipped.
+        self.assertFalse(
+            self.contains_regex_in_file(log_file, r"defect\(s\) in skip.cc")
+        )
+        self.assertFalse(
+            self.contains_regex_in_file(log_file, r"defect\(s\) in skip2.cc")
+        )
+
+    def test_per_file_skipfile_both_files_except_one(self):
+        """
+        Test: bazel test
+        //test/unit/skip:per_file_skipfile_both_files_except_one
+        """
+        ret, _, stderr = self.run_command(
+            "bazel test //test/unit/skip:"
+            "per_file_skipfile_both_files_except_one"
+        )
+        self.assertEqual(ret, 3, stderr)
+        log_file = (
+            f"{self.BAZEL_TESTLOGS_DIR}/"
+            "per_file_skipfile_both_files_except_one/test.log"
+        )
         self.assertTrue(
             self.contains_regex_in_file(log_file, r"defect\(s\) in skip.cc")
         )
-        # FIXME: Change to assertFalse after fix, should have been skipped.
-        self.assertTrue(
+        self.assertFalse(
             self.contains_regex_in_file(log_file, r"defect\(s\) in skip2.cc")
         )
 


### PR DESCRIPTION
Why:
There is no skipfile option for the per_file rule.
We should strive to solve this on the Bazel side, but in the meanwhile it is okay if we just create an empty plist file for skipped files.

What:
- Added skip option for the per_file rule.

Addresses:
Fixes: #160 
