### PR TITLE
Add default values for clang, clang-tidy etc. in toolchain

### DIFF
--- a/src/codechecker_toolchain.bzl
+++ b/src/codechecker_toolchain.bzl
@@ -25,18 +25,21 @@ codechecker_toolchain = rule(
     implementation = _codechecker_toolchain_impl,
     attrs = {
         "clang_tidy": attr.label(
+            default = "@default_codechecker_tools//:clang_tidy",
             doc = "Executable target for `clang-tidy`.",
             allow_single_file = True,
             executable = True,
             cfg = "exec",
         ),
         "clangsa": attr.label(
+            default = "@default_codechecker_tools//:clang",
             doc = "Executable target for `clang`, used for Clang Static Analyzer.",
             allow_single_file = True,
             executable = True,
             cfg = "exec",
         ),
         "codechecker": attr.label(
+            default = "@default_codechecker_tools//:codechecker",
             doc = "Executable target for `CodeChecker`.",
             allow_single_file = True,
             executable = True,


### PR DESCRIPTION
Why:
We do not/cannot expose the clang, clang-tidy, codechecker, etc. targets to users, so when they want to override only one of these, they need to provide targets for each.
To make it easier, we can expose our binary targets by making them the default value for the toolchain.

What:
- Added a default value to each binary provided by our toolchain. 

Addresses:
none
