### PR TITLE
Extend unit test with the ability to assert certain files not existing

### DIFF
--- a/test/unit/basic/BUILD
+++ b/test/unit/basic/BUILD
@@ -50,6 +50,7 @@ codechecker_test(
 
 unit_test(
     name = "basic_codechecker_test",
+    absent_files = "this/file/definitely/does/not.exists",
     contains = ["core.DivideZero"],
     data = [":basic_codechecker"],
     excludes = ["Text not in file"],
@@ -59,6 +60,7 @@ unit_test(
 
 unit_test(
     name = "basic_per_file_test",
+    absent_files = "this/file/definitely/does/not.exists",
     contains = ["Division by zero"],
     data = [":basic_per_file"],
     excludes = ["Text not in file"],

--- a/test/unit/basic/BUILD
+++ b/test/unit/basic/BUILD
@@ -50,20 +50,20 @@ codechecker_test(
 
 unit_test(
     name = "basic_codechecker_test",
-    absent_files = "this/file/definitely/does/not.exists",
     contains = ["core.DivideZero"],
     data = [":basic_codechecker"],
     excludes = ["Text not in file"],
+    expected_missing_files = "this/file/definitely/does/not.exists",
     files = "test/unit/basic/basic_codechecker/codechecker.log",
     regex_patterns = ["[a-z]"],
 )
 
 unit_test(
     name = "basic_per_file_test",
-    absent_files = "this/file/definitely/does/not.exists",
     contains = ["Division by zero"],
     data = [":basic_per_file"],
     excludes = ["Text not in file"],
+    expected_missing_files = "this/file/definitely/does/not.exists",
     files = "test/unit/basic/basic_per_file/**/*.plist",
     regex_patterns = ["[a-z]"],
     require_patterns_in_each_file = False,

--- a/test/unit/grep_check.py
+++ b/test/unit/grep_check.py
@@ -148,7 +148,7 @@ def check_file(content: str, args) -> tuple[bool, set[str], set[str]]:
     return all_passed, found_patterns, missing_patterns
 
 
-def assert_files_missing(files):
+def assert_expectedly_missing_files(files):
     """
     Asserts that none of the files exist in `files`.
     """

--- a/test/unit/grep_check.py
+++ b/test/unit/grep_check.py
@@ -45,7 +45,7 @@ def parse_args() -> argparse.Namespace:
         help="Path or glob pattern to the file(s) to search within.",
     )
     parser.add_argument(
-        "--no_files",
+        "--missing_files",
         nargs="+",
         required=False,
         help="Path or glob pattern to the file(s) that shouldn't exists.",
@@ -187,9 +187,9 @@ def main() -> None:
     args = parse_args()
     check_args(args)
 
-    assert_files_missing(args.no_files)
+    assert_expectedly_missing_files(args.missing_files)
 
-    files_to_check = [x for x in args.files if x not in args.no_files]
+    files_to_check = [x for x in args.files if x not in args.missing_files]
     if not files_to_check:
         print(
             "There is no files to check, "

--- a/test/unit/grep_check.py
+++ b/test/unit/grep_check.py
@@ -166,6 +166,22 @@ def fail(msg: str, exit_code: int = 1):
     print(msg)
     sys.exit(exit_code)
 
+
+def collect_file_paths(glob_list: list[str]) -> list[str]:
+    """Convert the glob patterns into a list of file paths"""
+    file_paths = []
+    for file_pattern in glob_list:
+        matched_files = glob.glob(file_pattern, recursive=True)
+        if not matched_files:
+            # Each file pattern must match at least a file
+            fail(f"  [WARN] No files matched pattern/path: '{file_pattern}'")
+        file_paths.extend(matched_files)
+
+    if not file_paths:
+        fail("  [ERR] No file collected to be checked.")
+    return file_paths
+
+
 def main() -> None:
     """Entry point for the pattern-matching test."""
     args = parse_args()
@@ -181,20 +197,11 @@ def main() -> None:
         )
         sys.exit(0)
 
+    file_paths = collect_file_paths(files_to_check)
+
     all_passed = True
     found_patterns = set()
     missing_patterns = set()
-
-    file_paths = []
-    for file_pattern in files_to_check:
-        matched_files = glob.glob(file_pattern, recursive=True)
-        if not matched_files:
-            # Each file pattern must match at least a file
-            fail(f"  [WARN] No files matched pattern/path: '{file_pattern}'")
-        file_paths.extend(matched_files)
-
-    if not file_paths:
-        fail("  [ERR] No file collected to be checked.")
 
     for file in file_paths:
         with open(file, "r", encoding="utf-8") as f:

--- a/test/unit/grep_check.py
+++ b/test/unit/grep_check.py
@@ -155,7 +155,7 @@ def assert_files_missing(files):
     for file_pattern in files:
         matched_files = glob.glob(file_pattern, recursive=True)
         if matched_files:
-            print(f"\n{file_pattern} exists, however it shouldn't.")
+            print(f"\n{file_pattern} unexpectedly exists.")
             sys.exit(1)
 
 

--- a/test/unit/grep_check.py
+++ b/test/unit/grep_check.py
@@ -45,6 +45,12 @@ def parse_args() -> argparse.Namespace:
         help="Path or glob pattern to the file(s) to search within.",
     )
     parser.add_argument(
+        "--no_files",
+        nargs="+",
+        required=False,
+        help="Path or glob pattern to the file(s) that shouldn't exists.",
+    )
+    parser.add_argument(
         "--contains",
         nargs="+",
         required=False,
@@ -75,8 +81,7 @@ def parse_args() -> argparse.Namespace:
 def check_args(args):
     """Checks wether the arguments are correct, aborts if not"""
     if not args.contains and not args.excludes and not args.regex_patterns:
-        print("  [ERROR] Must define at least one pattern or negative pattern.")
-        sys.exit(1)
+        fail("  [ERROR] Must define at least one pattern or negative pattern.")
 
 
 def exact_match(pattern: str, content: str) -> bool:
@@ -143,25 +148,53 @@ def check_file(content: str, args) -> tuple[bool, set[str], set[str]]:
     return all_passed, found_patterns, missing_patterns
 
 
+def assert_files_missing(files):
+    """
+    Asserts that the list of file paths given as parameter, doesn't exists.
+    """
+    for file_pattern in files:
+        matched_files = glob.glob(file_pattern, recursive=True)
+        if matched_files:
+            print(f"\n{file_pattern} exists, however it shouldn't.")
+            sys.exit(1)
+
+
+def fail(msg: str, exit_code: int = 1):
+    """
+    Exits the program, with a message
+    """
+    print(msg)
+    sys.exit(exit_code)
+
 def main() -> None:
     """Entry point for the pattern-matching test."""
     args = parse_args()
     check_args(args)
+
+    assert_files_missing(args.no_files)
+
+    files_to_check = [x for x in args.files if x not in args.no_files]
+    if not files_to_check:
+        print(
+            "There is no files to check, "
+            "since all files are expected to not exits"
+        )
+        sys.exit(0)
 
     all_passed = True
     found_patterns = set()
     missing_patterns = set()
 
     file_paths = []
-    for file_pattern in args.files:
+    for file_pattern in files_to_check:
         matched_files = glob.glob(file_pattern, recursive=True)
         if not matched_files:
-            print(f"  [WARN] No files matched pattern/path: '{file_pattern}'")
+            # Each file pattern must match at least a file
+            fail(f"  [WARN] No files matched pattern/path: '{file_pattern}'")
         file_paths.extend(matched_files)
 
     if not file_paths:
-        print("  [ERR] No file collected to be checked.")
-        sys.exit(1)
+        fail("  [ERR] No file collected to be checked.")
 
     for file in file_paths:
         with open(file, "r", encoding="utf-8") as f:
@@ -186,8 +219,7 @@ def main() -> None:
     if not all_passed:
         for file, pattern in missing_patterns:
             print(f"Missing pattern {pattern} in file {file}")
-        print("\nOne or more patterns missing. Test FAILED.")
-        sys.exit(1)
+        fail("\nOne or more patterns missing. Test FAILED.")
 
 
 if __name__ == "__main__":

--- a/test/unit/grep_check.py
+++ b/test/unit/grep_check.py
@@ -150,7 +150,7 @@ def check_file(content: str, args) -> tuple[bool, set[str], set[str]]:
 
 def assert_files_missing(files):
     """
-    Asserts that the list of file paths given as parameter, doesn't exists.
+    Asserts that none of the files exist in `files`.
     """
     for file_pattern in files:
         matched_files = glob.glob(file_pattern, recursive=True)

--- a/test/unit/unit_test.bzl
+++ b/test/unit/unit_test.bzl
@@ -31,7 +31,7 @@ Example:
 def unit_test(
         name,
         files,
-        absent_files = [],
+        expected_missing_files = [],
         contains = None,
         excludes = None,
         regex_patterns = None,
@@ -44,9 +44,9 @@ def unit_test(
     Args:
         name: Test name.
         files: Path or glob to the files to be checked.
-        absent_files: Path or glob that should not exists.
-                      If these are in the `files` list too,
-                      disregard the missing file error.
+        expected_missing_files: Path or glob that should not exists.
+                                If these are in the `files` list too,
+                                disregard the missing file error.
         contains: Text that should be inside the files.
         excludes: Text that shouldn't be inside the files.
         regex_patterns: Regex patterns that should be found inside the files.
@@ -57,8 +57,8 @@ def unit_test(
     """
     if type(files) == "string":
         files = [files]
-    if type(absent_files) == "string":
-        absent_files = [absent_files]
+    if type(expected_missing_files) == "string":
+        expected_missing_files = [expected_missing_files]
     if type(contains) == "string":
         contains = [contains]
     if type(excludes) == "string":
@@ -67,9 +67,9 @@ def unit_test(
         regex_patterns = [regex_patterns]
 
     python_args = ["--files"] + files
-    if absent_files:
+    if expected_missing_files:
         python_args.append("--no_files")
-        python_args.extend(absent_files)
+        python_args.extend(expected_missing_files)
     if contains:
         python_args.append("--contains")
         python_args.extend(["\"{}\"".format(pat) for pat in contains])

--- a/test/unit/unit_test.bzl
+++ b/test/unit/unit_test.bzl
@@ -31,6 +31,7 @@ Example:
 def unit_test(
         name,
         files,
+        absent_files = [],
         contains = None,
         excludes = None,
         regex_patterns = None,
@@ -43,6 +44,9 @@ def unit_test(
     Args:
         name: Test name.
         files: Path or glob to the files to be checked.
+        absent_files: Path or glob that should not exists.
+                      If these are in the `files` list too,
+                      disregard the missing file error.
         contains: Text that should be inside the files.
         excludes: Text that shouldn't be inside the files.
         regex_patterns: Regex patterns that should be found inside the files.
@@ -53,6 +57,8 @@ def unit_test(
     """
     if type(files) == "string":
         files = [files]
+    if type(absent_files) == "string":
+        absent_files = [absent_files]
     if type(contains) == "string":
         contains = [contains]
     if type(excludes) == "string":
@@ -61,6 +67,9 @@ def unit_test(
         regex_patterns = [regex_patterns]
 
     python_args = ["--files"] + files
+    if absent_files:
+        python_args.append("--no_files")
+        python_args.extend(absent_files)
     if contains:
         python_args.append("--contains")
         python_args.extend(["\"{}\"".format(pat) for pat in contains])

--- a/test/unit/unit_test.bzl
+++ b/test/unit/unit_test.bzl
@@ -68,7 +68,7 @@ def unit_test(
 
     python_args = ["--files"] + files
     if expected_missing_files:
-        python_args.append("--no_files")
+        python_args.append("--missing_files")
         python_args.extend(expected_missing_files)
     if contains:
         python_args.append("--contains")


### PR DESCRIPTION
Why:
We want to be able to write tests that assert that certain files do not exist (and require that all files listed under files exist).

What:
- Added parameter to assert that a file does not exist (if these files are also in files, remove them)
- Made it a requirement for all `file = ["..."]` patterns to match a file.

Addresses:
none
