### PR TITLE
Fix buildifier for micromamba

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,1 +1,2 @@
+.ci/micromamba
 test/unit/external_repository

--- a/.ci/buildifier/BUILD
+++ b/.ci/buildifier/BUILD
@@ -1,0 +1,4 @@
+exports_files([
+    "prune.patch",
+    "template.patch",
+])

--- a/.ci/buildifier/prune.patch
+++ b/.ci/buildifier/prune.patch
@@ -1,0 +1,13 @@
+--- a/buildifier/factory.bzl
++++ b/buildifier/factory.bzl
+@@ -133,8 +133,8 @@
+     if ctx.attr.exclude_patterns:
+         if test_rule and not ctx.attr.no_sandbox:
+             fail("Cannot use 'exclude_patterns' in a test rule without 'no_sandbox'")
+-        exclude_patterns = ["\\! -path %s" % shell.quote(pattern) for pattern in ctx.attr.exclude_patterns]
+-        exclude_patterns_str = " ".join(exclude_patterns)
++        exclude_patterns = ["-path %s" % shell.quote(pattern) for pattern in ctx.attr.exclude_patterns]
++        exclude_patterns_str = "\\( " + " -o ".join(exclude_patterns) + " \\) -prune -o"
+ 
+     workspace = ""
+     if test_rule and ctx.attr.no_sandbox:

--- a/.ci/buildifier/template.patch
+++ b/.ci/buildifier/template.patch
@@ -1,0 +1,12 @@
+--- a/runner.bash.template
++++ b/runner.bash.template
+@@ -32,8 +32,8 @@
+ 
+ # Run buildifier on all starlark files
+ find . \
+-  -type "${FIND_FILE_TYPE:-f}" \
+   @@EXCLUDE_PATTERNS@@ \
++  -type "${FIND_FILE_TYPE:-f}" \
+   \( -name '*.bzl' \
+     -o -name '*.sky' \
+     -o -name '*.bazel' \

--- a/BUILD
+++ b/BUILD
@@ -5,9 +5,11 @@ buildifier_test(
     name = "buildifier_native",
     diff_command = "diff -u",
     exclude_patterns = [
+        "./.ci/*",
         "./.git/*",
     ],
     lint_mode = "warn",
+    lint_warnings = ["all"],
     mode = "diff",
     no_sandbox = True,
     workspace = "//:WORKSPACE",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -24,6 +24,15 @@ bazel_dep(
     version = "6.4.0",
     dev_dependency = True,
 )
+single_version_override(
+    module_name = "buildifier_prebuilt",
+    patch_strip = 1,
+    patches = [
+        "//.ci/buildifier:prune.patch",
+        "//.ci/buildifier:template.patch",
+    ],
+)
+
 bazel_dep(name = "aspect_rules_lint", version = "1.11.0", dev_dependency = True)
 
 codechecker_extension = use_extension(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -32,6 +32,11 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "buildifier_prebuilt",
+    patch_args = ["-p1"],
+    patches = [
+        "//.ci/buildifier:prune.patch",
+        "//.ci/buildifier:template.patch",
+    ],
     sha256 = "8ada9d88e51ebf5a1fdff37d75ed41d51f5e677cdbeafb0a22dda54747d6e07e",
     strip_prefix = "buildifier-prebuilt-6.4.0",
     urls = [


### PR DESCRIPTION
Why:
Buildifier, unfortunately does not work under Micromamba environment
because buildifier scans (find) all subdirectories including bazel output base dir
inside micromamba dir and some files cannot be read there, so it causes error.

What:
- Add patches for buildifier to prune excluded locations
- Test for Bazel 6.5 and 7.7

Test:

    source .ci/micromamba/init.sh
    bazel test :buildifier_native

Addresses: #155, #163