### PR TITLE
Fix per_file jobs not getting the codechecker tag

### DIFF
--- a/src/codechecker.bzl
+++ b/src/codechecker.bzl
@@ -343,7 +343,7 @@ def codechecker_test(
             options = analyze,
             skip = skip,
             config = config,
-            tags = tags,
+            tags = codechecker_tags,
             **kwargs
         )
     else:


### PR DESCRIPTION
Why:
per_file targets don't get the codechecker tag therefore, they are not excludable with the `--test_tag_filters=-codechecker` argument.

What:
- Added the codechecker tag to the per_file rule targets.

Addresses:
#238 
