### PR TITLE
Add transitive quote includes to compile commands

### DIFF
--- a/src/compile_commands.bzl
+++ b/src/compile_commands.bzl
@@ -130,6 +130,11 @@ def get_compile_flags(ctx, dep):
                     include = "."
                 options.append("-I{}".format(include))
 
+            for quote_include in compilation_context.quote_includes.to_list():
+                if len(quote_include) == 0:
+                    quote_include = "."
+                options.append(QUOTE_INCLUDE + quote_include)
+
             for system_include in compilation_context.system_includes.to_list():
                 if len(system_include) == 0:
                     system_include = "."


### PR DESCRIPTION
Why:
We want to see quotes include paths from transitive dependencies.

What:
- Added paths from quote includes of dependencies.

Addresses:
none
