### PR TITLE
Fix micromamba environment error on first start

### DIFF
--- a/.ci/micromamba/README.md
+++ b/.ci/micromamba/README.md
@@ -40,6 +40,8 @@ For verbose output, use the `-v` or `-vv` flags:
 source .ci/micromamba/init.sh -v
 ```
 
+Alternatively you can run the `run_test.sh` script to handle both the environment and running of the tests.
+
 ### After installation
 
 Once the environment is activated, all tools (Python, Bazel, CodeChecker, clang, etc.) 

--- a/.ci/micromamba/init.sh
+++ b/.ci/micromamba/init.sh
@@ -70,8 +70,10 @@ if [[ "$VERBOSE" -ge 2 ]]; then
 fi
 
 # Make the leftover environment modifiable to allow micromamba to delete bazel cache folders during its setup
-info "Changing permissions for previous environment [$ENV_NAME]..."
-chmod -R +w $THIS_DIR/micromamba/envs/$ENV_NAME
+if [ -d $THIS_DIR/micromamba/envs/$ENV_NAME ]; then
+    info "Changing permissions for previous environment [$ENV_NAME]..."
+    chmod -R +w $THIS_DIR/micromamba/envs/$ENV_NAME
+fi
 
 micromamba deactivate
 # Create environment


### PR DESCRIPTION
Why:
On initial use of the micromamba environment, we get a warning:
```
[micromamba] Changing permissions for previous environment [dev]...
chmod: cannot access '/path/to/repo/.ci/micromamba/micromamba/envs/dev': No such file or directory
```

What:
- Check if the folder exists
- Mention the run_test.sh file in the micromamba README.md

Addresses:
none
