### PR TITLE
Disable workflow for changes made in documentation

### DIFF
--- a/.github/workflows/foss.yaml
+++ b/.github/workflows/foss.yaml
@@ -15,7 +15,17 @@
 name: codechecker-bazel-foss-tests
 
 # Triggers the workflow on push or pull request events.
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - "**/*.md"
+      - "README*"
+      - "LICENSE"
+  pull_request:
+    paths-ignore:
+      - "**/*.md"
+      - "README*"
+      - "LICENSE"
 
 permissions: read-all
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,6 +1,16 @@
 name: Linters
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - "**/*.md"
+      - "README*"
+      - "LICENSE"
+  pull_request:
+    paths-ignore:
+      - "**/*.md"
+      - "README*"
+      - "LICENSE"
 
 jobs:
   lint:

--- a/.github/workflows/unit_test.yaml
+++ b/.github/workflows/unit_test.yaml
@@ -15,7 +15,18 @@
 name: codechecker-bazel-unit-tests
 
 # Triggers the workflow on push or pull request events.
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - "**/*.md"
+      - "README*"
+      - "LICENSE"
+  pull_request:
+    paths-ignore:
+      - "**/*.md"
+      - "README*"
+      - "LICENSE"
+
 
 permissions: read-all
 


### PR DESCRIPTION
Why:
We don't need to run CI jobs for entirely documentation-related changes.

What:
- Disable CI jobs for pull request when only documentation was changed

Addresses:
none
