### PR TITLE
Fixed issues with  --features=external_include_paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,8 +427,3 @@ After that you can find all artifacts in `bazel-bin` directory:
     
     # compile_commands.json for compile_commands_pass
     cat bazel-bin/test/compile_commands_pass/compile_commands.json
-
-
-Limitations:
-------------
-In Bazel 6, we do not support using the `--features=external_include_paths` flag.

--- a/README.md
+++ b/README.md
@@ -427,3 +427,8 @@ After that you can find all artifacts in `bazel-bin` directory:
     
     # compile_commands.json for compile_commands_pass
     cat bazel-bin/test/compile_commands_pass/compile_commands.json
+
+
+Limitations:
+------------
+In Bazel 6, we do not support using the `--features=external_include_paths` flag.

--- a/src/compile_commands.bzl
+++ b/src/compile_commands.bzl
@@ -112,11 +112,11 @@ def get_compile_flags(ctx, dep):
         if len(quote_include) == 0:
             quote_include = "."
         options.append(QUOTE_INCLUDE + quote_include)
-
-    for external_include in compilation_context.external_includes.to_list():
-        if len(external_include) == 0:
-            external_include = "."
-        options.append(EXTERNAL_INCLUDE + external_include)
+    if hasattr(compilation_context, "external_includes"):
+        for external_include in compilation_context.external_includes.to_list():
+            if len(external_include) == 0:
+                external_include = "."
+            options.append(EXTERNAL_INCLUDE + external_include)
 
     for attr in SOURCE_ATTR:
         if not hasattr(ctx.rule.attr, attr):
@@ -145,11 +145,11 @@ def get_compile_flags(ctx, dep):
                 if len(quote_include) == 0:
                     quote_include = "."
                 options.append(QUOTE_INCLUDE + quote_include)
-
-            for external_include in compilation_context.external_includes.to_list():
-                if len(external_include) == 0:
-                    external_include = "."
-                options.append(EXTERNAL_INCLUDE + external_include)
+            if hasattr(compilation_context, "external_includes"):
+                for external_include in compilation_context.external_includes.to_list():
+                    if len(external_include) == 0:
+                        external_include = "."
+                    options.append(EXTERNAL_INCLUDE + external_include)
 
     return options
 

--- a/src/compile_commands.bzl
+++ b/src/compile_commands.bzl
@@ -141,10 +141,6 @@ def get_compile_flags(ctx, dep):
                     system_include = "."
                 options.append(SYSTEM_INCLUDE + system_include)
 
-            for quote_include in compilation_context.quote_includes.to_list():
-                if len(quote_include) == 0:
-                    quote_include = "."
-                options.append(QUOTE_INCLUDE + quote_include)
             if hasattr(compilation_context, "external_includes"):
                 for external_include in compilation_context.external_includes.to_list():
                     if len(external_include) == 0:

--- a/src/compile_commands.bzl
+++ b/src/compile_commands.bzl
@@ -76,6 +76,7 @@ _cc_rules = [
 
 SYSTEM_INCLUDE = "-isystem "
 QUOTE_INCLUDE = "-iquote "
+EXTERNAL_INCLUDE = "-isystem "
 
 # Function copied from https://gist.github.com/oquenchil/7e2c2bd761aa1341b458cc25608da50c
 # NOTE: added local_defines
@@ -112,6 +113,11 @@ def get_compile_flags(ctx, dep):
             quote_include = "."
         options.append(QUOTE_INCLUDE + quote_include)
 
+    for external_include in compilation_context.external_includes.to_list():
+        if len(external_include) == 0:
+            external_include = "."
+        options.append(EXTERNAL_INCLUDE + external_include)
+
     for attr in SOURCE_ATTR:
         if not hasattr(ctx.rule.attr, attr):
             continue
@@ -134,6 +140,16 @@ def get_compile_flags(ctx, dep):
                 if len(system_include) == 0:
                     system_include = "."
                 options.append(SYSTEM_INCLUDE + system_include)
+
+            for quote_include in compilation_context.quote_includes.to_list():
+                if len(quote_include) == 0:
+                    quote_include = "."
+                options.append(QUOTE_INCLUDE + quote_include)
+
+            for external_include in compilation_context.external_includes.to_list():
+                if len(external_include) == 0:
+                    external_include = "."
+                options.append(EXTERNAL_INCLUDE + external_include)
 
     return options
 

--- a/test/unit/external_repository/test_external_repo.py
+++ b/test/unit/external_repository/test_external_repo.py
@@ -147,6 +147,11 @@ class TestImplDepExternalDep(TestBase):
         --experimental_cc_implementation_deps --enable_bzlmod
         --features=external_include_paths
         """
+        if int(self.BAZEL_VERSION[0]) <= 6:  # pyright: ignore
+            self.skipTest(
+                "For Bazel 6 and older we do not support: "
+                "--features=external_include_paths"
+            )
         ret, _, stderr = self.run_command(
             "bazel test :codechecker_external_deps "
             "--experimental_cc_implementation_deps --enable_bzlmod "
@@ -163,6 +168,11 @@ class TestImplDepExternalDep(TestBase):
         --experimental_cc_implementation_deps
         --features=external_include_paths
         """
+        if int(self.BAZEL_VERSION[0]) <= 6:  # pyright: ignore
+            self.skipTest(
+                "For Bazel 6 and older we do not support: "
+                "--features=external_include_paths"
+            )
         ret, _, stderr = self.run_command(
             "bazel test :per_file_external_deps "
             "--experimental_cc_implementation_deps --enable_bzlmod "

--- a/test/unit/external_repository/test_external_repo.py
+++ b/test/unit/external_repository/test_external_repo.py
@@ -32,7 +32,7 @@ class TestImplDepExternalDep(TestBase):
     __test_path__ = os.path.dirname(os.path.abspath(__file__))
     BAZEL_BIN_DIR = os.path.join("bazel-bin")
     BAZEL_TESTLOGS_DIR = os.path.join("bazel-testlogs")
-    BAZEL_VERSION = None
+    BAZEL_VERSION: str = ""
 
     @final
     @classmethod
@@ -147,7 +147,7 @@ class TestImplDepExternalDep(TestBase):
         --experimental_cc_implementation_deps --enable_bzlmod
         --features=external_include_paths
         """
-        if int(self.BAZEL_VERSION[0]) <= 6:  # pyright: ignore
+        if int(self.BAZEL_VERSION[0]) <= 6:
             self.skipTest(
                 "For Bazel 6 and older we do not support: "
                 "--features=external_include_paths"
@@ -168,7 +168,7 @@ class TestImplDepExternalDep(TestBase):
         --experimental_cc_implementation_deps
         --features=external_include_paths
         """
-        if int(self.BAZEL_VERSION[0]) <= 6:  # pyright: ignore
+        if int(self.BAZEL_VERSION[0]) <= 6:
             self.skipTest(
                 "For Bazel 6 and older we do not support: "
                 "--features=external_include_paths"

--- a/test/unit/external_repository/test_external_repo.py
+++ b/test/unit/external_repository/test_external_repo.py
@@ -157,8 +157,7 @@ class TestImplDepExternalDep(TestBase):
             "--experimental_cc_implementation_deps --enable_bzlmod "
             "--features=external_include_paths"
         )
-        # FIXME: Should find nothing.h and finish with exit code 0
-        self.assertEqual(ret, 1, stderr)
+        self.assertEqual(ret, 0, stderr)
 
     def test_per_file_external_include_paths(self):
         """
@@ -178,8 +177,7 @@ class TestImplDepExternalDep(TestBase):
             "--experimental_cc_implementation_deps --enable_bzlmod "
             "--features=external_include_paths"
         )
-        # FIXME: Should find nothing.h and finish with exit code 0
-        self.assertEqual(ret, 3, stderr)
+        self.assertEqual(ret, 0, stderr)
 
 
 if __name__ == "__main__":

--- a/test/unit/external_repository/test_external_repo.py
+++ b/test/unit/external_repository/test_external_repo.py
@@ -147,11 +147,6 @@ class TestImplDepExternalDep(TestBase):
         --experimental_cc_implementation_deps --enable_bzlmod
         --features=external_include_paths
         """
-        if int(self.BAZEL_VERSION[0]) <= 6:
-            self.skipTest(
-                "For Bazel 6 and older we do not support: "
-                "--features=external_include_paths"
-            )
         ret, _, stderr = self.run_command(
             "bazel test :codechecker_external_deps "
             "--experimental_cc_implementation_deps --enable_bzlmod "
@@ -167,11 +162,6 @@ class TestImplDepExternalDep(TestBase):
         --experimental_cc_implementation_deps
         --features=external_include_paths
         """
-        if int(self.BAZEL_VERSION[0]) <= 6:
-            self.skipTest(
-                "For Bazel 6 and older we do not support: "
-                "--features=external_include_paths"
-            )
         ret, _, stderr = self.run_command(
             "bazel test :per_file_external_deps "
             "--experimental_cc_implementation_deps --enable_bzlmod "


### PR DESCRIPTION
Why:
We want to support running analysis with `--features=external_include_paths`.

What:
- Added flags from `external_includes` to compile commands.
- Added flags from `external_includes` of dependencies to compile commands.

Addresses:
Fixes: #236 
