### PR TITLE
feat: distributed rule metadata files

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -21,6 +21,16 @@ py_binary(
     visibility = ["//visibility:public"],
 )
 
+# For targets using WORKSPACE files we use our own python toolchain,
+# therefore we cannot load from rules_python.
+# buildifier: disable=native-py
+py_binary(
+    name = "metadata_merge",
+    srcs = ["metadata_merge.py"],
+    # Bazel 6 won't see this otherwise
+    visibility = ["//visibility:public"],
+)
+
 # Build & Test script template
 exports_files(
     [

--- a/src/metadata_merge.py
+++ b/src/metadata_merge.py
@@ -1,0 +1,124 @@
+# Copyright 2023 Ericsson AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Merges the metadata information of multiple CodeChecker analysis.
+"""
+
+import json
+import os
+import sys
+from typing import List, Dict, Any
+
+
+def merge_two_json(json1, json2):
+    """
+    Merges the data of two json files.
+
+    If both json files are empty, returns an empty json.
+    """
+    if json1 == {}:
+        return json2
+    if json2 == {}:
+        return json1
+    # Happens when analysis of all files was skipped
+    if json1 == {} and json2 == {}:
+        return {}
+    # Fail if the plist file version is different
+    assert json1["version"] == json2["version"]
+    json1_root = json1["tools"][0]
+    json2_root = json2["tools"][0]
+    # Command, working directory nad output directory may be different
+    # from metadata to metadata, due to remote workers.
+    # Currently we choose the first of these values.
+    # We expect the following fields to be the same in all metadata files.
+    assert json1_root["name"] == json2_root["name"]
+    # same CodeChecker version
+    assert json1_root["version"] == json2_root["version"]
+    # We assume that the list of enabled checkers haven't changed between runs.
+    # We append info from json2 to json1 from here on out
+    json1_root["action_num"] += json2_root["action_num"]
+    json1_root["result_source_files"].update(json2_root["result_source_files"])
+    json1_root["skipped"] = json1_root["skipped"] + json2_root["skipped"]
+    # Merge time; we assume here both json files describe jobs in
+    # the same analysis invocation, implying that the analysis start
+    # time is the lowest timestamp, and the end is the highest.
+    # Note: caching will break this assumption
+    json1_root["timestamps"]["begin"] = min(
+        float(json1_root["timestamps"]["begin"]),
+        float(json2_root["timestamps"]["begin"]),
+    )
+    json1_root["timestamps"]["end"] = max(
+        float(json1_root["timestamps"]["end"]),
+        float(json2_root["timestamps"]["end"]),
+    )
+    # Merge analyzers
+    for key, _ in json2_root["analyzers"].items():
+        json1_stat = json1_root["analyzers"][key]["analyzer_statistics"]
+        json2_stat = json2_root["analyzers"][key]["analyzer_statistics"]
+        json1_stat["failed"] = json1_stat["failed"] + json2_stat["failed"]
+        json1_stat["failed_sources"].extend(json2_stat["failed_sources"])
+        json1_stat["successful"] = (
+            json1_stat["successful"] + json2_stat["successful"]
+        )
+        json1_stat["successful_sources"].extend(
+            json2_stat["successful_sources"]
+        )
+    return json1
+
+
+def merge_json_files(file_paths: List[str]) -> Dict[str, Any]:
+    """
+    Merges a list of metadata.json files, using merge_two_json.
+
+    Returns the merged contents of the json files.
+    """
+    merged_data = {}
+    for file_path in file_paths:
+        if not os.path.exists(file_path):
+            print(
+                f"Error: File not found at '{file_path}'. Skipping.",
+                file=sys.stderr,
+            )
+            continue
+
+        try:
+            with open(file_path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+                merged_data = merge_two_json(merged_data, data)
+        except json.JSONDecodeError:
+            print(
+                f"Error: Could not decode JSON from '{file_path}'. Skipping.",
+                file=sys.stderr,
+            )
+
+    return merged_data
+
+def main():
+    """
+    Main function of metadata merge
+    """
+    output_file = sys.argv[1]
+    input_files = sys.argv[2:]
+
+    merged_data = merge_json_files(input_files)
+    if merged_data:
+        with open(output_file, "w", encoding="utf-8") as f:
+            json.dump(merged_data, f, indent=4)
+    else:
+        print("\nNo data was merged. Output file will not be created.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/metadata_merge.py
+++ b/src/metadata_merge.py
@@ -22,6 +22,9 @@ import sys
 from typing import List, Dict, Any
 
 
+# Structure of metadata files is defined here:
+# https://github.com/Ericsson/codechecker/blob/master/docs/report_directory.md#metadata-structure
+
 def _merge_analyzer_statistics(stat1, stat2):
     """
     Merges two analyzer_statistics dicts into stat1.

--- a/src/metadata_merge.py
+++ b/src/metadata_merge.py
@@ -22,11 +22,80 @@ import sys
 from typing import List, Dict, Any
 
 
+def _merge_analyzer_statistics(stat1, stat2):
+    """
+    Merges two analyzer_statistics dicts into stat1.
+
+    Sums failed/successful counts, extends source lists,
+    and preserves the version field.
+    """
+    stat1["failed"] = stat1["failed"] + stat2["failed"]
+    stat1["failed_sources"].extend(stat2["failed_sources"])
+    stat1["successful"] = stat1["successful"] + stat2["successful"]
+    stat1["successful_sources"].extend(stat2["successful_sources"])
+
+
+def _merge_checkers(checkers1, checkers2):
+    """
+    Merges two checker dicts.
+
+    A checker is enabled (True) in the result if it is enabled
+    in either input. This handles the case where different
+    per-file runs may report slightly different checker sets.
+    """
+    for checker, enabled in checkers2.items():
+        if checker not in checkers1:
+            checkers1[checker] = enabled
+        else:
+            # If enabled in either, mark as enabled
+            checkers1[checker] = checkers1[checker] or enabled
+
+
+def _merge_analyzers(analyzers1, analyzers2):
+    """
+    Merges analyzer sections from two metadata files.
+
+    Handles the case where json2 has analyzers not present
+    in json1 by initializing them from json2.
+    """
+    for analyzer_name, analyzer_data in analyzers2.items():
+        if analyzer_name not in analyzers1:
+            # Analyzer exists in json2 but not json1; adopt it
+            analyzers1[analyzer_name] = analyzer_data
+            continue
+
+        # Merge checkers
+        if "checkers" in analyzer_data:
+            if "checkers" not in analyzers1[analyzer_name]:
+                analyzers1[analyzer_name]["checkers"] = {}
+            _merge_checkers(
+                analyzers1[analyzer_name]["checkers"],
+                analyzer_data["checkers"],
+            )
+
+        # Merge analyzer_statistics
+        if "analyzer_statistics" in analyzer_data:
+            if "analyzer_statistics" not in analyzers1[analyzer_name]:
+                analyzers1[analyzer_name]["analyzer_statistics"] = (
+                    analyzer_data["analyzer_statistics"]
+                )
+            else:
+                _merge_analyzer_statistics(
+                    analyzers1[analyzer_name]["analyzer_statistics"],
+                    analyzer_data["analyzer_statistics"],
+                )
+
+
 def merge_two_json(json1, json2):
     """
-    Merges the data of two json files.
+    Merges the data of two metadata json files.
 
     If both json files are empty, returns an empty json.
+    Handles all fields defined in the CodeChecker metadata spec:
+    - version, name, action_num, command, working_directory,
+      output_path, result_source_files, analyzers (with checkers
+      and analyzer_statistics including version), skipped,
+      timestamps.
     """
     if json1 == {}:
         return json2
@@ -35,46 +104,49 @@ def merge_two_json(json1, json2):
     # Happens when analysis of all files was skipped
     if json1 == {} and json2 == {}:
         return {}
-    # Fail if the plist file version is different
-    assert json1["version"] == json2["version"]
-    json1_root = json1["tools"][0]
-    json2_root = json2["tools"][0]
-    # Command, working directory nad output directory may be different
-    # from metadata to metadata, due to remote workers.
-    # Currently we choose the first of these values.
-    # We expect the following fields to be the same in all metadata files.
-    assert json1_root["name"] == json2_root["name"]
-    # same CodeChecker version
-    assert json1_root["version"] == json2_root["version"]
-    # We assume that the list of enabled checkers haven't changed between runs.
-    # We append info from json2 to json1 from here on out
-    json1_root["action_num"] += json2_root["action_num"]
-    json1_root["result_source_files"].update(json2_root["result_source_files"])
-    json1_root["skipped"] = json1_root["skipped"] + json2_root["skipped"]
-    # Merge time; we assume here both json files describe jobs in
-    # the same analysis invocation, implying that the analysis start
-    # time is the lowest timestamp, and the end is the highest.
+    # Fail if the metadata format version is not 2
+    assert json1["version"] == 2
+    assert json2["version"] == 2
+    json1_tools = json1["tools"][0]
+    json2_tools = json2["tools"][0]
+    # We expect the following fields to be the same in all
+    # metadata files from the same analysis invocation.
+    assert json1_tools["name"] == json2_tools["name"]
+    # Same CodeChecker version
+    assert json1_tools["version"] == json2_tools["version"]
+    # command, working_directory and output_path may differ
+    # between per-file runs (e.g. remote workers). We keep
+    # json1's values as the canonical ones.
+
+    # Sum action counts and skipped files
+    json1_tools["action_num"] += json2_tools["action_num"]
+    json1_tools["skipped"] = json1_tools["skipped"] + json2_tools["skipped"]
+
+    # Merge result_source_files mapping
+    json1_tools["result_source_files"].update(
+        json2_tools["result_source_files"]
+    )
+
+    # Merge timestamps; we assume both json files describe jobs
+    # in the same analysis invocation, implying that the analysis
+    # start time is the lowest timestamp, and the end is the
+    # highest.
     # Note: caching will break this assumption
-    json1_root["timestamps"]["begin"] = min(
-        float(json1_root["timestamps"]["begin"]),
-        float(json2_root["timestamps"]["begin"]),
+    # Users may see months, or even years long difference in timestamps
+    json1_tools["timestamps"]["begin"] = min(
+        float(json1_tools["timestamps"]["begin"]),
+        float(json2_tools["timestamps"]["begin"]),
     )
-    json1_root["timestamps"]["end"] = max(
-        float(json1_root["timestamps"]["end"]),
-        float(json2_root["timestamps"]["end"]),
+    json1_tools["timestamps"]["end"] = max(
+        float(json1_tools["timestamps"]["end"]),
+        float(json2_tools["timestamps"]["end"]),
     )
-    # Merge analyzers
-    for key, _ in json2_root["analyzers"].items():
-        json1_stat = json1_root["analyzers"][key]["analyzer_statistics"]
-        json2_stat = json2_root["analyzers"][key]["analyzer_statistics"]
-        json1_stat["failed"] = json1_stat["failed"] + json2_stat["failed"]
-        json1_stat["failed_sources"].extend(json2_stat["failed_sources"])
-        json1_stat["successful"] = (
-            json1_stat["successful"] + json2_stat["successful"]
-        )
-        json1_stat["successful_sources"].extend(
-            json2_stat["successful_sources"]
-        )
+
+    # Merge analyzers (checkers + analyzer_statistics)
+    _merge_analyzers(
+        json1_tools["analyzers"], json2_tools["analyzers"]
+    )
+
     return json1
 
 

--- a/src/per_file.bzl
+++ b/src/per_file.bzl
@@ -90,7 +90,6 @@ def _run_code_checker(
         clang_tidy_plist,
         clangsa_plist,
         codechecker_log,
-        codechecker_metadata,
     ]
 
     analyzer_output_paths = "clangsa," + clangsa_plist.path + \
@@ -102,7 +101,9 @@ def _run_code_checker(
     # Action to run CodeChecker for a file
     ctx.actions.run(
         inputs = inputs,
-        outputs = outputs,
+        # We do not want all individual metadata files
+        # cluttering the data folder
+        outputs = outputs + [codechecker_metadata],
         executable = ctx.outputs.per_file_script,
         arguments = [
             info.codechecker.path,
@@ -118,7 +119,7 @@ def _run_code_checker(
         use_default_shell_env = True,
         progress_message = "CodeChecker analyze {}".format(src.short_path),
     )
-    return outputs
+    return outputs, codechecker_metadata
 
 def check_valid_file_type(src):
     """
@@ -176,13 +177,12 @@ def _create_wrapper_script(ctx, options, compile_commands_json, config_file):
         },
     )
 
-def _merge_metadata(ctx, all_files):
+def _merge_metadata(ctx, metadata):
     """
     Merges metadata files of individual CodeChecker runs into 1
 
     Returns the metadata file objects
     """
-    metadata = [file for file in all_files if file.path.endswith("metadata.json")]
     metadata_json = ctx.actions.declare_file(ctx.attr.name + "/data/metadata.json")
     ctx.actions.run(
         inputs = metadata,
@@ -205,6 +205,7 @@ def _per_file_impl(ctx):
         fail("Seems compile_commands.json file is incorrect!")
     sources_and_headers = _collect_all_sources_and_headers(ctx)
     options = ctx.attr.default_options + ctx.attr.options
+    all_metadata = []
     config_file, env_vars = get_config_file(ctx)
     all_files = [compile_commands, config_file]
     _create_wrapper_script(ctx, options, compile_commands, config_file)
@@ -223,7 +224,7 @@ def _per_file_impl(ctx):
                     if not check_valid_file_type(src):
                         continue
                     args = target[SourceFilesInfo].compilation_db.to_list()
-                    outputs = _run_code_checker(
+                    outputs, metadata = _run_code_checker(
                         ctx,
                         src,
                         args,
@@ -238,7 +239,8 @@ def _per_file_impl(ctx):
                         sources_and_headers,
                     )
                     all_files += outputs
-    all_files.append(_merge_metadata(ctx, all_files))
+                    all_metadata.append(metadata)
+    all_files.append(_merge_metadata(ctx, all_metadata))
     ctx.actions.write(
         output = ctx.outputs.test_script,
         is_executable = True,

--- a/src/per_file.bzl
+++ b/src/per_file.bzl
@@ -176,6 +176,24 @@ def _create_wrapper_script(ctx, options, compile_commands_json, config_file):
         },
     )
 
+def _merge_metadata(ctx, all_files):
+    """
+    Merges metadata files of individual CodeChecker runs into 1
+
+    Returns the metadata file objects
+    """
+    metadata = [file for file in all_files if file.path.endswith("metadata.json")]
+    metadata_json = ctx.actions.declare_file(ctx.attr.name + "/data/metadata.json")
+    ctx.actions.run(
+        inputs = metadata,
+        outputs = [metadata_json],
+        executable = ctx.executable._metadata_merge,
+        arguments = [metadata_json.path] + [file.path for file in metadata],
+        mnemonic = "Metadata",
+        progress_message = "Merging metadata.json",
+    )
+    return metadata_json
+
 def _per_file_impl(ctx):
     compile_commands = None
     for output in compile_commands_impl(ctx):
@@ -220,6 +238,7 @@ def _per_file_impl(ctx):
                         sources_and_headers,
                     )
                     all_files += outputs
+    all_files.append(_merge_metadata(ctx, all_files))
     ctx.actions.write(
         output = ctx.outputs.test_script,
         is_executable = True,
@@ -272,6 +291,11 @@ per_file_test = rule(
                 compile_commands_aspect,
             ],
             doc = "List of compilable targets which should be checked.",
+        ),
+        "_metadata_merge": attr.label(
+            default = ":metadata_merge",
+            executable = True,
+            cfg = "exec",
         ),
         "_per_file_script_template": attr.label(
             default = ":per_file_script.py",

--- a/test/unit/metadata/BUILD
+++ b/test/unit/metadata/BUILD
@@ -61,10 +61,9 @@ unit_test(
 
 unit_test(
     name = "per_file_metadata_test",
-    contains = [r"\"action_num\": 1,"],
+    contains = [r"\"action_num\": 2,"],
     data = [":per_file_multiple_source"],
     files = [
-        "test/unit/metadata/per_file_multiple_source/data/test-unit-metadata-main.cc_metadata.json",
-        "test/unit/metadata/per_file_multiple_source/data/test-unit-metadata-other.cc_metadata.json",
+        "test/unit/metadata/per_file_multiple_source/data/metadata.json",
     ],
 )


### PR DESCRIPTION
Why:
We don't need multiple metadata files, just one.

What:
- Merge metadata files.

Addresses:
Fixes: #45 

Depends on:
#79 
