### PR TITLE
Fix config file not being part of DefaulInfo files

### DIFF
--- a/src/per_file.bzl
+++ b/src/per_file.bzl
@@ -165,8 +165,8 @@ def _per_file_impl(ctx):
         fail("Seems compile_commands.json file is incorrect!")
     sources_and_headers = _collect_all_sources_and_headers(ctx)
     options = ctx.attr.default_options + ctx.attr.options
-    all_files = [compile_commands]
     config_file, env_vars = get_config_file(ctx)
+    all_files = [compile_commands, config_file]
     _create_wrapper_script(ctx, options, compile_commands, config_file)
     for target in ctx.attr.targets:
         if not CcInfo in target:


### PR DESCRIPTION
Why:
We want config files as output files for our rule.
We use the config file in testing: `test/unt/config`.
The current setup works, but is not explicitly supported by Bazel.
Using remote execution or rewriting the test to run inside Bazel results in the file not being found for the tests.

What:
- Added config files to `DefaultInfo` files output.

Addresses:
none