### PR TITLE
Added ZSH support for micromamba

### DIFF
--- a/.ci/micromamba/init.sh
+++ b/.ci/micromamba/init.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Make sure we source the script
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     echo "ERROR: This script must be 'sourced':"

--- a/.ci/micromamba/init.sh
+++ b/.ci/micromamba/init.sh
@@ -38,7 +38,13 @@ ENV_NAME="${1:-dev}"
 log "Environment: $ENV_NAME"
 
 # Get the location of this script
-THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+if [ -n "$ZSH_VERSION" ]; then
+    RAW_SOURCE="${(%):-%x}"
+else
+    RAW_SOURCE="${BASH_SOURCE[0]}"
+fi
+
+THIS_DIR="$( cd "$( dirname "$RAW_SOURCE" )" &> /dev/null && pwd )"
 log "Location: $THIS_DIR"
 
 # Check if we have environment file


### PR DESCRIPTION
Why:
When using Zsh source ` source .ci/micromamba/init.sh` did not work, because it did not find the location of the script.

What:
Added a branch if the shell is Zsh

Addresses:
None
