### PR TITLE
Fix timeout being 1000x longer than it should

### DIFF
--- a/test/common/base.py
+++ b/test/common/base.py
@@ -53,7 +53,7 @@ def wait_codechecker_server(
     """
     start = time.monotonic()
     url = f"http://{host}:{port}/{product}"
-    while time.monotonic() - start < timeout:
+    while time.monotonic() - start < timeout / 1000:
         try:
             with urllib.request.urlopen(url, timeout=timeout / 1000) as resp:
                 if resp.getcode() == 200:


### PR DESCRIPTION
Why:
Currently, the timeout for checking if the CodeChecker server has started is not being divided by 1000, as it should be.

What:
- Fixed handling of milliseconds as seconds.

Addresses:
none