### PR TITLE
Downgrade rules_cc in external unittest

### DIFF
--- a/test/unit/external_repository/MODULE.bazel
+++ b/test/unit/external_repository/MODULE.bazel
@@ -30,4 +30,4 @@ local_path_override(
 )
 
 bazel_dep(name = "external_lib")
-bazel_dep(name = "rules_cc", version = "0.2.17")
+bazel_dep(name = "rules_cc", version = "0.2.3")

--- a/test/unit/external_repository/third_party/my_lib/MODULE.bazel
+++ b/test/unit/external_repository/third_party/my_lib/MODULE.bazel
@@ -20,4 +20,4 @@ module(
     name = "external_lib",
 )
 
-bazel_dep(name = "rules_cc", version = "0.2.17")
+bazel_dep(name = "rules_cc", version = "0.2.3")


### PR DESCRIPTION
Why:
The version selected for rules_cc is too new for some bazel versions causing the tests to fail.

What:
- Downgraded rules_cc

Addresses:
none
