### PR TITLE
Introduce CodeChecker toolchain

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -38,3 +38,7 @@ codechecker_extension = use_extension(
     "module_register_default_codechecker_tools",
 )
 use_repo(codechecker_extension, "default_codechecker_tools")
+
+register_toolchains(
+    "//src:codechecker_local_toolchain",
+)

--- a/README.md
+++ b/README.md
@@ -427,3 +427,83 @@ After that you can find all artifacts in `bazel-bin` directory:
     
     # compile_commands.json for compile_commands_pass
     cat bazel-bin/test/compile_commands_pass/compile_commands.json
+
+Toolchains
+----------
+
+The previous rules locate the CodeChecker, Clang and clang-tidy executables through a
+Bazel [toolchain](https://bazel.build/extending/toolchains). Modeling the tools
+as a toolchain means the analysis rule (`codechecker_test`) never hardcode binary paths:
+Bazel resolves the correct tools at build time, and you can override them
+per-project or per-platform without touching the rules themselves.
+
+### The default toolchain
+
+For most users no setup is required. `rules_codechecker` ships with a module
+extension that provisions a default set of tools and a pre-registered
+toolchain.
+
+> [!NOTE]
+> The default tools resolve to the `CodeChecker`, `clang` and `clang-tidy`
+> binaries available from PATH on your system (see the [Prerequisites](#prerequisites)).
+
+To enable it, add the following to your `MODULE.bazel`:
+
+```python
+codechecker_extension = use_extension(
+    "@rules_codechecker//src:tools.bzl",
+    "module_register_default_codechecker_tools",
+)
+use_repo(codechecker_extension, "default_codechecker_tools")
+register_toolchains("@rules_codechecker//src:codechecker_local_toolchain")
+```
+
+Or the following to your `WORKSPACE`:
+
+```python
+load(
+    "@rules_codechecker//src:tools.bzl",
+    "register_default_codechecker_tools",
+)
+
+register_default_codechecker_tools()
+register_toolchains(
+    "//src:codechecker_local_toolchain",
+)
+```
+
+### Providing your own tools
+
+If you don't want the default system tools -- for example to pin a specific
+CodeChecker version or point at a custom build —- you can define and register your own toolchain.
+
+First, define an implementation in a BUILD file with `codechecker_toolchain()`:
+
+```python
+load(
+    "@rules_codechecker//src:codechecker_toolchain.bzl",
+    "codechecker_toolchain",
+)
+
+codechecker_toolchain(
+    name = "codechecker_custom",
+    clang_tidy_binary  = "@my_tools//:clang-tidy",
+    clangsa_binary     = "@my_tools//:clang",
+    codechecker_binary = "@my_tools//:CodeChecker",
+)
+
+toolchain(
+    name = "codechecker_custom_toolchain",
+    toolchain = ":codechecker_custom",
+    toolchain_type = "@rules_codechecker//src:toolchain_type",
+    # Optionally constrain which execution platform this applies to:
+    # exec_compatible_with = ["@platforms//os:linux"],
+)
+```
+Finally register it in your `MODULE.bazel` (or `WORKSPACE`):
+```python
+register_toolchains("//path/to:codechecker_custom_toolchain")
+```
+
+[!NOTE]
+> Toolchains you register yourself take precedence over the default one if registered earlier.

--- a/README.md
+++ b/README.md
@@ -478,8 +478,6 @@ If you don't want the default system tools -- for example to pin a specific
 CodeChecker version or point at a custom build —- you can define and register your own toolchain.
 
 First, you will have to create or obtain labels for codechecker, clang and clang-tidy.
-In case you are unable to obtain a label for one, not defining the tool, will default to
-a target, pointing to the path given by `which <tool>`.
 
 Then define an implementation in a BUILD file with `codechecker_toolchain()`:
 

--- a/README.md
+++ b/README.md
@@ -477,7 +477,11 @@ register_toolchains(
 If you don't want the default system tools -- for example to pin a specific
 CodeChecker version or point at a custom build —- you can define and register your own toolchain.
 
-First, define an implementation in a BUILD file with `codechecker_toolchain()`:
+First, you will have to create or obtain labels for codechecker, clang and clang-tidy.
+In case you are unable to obtain a label for one, not defining the tool, will default to
+a target, pointing to the path given by `which <tool>`.
+
+Then define an implementation in a BUILD file with `codechecker_toolchain()`:
 
 ```python
 load(
@@ -487,9 +491,9 @@ load(
 
 codechecker_toolchain(
     name = "codechecker_custom",
-    clang_tidy_binary  = "@my_tools//:clang-tidy",
-    clangsa_binary     = "@my_tools//:clang",
-    codechecker_binary = "@my_tools//:CodeChecker",
+    clang_tidy  = "//example_target:clang-tidy",
+    clangsa     = "//example_target:clang",
+    codechecker = "//example_target:CodeChecker",
 )
 
 toolchain(

--- a/README.md
+++ b/README.md
@@ -479,6 +479,15 @@ CodeChecker version or point at a custom build —- you can define and register 
 
 First, you will have to create or obtain labels for codechecker, clang and clang-tidy.
 
+You may create such a label like this:
+```python
+filegroup(
+    name = "clang",
+    srcs = ["/usr/bin/clang"],
+    visibility = ["//visibility:public"],
+)
+```
+
 Then define an implementation in a BUILD file with `codechecker_toolchain()`:
 
 ```python

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -22,7 +22,10 @@ load(
 
 register_default_python_toolchain()
 
-register_toolchains("@default_python_tools//:python_toolchain")
+register_toolchains(
+    "@default_python_tools//:python_toolchain",
+    "//src:codechecker_local_toolchain",
+)
 
 register_default_codechecker_tools()
 

--- a/src/BUILD
+++ b/src/BUILD
@@ -73,7 +73,7 @@ codechecker_toolchain(
     name = "codechecker_local",
     clang_tidy_binary = "clang-tidy",
     clangsa_binary = "clang",
-    codechecker_binary = "CodeChecker",  # Find it in PATH ?
+    codechecker_binary = "@default_codechecker_tools//:CodeChecker",
 )
 
 toolchain(

--- a/src/BUILD
+++ b/src/BUILD
@@ -71,8 +71,8 @@ toolchain_type(name = "toolchain_type")
 
 codechecker_toolchain(
     name = "codechecker_local",
-    clang_tidy_binary = "clang-tidy",
-    clangsa_binary = "clang",
+    clang_tidy_binary = "@default_codechecker_tools//:clang_tidy",
+    clangsa_binary = "@default_codechecker_tools//:clang",
     codechecker_binary = "@default_codechecker_tools//:CodeChecker",
 )
 

--- a/src/BUILD
+++ b/src/BUILD
@@ -71,7 +71,9 @@ toolchain_type(name = "toolchain_type")
 
 codechecker_toolchain(
     name = "codechecker_local",
-    analyzer_binary = "CodeChecker",  # Find it in PATH ?
+    clang_tidy_binary = "clang-tidy",
+    clangsa_binary = "clang",
+    codechecker_binary = "CodeChecker",  # Find it in PATH ?
 )
 
 toolchain(

--- a/src/BUILD
+++ b/src/BUILD
@@ -71,9 +71,9 @@ toolchain_type(name = "toolchain_type")
 
 codechecker_toolchain(
     name = "codechecker_local",
-    clang_tidy_binary = "@default_codechecker_tools//:clang_tidy",
-    clangsa_binary = "@default_codechecker_tools//:clang",
-    codechecker_binary = "@default_codechecker_tools//:CodeChecker",
+    clang_tidy = "@default_codechecker_tools//:clang_tidy",
+    clangsa = "@default_codechecker_tools//:clang",
+    codechecker = "@default_codechecker_tools//:CodeChecker",
 )
 
 toolchain(

--- a/src/BUILD
+++ b/src/BUILD
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+load(":codechecker_toolchain.bzl", "codechecker_toolchain")
 
 # Tool filter compile_commands.json file
 # In bazel 6 we use our own python toolchain,
@@ -62,4 +63,19 @@ label_flag(
     name = "clang_tidy_additional_deps",
     build_setting_default = ":clang_tidy_additional_deps_default",
     visibility = ["//visibility:public"],
+)
+
+# named this by convention
+# https://bazel.build/extending/toolchains#:~:text=%23%20By%20convention%2C%20toolchain%5Ftype%20targets%20are%20named%20%22toolchain%5Ftype%22%20and
+toolchain_type(name = "toolchain_type")
+
+codechecker_toolchain(
+    name = "codechecker_local",
+    analyzer_binary = "CodeChecker",  # Find it in PATH ?
+)
+
+toolchain(
+    name = "codechecker_local_toolchain",
+    toolchain = "codechecker_local",
+    toolchain_type = ":toolchain_type",
 )

--- a/src/codechecker.bzl
+++ b/src/codechecker.bzl
@@ -103,10 +103,10 @@ def _codechecker_impl(ctx):
         substitutions = {
             "{Mode}": "Run",
             "{Verbosity}": "DEBUG",
-            "{clang_bin}": info.clangsa_bin.path,
-            "{clang_tidy_bin}": info.clang_tidy_bin.path,
+            "{clang_bin}": info.clangsa.path,
+            "{clang_tidy_bin}": info.clang_tidy.path,
             "{codechecker_analyze}": " ".join(ctx.attr.analyze),
-            "{codechecker_bin}": info.codechecker_bin.path,
+            "{codechecker_bin}": info.codechecker.path,
             "{codechecker_config}": config_file.path,
             "{codechecker_env}": codechecker_env,
             "{codechecker_files}": codechecker_files.path,
@@ -119,9 +119,9 @@ def _codechecker_impl(ctx):
     ctx.actions.run(
         inputs = depset(
             [
-                info.codechecker_bin,
-                info.clangsa_bin,
-                info.clang_tidy_bin,
+                info.codechecker,
+                info.clangsa,
+                info.clang_tidy,
                 ctx.outputs.codechecker_script,
                 ctx.outputs.codechecker_commands,
                 ctx.outputs.codechecker_skipfile,
@@ -242,9 +242,9 @@ def _codechecker_test_impl(ctx):
             "{Mode}": "Test",
             "{Severities}": " ".join(ctx.attr.severities),
             "{Verbosity}": "INFO",
-            "{clang_bin}": info.clangsa_bin.short_path,
-            "{clang_tidy_bin}": info.clang_tidy_bin.short_path,
-            "{codechecker_bin}": info.codechecker_bin.short_path,
+            "{clang_bin}": info.clangsa.short_path,
+            "{clang_tidy_bin}": info.clang_tidy.short_path,
+            "{codechecker_bin}": info.codechecker.short_path,
             "{codechecker_files}": codechecker_files.short_path,
         },
     )
@@ -252,9 +252,9 @@ def _codechecker_test_impl(ctx):
     # Return test script and all required files
     run_files = default_runfiles + [
         ctx.outputs.codechecker_test_script,
-        info.codechecker_bin,
-        info.clang_tidy_bin,
-        info.clangsa_bin,
+        info.codechecker,
+        info.clang_tidy,
+        info.clangsa,
     ]
     return [
         DefaultInfo(

--- a/src/codechecker.bzl
+++ b/src/codechecker.bzl
@@ -17,12 +17,6 @@ Rulesets for running codechecker in a single Bazel job.
 """
 
 load(
-    "@default_codechecker_tools//:defs.bzl",
-    "CLANG_BIN_PATH",
-    "CLANG_TIDY_BIN_PATH",
-    "CODECHECKER_BIN_PATH",
-)
-load(
     "codechecker_config.bzl",
     "codechecker_config_internal",
     "get_config_file",
@@ -99,6 +93,8 @@ def _codechecker_impl(ctx):
 
     config_file, codechecker_env = get_config_file(ctx)
 
+    info = ctx.toolchains["//src:toolchain_type"].codecheckerinfo
+
     codechecker_files = ctx.actions.declare_directory(ctx.label.name + "/codechecker-files")
     ctx.actions.expand_template(
         template = ctx.file._codechecker_script_template,
@@ -107,10 +103,10 @@ def _codechecker_impl(ctx):
         substitutions = {
             "{Mode}": "Run",
             "{Verbosity}": "DEBUG",
-            "{clang_bin}": CLANG_BIN_PATH,
-            "{clang_tidy_bin}": CLANG_TIDY_BIN_PATH,
+            "{clang_bin}": info.clangsa_bin.path,
+            "{clang_tidy_bin}": info.clang_tidy_bin.path,
             "{codechecker_analyze}": " ".join(ctx.attr.analyze),
-            "{codechecker_bin}": CODECHECKER_BIN_PATH,
+            "{codechecker_bin}": info.codechecker_bin.path,
             "{codechecker_config}": config_file.path,
             "{codechecker_env}": codechecker_env,
             "{codechecker_files}": codechecker_files.path,
@@ -123,6 +119,9 @@ def _codechecker_impl(ctx):
     ctx.actions.run(
         inputs = depset(
             [
+                info.codechecker_bin,
+                info.clangsa_bin,
+                info.clang_tidy_bin,
                 ctx.outputs.codechecker_script,
                 ctx.outputs.codechecker_commands,
                 ctx.outputs.codechecker_skipfile,
@@ -209,7 +208,10 @@ codechecker = rule(
         "codechecker_skipfile": "%{name}/codechecker_skipfile.cfg",
         "compile_commands": "%{name}/compile_commands.json",
     },
-    toolchains = [python_toolchain_type()],
+    toolchains = [
+        python_toolchain_type(),
+        "//src:toolchain_type",
+    ],
 )
 
 def _codechecker_test_impl(ctx):
@@ -229,6 +231,8 @@ def _codechecker_test_impl(ctx):
     if not codechecker_files:
         fail("Execution results required for codechecker test are not available")
 
+    info = ctx.toolchains["//src:toolchain_type"].codecheckerinfo
+
     # Create test script from template
     ctx.actions.expand_template(
         template = ctx.file._codechecker_script_template,
@@ -238,15 +242,20 @@ def _codechecker_test_impl(ctx):
             "{Mode}": "Test",
             "{Severities}": " ".join(ctx.attr.severities),
             "{Verbosity}": "INFO",
-            "{clang_bin}": CLANG_BIN_PATH,
-            "{clang_tidy_bin}": CLANG_TIDY_BIN_PATH,
-            "{codechecker_bin}": CODECHECKER_BIN_PATH,
+            "{clang_bin}": info.clangsa_bin.short_path,
+            "{clang_tidy_bin}": info.clang_tidy_bin.short_path,
+            "{codechecker_bin}": info.codechecker_bin.short_path,
             "{codechecker_files}": codechecker_files.short_path,
         },
     )
 
     # Return test script and all required files
-    run_files = default_runfiles + [ctx.outputs.codechecker_test_script]
+    run_files = default_runfiles + [
+        ctx.outputs.codechecker_test_script,
+        info.codechecker_bin,
+        info.clang_tidy_bin,
+        info.clangsa_bin,
+    ]
     return [
         DefaultInfo(
             files = depset(all_files),
@@ -306,7 +315,10 @@ _codechecker_test = rule(
         "codechecker_test_script": "%{name}/codechecker_test_script.py",
         "compile_commands": "%{name}/compile_commands.json",
     },
-    toolchains = [python_toolchain_type()],
+    toolchains = [
+        python_toolchain_type(),
+        "//src:toolchain_type",
+    ],
     test = True,
 )
 

--- a/src/codechecker_script.py
+++ b/src/codechecker_script.py
@@ -30,8 +30,8 @@ import sys
 EXECUTION_MODE = "{Mode}"
 VERBOSITY = "{Verbosity}"
 CODECHECKER_PATH = os.path.realpath("{codechecker_bin}")
-CLANG_PATH = "{clang_bin}"
-CLANG_TIDY_PATH = "{clang_tidy_bin}"
+CLANG_PATH = os.path.realpath("{clang_bin}")
+CLANG_TIDY_PATH = os.path.realpath("{clang_tidy_bin}")
 CODECHECKER_SKIPFILE = "{codechecker_skipfile}"
 CODECHECKER_CONFIG = "{codechecker_config}"
 CODECHECKER_ANALYZE = "{codechecker_analyze}"

--- a/src/codechecker_script.py
+++ b/src/codechecker_script.py
@@ -29,7 +29,7 @@ import sys
 
 EXECUTION_MODE = "{Mode}"
 VERBOSITY = "{Verbosity}"
-CODECHECKER_PATH = "{codechecker_bin}"
+CODECHECKER_PATH = os.path.realpath("{codechecker_bin}")
 CLANG_PATH = "{clang_bin}"
 CLANG_TIDY_PATH = "{clang_tidy_bin}"
 CODECHECKER_SKIPFILE = "{codechecker_skipfile}"

--- a/src/codechecker_toolchain.bzl
+++ b/src/codechecker_toolchain.bzl
@@ -5,18 +5,18 @@ This file provides the toolchain rule for CodeChecker
 CodeCheckerInfo = provider(
     doc = "This provider provides the executable path for CodeChecker and its related tools",
     fields = {
-        "clang_tidy_bin": "clang-tidy executable",
-        "clangsa_bin": "Clang executable",
-        "codechecker_bin": "CodeChecker executable",
+        "clang_tidy": "clang-tidy executable",
+        "clangsa": "Clang executable",
+        "codechecker": "CodeChecker executable",
     },
 )
 
 def _codechecker_toolchain_impl(ctx):
     toolchain_info = platform_common.ToolchainInfo(
         codecheckerinfo = CodeCheckerInfo(
-            codechecker_bin = ctx.executable.codechecker_binary,
-            clang_tidy_bin = ctx.executable.clang_tidy_binary,
-            clangsa_bin = ctx.executable.clangsa_binary,
+            codechecker = ctx.executable.codechecker,
+            clang_tidy = ctx.executable.clang_tidy,
+            clangsa = ctx.executable.clangsa,
         ),
     )
     return [toolchain_info]
@@ -24,19 +24,19 @@ def _codechecker_toolchain_impl(ctx):
 codechecker_toolchain = rule(
     implementation = _codechecker_toolchain_impl,
     attrs = {
-        "clang_tidy_binary": attr.label(
+        "clang_tidy": attr.label(
             doc = "clang-tidy executable",
             allow_single_file = True,
             executable = True,
             cfg = "exec",
         ),
-        "clangsa_binary": attr.label(
+        "clangsa": attr.label(
             doc = "clang executable",
             allow_single_file = True,
             executable = True,
             cfg = "exec",
         ),
-        "codechecker_binary": attr.label(
+        "codechecker": attr.label(
             doc = "CodeChecker executable",
             allow_single_file = True,
             executable = True,

--- a/src/codechecker_toolchain.bzl
+++ b/src/codechecker_toolchain.bzl
@@ -15,8 +15,8 @@ def _codechecker_toolchain_impl(ctx):
     toolchain_info = platform_common.ToolchainInfo(
         codecheckerinfo = CodeCheckerInfo(
             codechecker_bin = ctx.executable.codechecker_binary,
-            clang_tidy_bin = ctx.attr.clang_tidy_binary,
-            clangsa_bin = ctx.attr.clangsa_binary,
+            clang_tidy_bin = ctx.executable.clang_tidy_binary,
+            clangsa_bin = ctx.executable.clangsa_binary,
         ),
     )
     return [toolchain_info]
@@ -24,10 +24,20 @@ def _codechecker_toolchain_impl(ctx):
 codechecker_toolchain = rule(
     implementation = _codechecker_toolchain_impl,
     attrs = {
-        "clang_tidy_binary": attr.string(),
-        "clangsa_binary": attr.string(),
+        "clang_tidy_binary": attr.label(
+            doc = "clang-tidy executable",
+            allow_single_file = True,
+            executable = True,
+            cfg = "exec",
+        ),
+        "clangsa_binary": attr.label(
+            doc = "clang executable",
+            allow_single_file = True,
+            executable = True,
+            cfg = "exec",
+        ),
         "codechecker_binary": attr.label(
-            doc = "CodeChecker executable label",
+            doc = "CodeChecker executable",
             allow_single_file = True,
             executable = True,
             cfg = "exec",

--- a/src/codechecker_toolchain.bzl
+++ b/src/codechecker_toolchain.bzl
@@ -14,7 +14,7 @@ CodeCheckerInfo = provider(
 def _codechecker_toolchain_impl(ctx):
     toolchain_info = platform_common.ToolchainInfo(
         codecheckerinfo = CodeCheckerInfo(
-            codechecker_bin = ctx.attr.codechecker_binary,
+            codechecker_bin = ctx.executable.codechecker_binary,
             clang_tidy_bin = ctx.attr.clang_tidy_binary,
             clangsa_bin = ctx.attr.clangsa_binary,
         ),
@@ -26,6 +26,11 @@ codechecker_toolchain = rule(
     attrs = {
         "clang_tidy_binary": attr.string(),
         "clangsa_binary": attr.string(),
-        "codechecker_binary": attr.string(),
+        "codechecker_binary": attr.label(
+            doc = "CodeChecker executable label",
+            allow_single_file = True,
+            executable = True,
+            cfg = "exec",
+        ),
     },
 )

--- a/src/codechecker_toolchain.bzl
+++ b/src/codechecker_toolchain.bzl
@@ -25,22 +25,25 @@ codechecker_toolchain = rule(
     implementation = _codechecker_toolchain_impl,
     attrs = {
         "clang_tidy": attr.label(
-            doc = "clang-tidy executable",
+            doc = "Executable target for `clang-tidy`. Defaults to the `clang-tidy` binary discovered on `PATH`.",
             allow_single_file = True,
             executable = True,
             cfg = "exec",
+            default = Label("@default_codechecker_tools//:clang_tidy"),
         ),
         "clangsa": attr.label(
-            doc = "clang executable",
+            doc = "Executable target for `clang`, used for Clang Static Analyzer. Defaults to the `clang` binary discovered on `PATH`.",
             allow_single_file = True,
             executable = True,
             cfg = "exec",
+            default = Label("@default_codechecker_tools//:clang"),
         ),
         "codechecker": attr.label(
-            doc = "CodeChecker executable",
+            doc = "Executable target for `CodeChecker`. Defaults to the `CodeChecker` binary discovered on `PATH`.",
             allow_single_file = True,
             executable = True,
             cfg = "exec",
+            default = Label("@default_codechecker_tools//:CodeChecker"),
         ),
     },
 )

--- a/src/codechecker_toolchain.bzl
+++ b/src/codechecker_toolchain.bzl
@@ -3,16 +3,20 @@ This file provides the toolchain rule for CodeChecker
 """
 
 CodeCheckerInfo = provider(
-    doc = "This provider provides the executable path for CodeChecker",
-    fields = [
-        "executable",
-    ],
+    doc = "This provider provides the executable path for CodeChecker and its related tools",
+    fields = {
+        "clang_tidy_bin": "clang-tidy executable",
+        "clangsa_bin": "Clang executable",
+        "codechecker_bin": "CodeChecker executable",
+    },
 )
 
 def _codechecker_toolchain_impl(ctx):
     toolchain_info = platform_common.ToolchainInfo(
         codecheckerinfo = CodeCheckerInfo(
-            executable = ctx.attr.analyzer_binary,
+            codechecker_bin = ctx.attr.codechecker_binary,
+            clang_tidy_bin = ctx.attr.clang_tidy_binary,
+            clangsa_bin = ctx.attr.clangsa_binary,
         ),
     )
     return [toolchain_info]
@@ -20,6 +24,8 @@ def _codechecker_toolchain_impl(ctx):
 codechecker_toolchain = rule(
     implementation = _codechecker_toolchain_impl,
     attrs = {
-        "analyzer_binary": attr.string(),
+        "clang_tidy_binary": attr.string(),
+        "clangsa_binary": attr.string(),
+        "codechecker_binary": attr.string(),
     },
 )

--- a/src/codechecker_toolchain.bzl
+++ b/src/codechecker_toolchain.bzl
@@ -1,0 +1,25 @@
+"""
+This file provides the toolchain rule for CodeChecker
+"""
+
+CodeCheckerInfo = provider(
+    doc = "This provider provides the executable path for CodeChecker",
+    fields = [
+        "executable",
+    ],
+)
+
+def _codechecker_toolchain_impl(ctx):
+    toolchain_info = platform_common.ToolchainInfo(
+        codecheckerinfo = CodeCheckerInfo(
+            executable = ctx.attr.analyzer_binary,
+        ),
+    )
+    return [toolchain_info]
+
+codechecker_toolchain = rule(
+    implementation = _codechecker_toolchain_impl,
+    attrs = {
+        "analyzer_binary": attr.string(),
+    },
+)

--- a/src/codechecker_toolchain.bzl
+++ b/src/codechecker_toolchain.bzl
@@ -25,25 +25,22 @@ codechecker_toolchain = rule(
     implementation = _codechecker_toolchain_impl,
     attrs = {
         "clang_tidy": attr.label(
-            doc = "Executable target for `clang-tidy`. Defaults to the `clang-tidy` binary discovered on `PATH`.",
+            doc = "Executable target for `clang-tidy`.",
             allow_single_file = True,
             executable = True,
             cfg = "exec",
-            default = Label("@default_codechecker_tools//:clang_tidy"),
         ),
         "clangsa": attr.label(
-            doc = "Executable target for `clang`, used for Clang Static Analyzer. Defaults to the `clang` binary discovered on `PATH`.",
+            doc = "Executable target for `clang`, used for Clang Static Analyzer.",
             allow_single_file = True,
             executable = True,
             cfg = "exec",
-            default = Label("@default_codechecker_tools//:clang"),
         ),
         "codechecker": attr.label(
-            doc = "Executable target for `CodeChecker`. Defaults to the `CodeChecker` binary discovered on `PATH`.",
+            doc = "Executable target for `CodeChecker`.",
             allow_single_file = True,
             executable = True,
             cfg = "exec",
-            default = Label("@default_codechecker_tools//:CodeChecker"),
         ),
     },
 )

--- a/src/per_file.bzl
+++ b/src/per_file.bzl
@@ -59,6 +59,8 @@ def _run_code_checker(
         content = "\n".join(ctx.attr.skip),
     )
 
+    info = ctx.toolchains["//src:toolchain_type"].codecheckerinfo
+
     if "--ctu" in options:
         inputs = [
             compile_commands_json,
@@ -86,6 +88,7 @@ def _run_code_checker(
         outputs = outputs,
         executable = ctx.outputs.per_file_script,
         arguments = [
+            info.executable,
             data_dir,
             src.path,
             codechecker_log.path,
@@ -155,6 +158,8 @@ def _create_wrapper_script(ctx, options, compile_commands_json, config_file):
     )
 
 def _per_file_impl(ctx):
+    info = ctx.toolchains["//src:toolchain_type"].codecheckerinfo
+    print("CodeChecker path resolved:", info.executable)
     compile_commands = None
     for output in compile_commands_impl(ctx):
         if type(output) == "DefaultInfo":
@@ -258,4 +263,5 @@ per_file_test = rule(
         "test_script": "%{name}/test_script.sh",
     },
     test = True,
+    toolchains = ["//src:toolchain_type"],
 )

--- a/src/per_file.bzl
+++ b/src/per_file.bzl
@@ -66,9 +66,9 @@ def _run_code_checker(
             compile_commands_json,
             config_file,
             config,
-            info.codechecker_bin,
-            info.clangsa_bin,
-            info.clang_tidy_bin,
+            info.codechecker,
+            info.clangsa,
+            info.clang_tidy,
         ] + sources_and_headers
     else:
         # NOTE: we collect only headers, so CTU may not work!
@@ -78,9 +78,9 @@ def _run_code_checker(
             config_file,
             src,
             config,
-            info.codechecker_bin,
-            info.clangsa_bin,
-            info.clang_tidy_bin,
+            info.codechecker,
+            info.clangsa,
+            info.clang_tidy,
         ], transitive = [headers])
 
     outputs = [clang_tidy_plist, clangsa_plist, codechecker_log]
@@ -88,8 +88,8 @@ def _run_code_checker(
     analyzer_output_paths = "clangsa," + clangsa_plist.path + \
                             ";clang-tidy," + clang_tidy_plist.path
 
-    analyzer_executables = "clangsa:" + info.clangsa_bin.path + \
-                           ";clang-tidy:" + info.clang_tidy_bin.path
+    analyzer_executables = "clangsa:" + info.clangsa.path + \
+                           ";clang-tidy:" + info.clang_tidy.path
 
     # Action to run CodeChecker for a file
     ctx.actions.run(
@@ -97,7 +97,7 @@ def _run_code_checker(
         outputs = outputs,
         executable = ctx.outputs.per_file_script,
         arguments = [
-            info.codechecker_bin.path,
+            info.codechecker.path,
             data_dir,
             src.path,
             codechecker_log.path,

--- a/src/per_file.bzl
+++ b/src/per_file.bzl
@@ -82,18 +82,22 @@ def _run_code_checker(
     analyzer_output_paths = "clangsa," + clangsa_plist.path + \
                             ";clang-tidy," + clang_tidy_plist.path
 
+    analyzer_executables = "clangsa:" + info.clangsa_bin + \
+                           ";clang-tidy:" + info.clang_tidy_bin
+
     # Action to run CodeChecker for a file
     ctx.actions.run(
         inputs = inputs,
         outputs = outputs,
         executable = ctx.outputs.per_file_script,
         arguments = [
-            info.executable,
+            info.codechecker_bin,
             data_dir,
             src.path,
             codechecker_log.path,
             config.path,
             analyzer_output_paths,
+            analyzer_executables,
         ],
         mnemonic = "CodeChecker",
         use_default_shell_env = True,
@@ -158,8 +162,6 @@ def _create_wrapper_script(ctx, options, compile_commands_json, config_file):
     )
 
 def _per_file_impl(ctx):
-    info = ctx.toolchains["//src:toolchain_type"].codecheckerinfo
-    print("CodeChecker path resolved:", info.executable)
     compile_commands = None
     for output in compile_commands_impl(ctx):
         if type(output) == "DefaultInfo":

--- a/src/per_file.bzl
+++ b/src/per_file.bzl
@@ -59,6 +59,7 @@ def _run_code_checker(
         content = "\n".join(ctx.attr.skip),
     )
 
+    # TODO: Consider using aliases so we don't have to type //src: everywhere.
     info = ctx.toolchains["//src:toolchain_type"].codecheckerinfo
 
     if "--ctu" in options:

--- a/src/per_file.bzl
+++ b/src/per_file.bzl
@@ -67,6 +67,8 @@ def _run_code_checker(
             config_file,
             config,
             info.codechecker_bin,
+            info.clangsa_bin,
+            info.clang_tidy_bin,
         ] + sources_and_headers
     else:
         # NOTE: we collect only headers, so CTU may not work!
@@ -77,6 +79,8 @@ def _run_code_checker(
             src,
             config,
             info.codechecker_bin,
+            info.clangsa_bin,
+            info.clang_tidy_bin,
         ], transitive = [headers])
 
     outputs = [clang_tidy_plist, clangsa_plist, codechecker_log]
@@ -84,8 +88,8 @@ def _run_code_checker(
     analyzer_output_paths = "clangsa," + clangsa_plist.path + \
                             ";clang-tidy," + clang_tidy_plist.path
 
-    analyzer_executables = "clangsa:" + info.clangsa_bin + \
-                           ";clang-tidy:" + info.clang_tidy_bin
+    analyzer_executables = "clangsa:" + info.clangsa_bin.path + \
+                           ";clang-tidy:" + info.clang_tidy_bin.path
 
     # Action to run CodeChecker for a file
     ctx.actions.run(

--- a/src/per_file.bzl
+++ b/src/per_file.bzl
@@ -66,6 +66,7 @@ def _run_code_checker(
             compile_commands_json,
             config_file,
             config,
+            info.codechecker_bin,
         ] + sources_and_headers
     else:
         # NOTE: we collect only headers, so CTU may not work!
@@ -75,6 +76,7 @@ def _run_code_checker(
             config_file,
             src,
             config,
+            info.codechecker_bin,
         ], transitive = [headers])
 
     outputs = [clang_tidy_plist, clangsa_plist, codechecker_log]
@@ -91,7 +93,7 @@ def _run_code_checker(
         outputs = outputs,
         executable = ctx.outputs.per_file_script,
         arguments = [
-            info.codechecker_bin,
+            info.codechecker_bin.path,
             data_dir,
             src.path,
             codechecker_log.path,

--- a/src/per_file_script.py
+++ b/src/per_file_script.py
@@ -28,14 +28,15 @@ COMPILE_COMMANDS_JSON: str = "{compile_commands_json}"
 COMPILE_COMMANDS_ABSOLUTE: str = f"{COMPILE_COMMANDS_JSON}.abs"
 CODECHECKER_ARGS: str = "{codechecker_args}"
 CONFIG_FILE: str = "{config_file}"
-SKIP_FILE: str = sys.argv[4]
+SKIP_FILE: str = sys.argv[5]
+CODECHECKER_BIN = sys.argv[1]
 # The output directory for CodeChecker
-DATA_DIR = sys.argv[1]
+DATA_DIR = sys.argv[2]
 # The file to be analyzed
-FILE_PATH = sys.argv[2]
-LOG_FILE = sys.argv[3]
+FILE_PATH = sys.argv[3]
+LOG_FILE = sys.argv[4]
 # List of pairs of analyzers and their plist files
-ANALYZER_PLIST_PATHS = [item.split(",") for item in sys.argv[5].split(";")]
+ANALYZER_PLIST_PATHS = [item.split(",") for item in sys.argv[6].split(";")]
 
 EMPTY_PLIST = """<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -86,7 +87,7 @@ def _run_codechecker() -> None:
     Runs CodeChecker analyze
     """
     codechecker_cmd: list[str] = (
-        ["CodeChecker", "analyze"]
+        [CODECHECKER_BIN, "analyze"]
         + CODECHECKER_ARGS.split()
         + ["--output=" + DATA_DIR]
         + ["--file=*/" + FILE_PATH]
@@ -173,7 +174,7 @@ def main():
     """
     Main function of CodeChecker wrapper
     """
-    if len(sys.argv) != 6:
+    if len(sys.argv) != 7:
         print("Wrong amount of arguments")
         sys.exit(1)
     _create_compile_commands_json_with_absolute_paths()

--- a/src/per_file_script.py
+++ b/src/per_file_script.py
@@ -37,6 +37,7 @@ FILE_PATH = sys.argv[3]
 LOG_FILE = sys.argv[4]
 # List of pairs of analyzers and their plist files
 ANALYZER_PLIST_PATHS = [item.split(",") for item in sys.argv[6].split(";")]
+ANALYZER_EXECUTABLES_ENV_VAR = sys.argv[7]
 
 EMPTY_PLIST = """<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -82,6 +83,15 @@ def _create_compile_commands_json_with_absolute_paths():
         new_file.write(new_content)
 
 
+def _get_codechecker_env() -> dict[str, str]:
+    """
+    Returns the environment for running CodeChecker
+    """
+    cc_env = os.environ.copy()
+    # Overwrite analyzer paths
+    cc_env["CC_ANALYZER_BIN"] = ANALYZER_EXECUTABLES_ENV_VAR
+    return cc_env
+
 def _run_codechecker() -> None:
     """
     Runs CodeChecker analyze
@@ -103,7 +113,7 @@ def _run_codechecker() -> None:
     result = subprocess.run(
         ["echo", "$PATH"],
         shell=True,
-        env=os.environ,
+        env=_get_codechecker_env(),
         capture_output=True,
         text=True,
         check=False,
@@ -114,7 +124,7 @@ def _run_codechecker() -> None:
         with open(LOG_FILE, "a", encoding="utf-8") as log_file:
             subprocess.run(
                 codechecker_cmd,
-                env=os.environ,
+                env=_get_codechecker_env(),
                 stdout=log_file,
                 stderr=log_file,
                 check=True,
@@ -174,7 +184,7 @@ def main():
     """
     Main function of CodeChecker wrapper
     """
-    if len(sys.argv) != 7:
+    if len(sys.argv) != 8:
         print("Wrong amount of arguments")
         sys.exit(1)
     _create_compile_commands_json_with_absolute_paths()

--- a/src/per_file_script.py
+++ b/src/per_file_script.py
@@ -37,7 +37,13 @@ FILE_PATH = sys.argv[3]
 LOG_FILE = sys.argv[4]
 # List of pairs of analyzers and their plist files
 ANALYZER_PLIST_PATHS = [item.split(",") for item in sys.argv[6].split(";")]
-ANALYZER_EXECUTABLES_ENV_VAR = sys.argv[7]
+ANALYZER_EXECUTABLES_ENV_VAR = ";".join(
+    f"{name}:{os.path.realpath(path)}"
+    for name, path in [
+        pair.split(":", 1) for pair in sys.argv[7].split(";") if pair
+    ]
+)
+
 
 EMPTY_PLIST = """<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -91,6 +97,7 @@ def _get_codechecker_env() -> dict[str, str]:
     # Overwrite analyzer paths
     cc_env["CC_ANALYZER_BIN"] = ANALYZER_EXECUTABLES_ENV_VAR
     return cc_env
+
 
 def _run_codechecker() -> None:
     """

--- a/src/per_file_script.py
+++ b/src/per_file_script.py
@@ -29,7 +29,7 @@ COMPILE_COMMANDS_ABSOLUTE: str = f"{COMPILE_COMMANDS_JSON}.abs"
 CODECHECKER_ARGS: str = "{codechecker_args}"
 CONFIG_FILE: str = "{config_file}"
 SKIP_FILE: str = sys.argv[5]
-CODECHECKER_BIN = sys.argv[1]
+CODECHECKER_BIN = os.path.realpath(sys.argv[1])
 # The output directory for CodeChecker
 DATA_DIR = sys.argv[2]
 # The file to be analyzed

--- a/src/tools.bzl
+++ b/src/tools.bzl
@@ -97,12 +97,6 @@ module_register_default_python_toolchain = module_extension(
 )
 
 def _codechecker_local_repository_impl(repository_ctx):
-    repository_ctx.file(
-        repository_ctx.path("BUILD"),
-        content = "",
-        executable = False,
-    )
-
     codechecker_bin_path = repository_ctx.which("CodeChecker")
     if not codechecker_bin_path:
         fail("ERROR! CodeChecker is not detected")
@@ -120,6 +114,20 @@ def _codechecker_local_repository_impl(repository_ctx):
     repository_ctx.file(
         repository_ctx.path("defs.bzl"),
         content = defs,
+        executable = False,
+    )
+
+    repository_ctx.symlink(codechecker_bin_path, "codechecker_bin")
+
+    repository_ctx.file(
+        repository_ctx.path("BUILD"),
+        content = """
+filegroup(
+    name = "CodeChecker",
+    srcs = ["codechecker_bin"],
+    visibility = ["//visibility:public"],
+)
+        """,
         executable = False,
     )
 

--- a/src/tools.bzl
+++ b/src/tools.bzl
@@ -117,7 +117,12 @@ def _codechecker_local_repository_impl(repository_ctx):
         executable = False,
     )
 
+    clang_bin_path = repository_ctx.which("clang")
+    clang_tidy_bin_path = repository_ctx.which("clang-tidy")
+
     repository_ctx.symlink(codechecker_bin_path, "codechecker_bin")
+    repository_ctx.symlink(clang_bin_path, "clang_bin")
+    repository_ctx.symlink(clang_tidy_bin_path, "clang_tidy_bin")
 
     repository_ctx.file(
         repository_ctx.path("BUILD"),
@@ -125,6 +130,16 @@ def _codechecker_local_repository_impl(repository_ctx):
 filegroup(
     name = "CodeChecker",
     srcs = ["codechecker_bin"],
+    visibility = ["//visibility:public"],
+)
+filegroup(
+    name = "clang",
+    srcs = ["clang_bin"],
+    visibility = ["//visibility:public"],
+)
+filegroup(
+    name = "clang_tidy",
+    srcs = ["clang_tidy_bin"],
     visibility = ["//visibility:public"],
 )
         """,

--- a/src/tools.bzl
+++ b/src/tools.bzl
@@ -117,9 +117,6 @@ def _codechecker_local_repository_impl(repository_ctx):
         executable = False,
     )
 
-    clang_bin_path = repository_ctx.which("clang")
-    clang_tidy_bin_path = repository_ctx.which("clang-tidy")
-
     repository_ctx.symlink(codechecker_bin_path, "codechecker_bin")
     repository_ctx.symlink(clang_bin_path, "clang_bin")
     repository_ctx.symlink(clang_tidy_bin_path, "clang_tidy_bin")

--- a/test/foss/templates/WORKSPACE.template
+++ b/test/foss/templates/WORKSPACE.template
@@ -14,7 +14,10 @@ load(
 )
 
 register_default_python_toolchain()
-register_toolchains("@default_python_tools//:python_toolchain")
+register_toolchains(
+    "@default_python_tools//:python_toolchain",
+    "@rules_codechecker//src:codechecker_local_toolchain",
+)
 
 register_default_codechecker_tools()
 


### PR DESCRIPTION
Why:
We want to use toolchains to determine which CodeChecker binary to use.

What:
- Created a toolchain for CodeChecker following the Bazel documentation (https://bazel.build/extending/toolchains)
- Made both CodeChecker rules use the toolchain
- Added documentation for the toolchain

Addresses:
none

Notes:
- Looking around in other toolchains: [rules_go](https://github.com/bazel-contrib/rules_go) and [rules_python](https://github.com/bazel-contrib/rules_python) it seems toolchains are usually under a folder named the program - in out case CodeChecker (python for rules_python, go for rules_go) - this seems to be to have the toolchain path be `//codechecker:toolchain_type` instead of `//src:toolchain_type`.