### PR TITLE
Fix README venv instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Install CodeChecker:
 
 ```bash
 python3 -m venv ./codechecker_venv && \
-source ./codechecker_venv && \
+source ./codechecker_venv/bin/activate && \
 pip3 install codechecker
 ```
 


### PR DESCRIPTION
We should source ./codechecker_venv/bin/activate.

Why:

`./codechecker_venv/` is a directory, it can't be sourced.

What:

Instead, source what we really should, the `acticvate` script.

Addresses:

-