### PR TITLE
Define how to run tests

### DIFF
--- a/.ci/micromamba/init.sh
+++ b/.ci/micromamba/init.sh
@@ -69,10 +69,10 @@ if [[ "$VERBOSE" -ge 2 ]]; then
     micromamba info
 fi
 
-# Clean up previous environment
-info "Cleaning up previous environment [$ENV_NAME]..."
-chmod -R +w $THIS_DIR/micromamba/envs/dev
-rm -rf $THIS_DIR/micromamba/envs/dev
+# Make previous environment modifiable to avoid bazel cache related micromamba errors
+info "Changing permissions for previous environment [$ENV_NAME]..."
+chmod -R +w $THIS_DIR/micromamba/envs/$ENV_NAME
+
 micromamba deactivate
 # Create environment
 info "Creating environment [$ENV_NAME]..."

--- a/.ci/micromamba/init.sh
+++ b/.ci/micromamba/init.sh
@@ -69,7 +69,7 @@ if [[ "$VERBOSE" -ge 2 ]]; then
     micromamba info
 fi
 
-# Make previous environment modifiable to avoid bazel cache related micromamba errors
+# Make the leftover environment modifiable to allow micromamba to delete bazel cache folders during its setup
 info "Changing permissions for previous environment [$ENV_NAME]..."
 chmod -R +w $THIS_DIR/micromamba/envs/$ENV_NAME
 

--- a/.ci/micromamba/init.sh
+++ b/.ci/micromamba/init.sh
@@ -69,9 +69,13 @@ if [[ "$VERBOSE" -ge 2 ]]; then
     micromamba info
 fi
 
+# Clean up previous environment
+info "Cleaning up previous environment [$ENV_NAME]..."
+chmod -R +w $THIS_DIR/micromamba/envs/dev
+rm -rf $THIS_DIR/micromamba/envs/dev
+micromamba deactivate
 # Create environment
 info "Creating environment [$ENV_NAME]..."
-micromamba deactivate
 micromamba create --file $THIS_DIR/$ENV_NAME.yaml --name $ENV_NAME --yes $MAMBA_VERBOSITY
 # micromamba config set env_prompt "[{name}] "
 micromamba activate $ENV_NAME

--- a/.ci/micromamba/run_tests.sh
+++ b/.ci/micromamba/run_tests.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
+SCRIPT_DIR=$(dirname "$(realpath "$0")")
+cd $SCRIPT_DIR
+
 echo "Initialize micromamba environment..."
-source ./.ci/micromamba/init.sh
+source ./init.sh
+
+# Change directory to project root 
+cd ../../
 
 echo "Running pylint..."
 pylint .

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,4 +49,15 @@ test/test.sh                   | Functional and unit test runner
 Submitting a patch and testing
 -------
 
-Before submitting any changes please make sure all tests and checks are passed, pylint doesn't show warnings on new code, and fill out the Pull Request template. If you are a new contributor, and the template is confusing, feel free to submit the PR and we will help you iron it out! On how to run or add a new test, please see [test/README.md](test/README.md).
+Before submitting any changes please make sure all tests and checks are passed.
+
+You must run the following tests locally:
+* `pylint .`
+* `bazel test //...`
+* `pytest test`
+
+
+On how to run or add a new test, please see [test/README.md](test/README.md).
+
+
+Finally, fill out the Pull Request template. If you are a new contributor, and the template is confusing, feel free to submit the PR and we will help you iron it out!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,13 +49,16 @@ test/test.sh                   | Functional and unit test runner
 Submitting a patch and testing
 -------
 
-Before submitting any changes please make sure all tests and checks are passed.
+Before submitting any changes please make sure all tests and checks have passed inside the micromamba environment.
 
+To enable the Micromamba testing environment run `source .ci/micromamba/init.sh`.
+For more information see `.ci/micromamba/README.md`.
 You must run the following tests locally:
 * `pylint .`
 * `bazel test //...`
 * `pytest test`
 
+To run all these test inside the micromamba environment automatically, run `.ci/micromamba/run_tests.sh`.
 
 On how to run or add a new test, please see [test/README.md](test/README.md).
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# This script currently assumes that the user have set up their environment.
+# This means users using bazelisk have set their bazel version.
+# Either with the environment variable: USE_BAZEL_VERSION
+# or with the .bazelversion file.
+pylint .
+bazel test //...
+pytest test/

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,8 +1,4 @@
 #!/usr/bin/env bash
-echo "Clean up previous micromamba environment"
-chmod -R +w .ci/micromamba/micromamba/envs/dev
-rm -rf .ci/micromamba/micromamba/envs/dev
-
 echo "Initialize micromamba environment..."
 source ./.ci/micromamba/init.sh
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,16 +1,17 @@
 #!/usr/bin/env bash
+echo "Clean up previous micromamba environment"
+chmod -R +w .ci/micromamba/micromamba/envs/dev
+rm -rf .ci/micromamba/micromamba/envs/dev
 
-cleanup() {
-    # Very important
-    # reactivation of the mamba environment is not possible if skipped
-    bazel clean
-    micromamba deactivate
-}
-
-trap cleanup EXIT
-
+echo "Initialize micromamba environment..."
 source ./.ci/micromamba/init.sh
 
+echo "Running pylint..."
 pylint .
+echo "Running bazel test //..."
 bazel test //...
+echo "Running pytest ..."
 pytest test
+
+echo "Exiting micromamba..."
+micromamba deactivate

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,8 +1,16 @@
 #!/usr/bin/env bash
-# This script currently assumes that the user have set up their environment.
-# This means users using bazelisk have set their bazel version.
-# Either with the environment variable: USE_BAZEL_VERSION
-# or with the .bazelversion file.
+
+cleanup() {
+    # Very important
+    # reactivation of the mamba environment is not possible if skipped
+    bazel clean
+    micromamba deactivate
+}
+
+trap cleanup EXIT
+
+source ./.ci/micromamba/init.sh
+
 pylint .
 bazel test //...
-pytest test/
+pytest test


### PR DESCRIPTION
Why:
The requirements for running tests are not well defined.
This patch aims to define which targets should be run for testing.
This patch does not define how the user should set up their environment, only how the tests should be run. That is a todo for the next patch.

What:
- Added a script that runs all checks.
-  Modified the `CONTRIBUTING.md` to specify which tests must be run

Addresses:
none?