### PR TITLE
Add warning about filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ bazel test ...
 ```
 
 > [!WARNING]
-> Filtering codecheckerr_tests with only `--test_tag_filters=-codechecker` is not enough.
+> Filtering codechecker_tests with only `--test_tag_filters=-codechecker` is not enough.
 > To skip the actual analysis `--build_tag_filters=-codechecker` must also be specified.
 
 You can find the analysis results in the `bazel-bin/` folder, on which you

--- a/README.md
+++ b/README.md
@@ -225,8 +225,8 @@ bazel test ...
 ```
 
 > [!WARNING]
-> The option is still in prototype status and is subject to changes or removal without notice. See [#31](https://github.com/Ericsson/rules_codechecker/issues/31).
-> You are free to experiment and report issues however!
+> Filtering codecheckerr_tests with only `--test_tag_filters=-codechecker` is not enough.
+> To skip the actual analysis `--build_tag_filters=-codechecker` must also be specified.
 
 You can find the analysis results in the `bazel-bin/` folder, on which you
 can run [`CodeChecker store`](https://github.com/Ericsson/codechecker/blob/master/docs/web/user_guide.md#store)

--- a/README.md
+++ b/README.md
@@ -224,6 +224,10 @@ bazel test ://your_codechecker_rule_name
 bazel test ...
 ```
 
+> [!WARNING]
+> The option is still in prototype status and is subject to changes or removal without notice. See [#31](https://github.com/Ericsson/rules_codechecker/issues/31).
+> You are free to experiment and report issues however!
+
 You can find the analysis results in the `bazel-bin/` folder, on which you
 can run [`CodeChecker store`](https://github.com/Ericsson/codechecker/blob/master/docs/web/user_guide.md#store)
 or [`CodeChecker parse`](https://github.com/Ericsson/codechecker/blob/master/docs/analyzer/user_guide.md#parse).


### PR DESCRIPTION
Why:
Users are confused about why `--test_tag_filters=-codechecker` does not skip expensive analysis jobs.

What:
- Added a warning explaining how to correctly filter codechecker tests.

Addresses:
#238 