### PR TITLE
Update README example to the latest commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ In Bazel 6, to activate the MODULE system, add `--enable_bzlmod` to the `.bazelr
 git_override(
     module_name = "rules_codechecker",
     remote = "https://github.com/Ericsson/rules_codechecker.git",
-    commit = "a32e9d75df4fb453c8bbfdf0fdf6a767797ae53d", # Update to latest
+    commit = "5ec36cdb443a9aab8b2503653d1c7fbff512d39e", # Update to latest
 )
 bazel_dep(name = "rules_codechecker")
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ In Bazel 6, to activate the MODULE system, add `--enable_bzlmod` to the `.bazelr
 git_override(
     module_name = "rules_codechecker",
     remote = "https://github.com/Ericsson/rules_codechecker.git",
-    commit = "5ec36cdb443a9aab8b2503653d1c7fbff512d39e", # Update to latest
+    commit = "<latest commit id>",
 )
 bazel_dep(name = "rules_codechecker")
 


### PR DESCRIPTION
Why:
The example commit is so old, it dates back to when this repo was called codechecker_bazel, which actually results in an error:
```
ERROR: Error computing the main repository mapping:
  in module dependency chain <root> -> rules_codechecker@_:
  the MODULE.bazel file of rules_codechecker@_ declares a different name (bazel_codechecker)
```

What:
Use the latest commit in the `MODULE.bazel` example snippet in README.

Addresses:

