### PR TITLE
Limit/declare thread usage to bazel

### DIFF
--- a/src/codechecker.bzl
+++ b/src/codechecker.bzl
@@ -43,7 +43,7 @@ load(
     "per_file_test",
 )
 
-def _codechecker_resource_set(os_name, input_count):
+def _codechecker_resource_set(_os_name, input_count):
     """
     Requests thread count based on number of input files.
 
@@ -52,7 +52,7 @@ def _codechecker_resource_set(os_name, input_count):
     This may not work with remote machines.
     """
     return {
-        "cpu": input_count, # analysis is run for most input files
+        "cpu": input_count,  # analysis is run for most input files
     }
 
 def get_platform_alias(platform):

--- a/src/codechecker.bzl
+++ b/src/codechecker.bzl
@@ -43,6 +43,18 @@ load(
     "per_file_test",
 )
 
+def _codechecker_resource_set(os_name, input_count):
+    """
+    Requests thread count based on number of input files.
+
+    If requested thread count is higher than available
+    bazel schedules the job to run alone.
+    This may not work with remote machines.
+    """
+    return {
+        "cpu": input_count, # analysis is run for most input files
+    }
+
 def get_platform_alias(platform):
     """
     Get platform alias for full platform names being used
@@ -139,6 +151,7 @@ def _codechecker_impl(ctx):
         # arguments = [ctx.outputs.codechecker_script.path],
         mnemonic = "CodeChecker",
         progress_message = "CodeChecker %s" % str(ctx.label),
+        resource_set = _codechecker_resource_set,
         # use_default_shell_env = True,
     )
 

--- a/src/per_file_script.py
+++ b/src/per_file_script.py
@@ -93,6 +93,7 @@ def _run_codechecker() -> None:
         + ["--skip", SKIP_FILE]
         + ["--config", CONFIG_FILE]
         + [COMPILE_COMMANDS_ABSOLUTE]
+        + ["-j 1"] # Analysis of a single file should use a single thread!
     )
     log(f"CodeChecker command: {' '.join(codechecker_cmd)}\n")
     log("===-----------------------------------------------------===\n")


### PR DESCRIPTION
Why:
Bazel expects its actions to use 1 thread by default.
This can result in it scheduling multiple long analysis jobs on the same machine, each trying to hog resources from the others.

What:
- Limit thread usage of per_file to 1
- Try declaring thread usage for the monolithic rule (only affects local execution)

Addresses:
#246 
