### PR TITLE
Fix buildifier setup

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -29,6 +29,6 @@ jobs:
 
     - name: Analyzing the code with Buildifier
       run: |
-        bazel test //:format_test --test_output=errors
+        bazel test //:buildifier --test_output=all
 
     # TODO: Add more linters here

--- a/BUILD
+++ b/BUILD
@@ -1,31 +1,14 @@
-load("@aspect_rules_lint//format:defs.bzl", "format_test")
 load("@buildifier_prebuilt//:rules.bzl", "buildifier_test")
 
 buildifier_test(
-    name = "buildifier_native",
-    diff_command = "diff -u",
+    name = "buildifier",
     exclude_patterns = [
         "./.git/*",
     ],
     lint_mode = "warn",
+    lint_warnings = ["all"],
     mode = "diff",
     no_sandbox = True,
-    workspace = "//:WORKSPACE",
-)
-
-format_test(
-    name = "format_test",
-    # Temporary workaround for not being able to use -diff_command
-    env = ["BUILDIFIER_DIFF='diff -u'"],
-    no_sandbox = True,
-    # TODO: extend with pylint
-    starlark = "@buildifier_prebuilt//:buildifier",
-    starlark_check_args = [
-        "-lint=warn",
-        "-warnings=all",
-        "-mode=diff",
-        # -u will always get passed to buildifier not diff_command
-        #"-diff_command=\"diff -u\"",
-    ],
+    verbose = True,
     workspace = "//:WORKSPACE",
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -21,10 +21,9 @@ bazel_dep(name = "rules_cc", version = "0.2.3")
 
 bazel_dep(
     name = "buildifier_prebuilt",
-    version = "6.4.0",
+    version = "7.3.1",
     dev_dependency = True,
 )
-bazel_dep(name = "aspect_rules_lint", version = "1.11.0", dev_dependency = True)
 
 codechecker_extension = use_extension(
     "//src:tools.bzl",

--- a/test/unit/generated_files/BUILD
+++ b/test/unit/generated_files/BUILD
@@ -40,6 +40,7 @@ cc_binary(
         "genrule_header_consumer.cc",
         ":genrule_header.h",
     ],
+    copts = ["-Wno-unused-variable"],
 )
 
 codechecker_test(

--- a/test/unit/legacy/BUILD
+++ b/test/unit/legacy/BUILD
@@ -46,6 +46,7 @@ cc_library(
 cc_library(
     name = "test_lib",
     srcs = ["src/lib.cc"],
+    copts = ["-Wno-unused-variable"],
 )
 
 # Test defect in CTU mode

--- a/test/unit/virtual_include/BUILD
+++ b/test/unit/virtual_include/BUILD
@@ -34,6 +34,7 @@ cc_library(
 cc_library(
     name = "virtual_include",
     srcs = ["source.cc"],
+    copts = ["-Wno-return-type"],
     deps = ["test_inc"],
 )
 


### PR DESCRIPTION
Why:
Buildifier setup is a bit excessive.
It can be improved.

What:
- Remove duplicating aspect_rules_lint
- Uplift buildifier version
- Silence warnings from compiler

Addresses: #155
