### PR TITLE
Remove aspect lint

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -29,6 +29,6 @@ jobs:
 
     - name: Analyzing the code with Buildifier
       run: |
-        bazel test //:format_test --test_output=errors
+        bazel test //:buildifier --test_output=all
 
     # TODO: Add more linters here

--- a/BUILD
+++ b/BUILD
@@ -1,9 +1,7 @@
-load("@aspect_rules_lint//format:defs.bzl", "format_test")
 load("@buildifier_prebuilt//:rules.bzl", "buildifier_test")
 
 buildifier_test(
-    name = "buildifier_native",
-    diff_command = "diff -u",
+    name = "buildifier",
     exclude_patterns = [
         "./.ci/*",
         "./.git/*",
@@ -12,22 +10,6 @@ buildifier_test(
     lint_warnings = ["all"],
     mode = "diff",
     no_sandbox = True,
-    workspace = "//:WORKSPACE",
-)
-
-format_test(
-    name = "format_test",
-    # Temporary workaround for not being able to use -diff_command
-    env = ["BUILDIFIER_DIFF='diff -u'"],
-    no_sandbox = True,
-    # TODO: extend with pylint
-    starlark = "@buildifier_prebuilt//:buildifier",
-    starlark_check_args = [
-        "-lint=warn",
-        "-warnings=all",
-        "-mode=diff",
-        # -u will always get passed to buildifier not diff_command
-        #"-diff_command=\"diff -u\"",
-    ],
+    verbose = True,
     workspace = "//:WORKSPACE",
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -21,7 +21,7 @@ bazel_dep(name = "rules_cc", version = "0.2.3")
 
 bazel_dep(
     name = "buildifier_prebuilt",
-    version = "6.4.0",
+    version = "7.3.1",
     dev_dependency = True,
 )
 single_version_override(
@@ -32,8 +32,6 @@ single_version_override(
         "//.ci/buildifier:template.patch",
     ],
 )
-
-bazel_dep(name = "aspect_rules_lint", version = "1.11.0", dev_dependency = True)
 
 codechecker_extension = use_extension(
     "//src:tools.bzl",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -55,29 +55,3 @@ bazel_skylib_workspace()
 load("@buildifier_prebuilt//:defs.bzl", "buildifier_prebuilt_register_toolchains")
 
 buildifier_prebuilt_register_toolchains()
-
-http_archive(
-    name = "aspect_rules_lint",
-    sha256 = "329cf5ba776a75b70049a5695e9ca29a25113230f4f447aff7102b62afe7c24a",
-    strip_prefix = "rules_lint-1.11.0",
-    url = "https://github.com/aspect-build/rules_lint/releases/download/v1.11.0/rules_lint-v1.11.0.tar.gz",
-)
-
-http_archive(
-    name = "bazel_lib",
-    sha256 = "0758ace949a93f709230a8e08ef35c5f0aacae2ff5d219b27da1d21d8233a709",
-    strip_prefix = "bazel-lib-3.0.0-rc.0",
-    url = "https://github.com/bazel-contrib/bazel-lib/releases/download/v3.0.0-rc.0/bazel-lib-v3.0.0-rc.0.tar.gz",
-)
-
-load("@bazel_lib//lib:repositories.bzl", "bazel_lib_dependencies")
-
-bazel_lib_dependencies()
-
-load(
-    "@aspect_rules_lint//format:repositories.bzl",
-    # Fetch additional formatter binaries you need:
-    "rules_lint_dependencies",
-)
-
-rules_lint_dependencies()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -37,10 +37,10 @@ http_archive(
         "//.ci/buildifier:prune.patch",
         "//.ci/buildifier:template.patch",
     ],
-    sha256 = "8ada9d88e51ebf5a1fdff37d75ed41d51f5e677cdbeafb0a22dda54747d6e07e",
-    strip_prefix = "buildifier-prebuilt-6.4.0",
+    sha256 = "7f85b688a4b558e2d9099340cfb510ba7179f829454fba842370bccffb67d6cc",
+    strip_prefix = "buildifier-prebuilt-7.3.1",
     urls = [
-        "http://github.com/keith/buildifier-prebuilt/archive/6.4.0.tar.gz",
+        "http://github.com/keith/buildifier-prebuilt/archive/7.3.1.tar.gz",
     ],
 )
 

--- a/test/unit/generated_files/BUILD
+++ b/test/unit/generated_files/BUILD
@@ -40,6 +40,7 @@ cc_binary(
         "genrule_header_consumer.cc",
         ":genrule_header.h",
     ],
+    copts = ["-Wno-unused-variable"],
 )
 
 codechecker_test(

--- a/test/unit/legacy/BUILD
+++ b/test/unit/legacy/BUILD
@@ -46,6 +46,7 @@ cc_library(
 cc_library(
     name = "test_lib",
     srcs = ["src/lib.cc"],
+    copts = ["-Wno-unused-variable"],
 )
 
 # Test defect in CTU mode

--- a/test/unit/virtual_include/BUILD
+++ b/test/unit/virtual_include/BUILD
@@ -34,6 +34,7 @@ cc_library(
 cc_library(
     name = "virtual_include",
     srcs = ["source.cc"],
+    copts = ["-Wno-return-type"],
     deps = ["test_inc"],
 )
 


### PR DESCRIPTION
Why:
Aspect Lint does not provide any value over `buildifier_prebuilt`, but it causes compatibility problems.
The used aspect lint version is incompatible with `bazel 7.2.1`.

What:
- Removed aspect lint from dependencies
- Fixed buildifier version mismatch between MODULE and WORKSPACE systems.

Addresses:
Fixes: #229 