### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ codechecker_test(
 Then invoke bazel:
 
 ```bash
-bazel test ://your_codechecker_rule_name
+bazel test //:your_codechecker_rule_name
 # Or, as a part of the rest of the testsuite
 bazel test ...
 ```

--- a/README.md
+++ b/README.md
@@ -466,17 +466,9 @@ First, you will have to create or obtain labels for codechecker, clang and clang
 
 You may create such a label like this:
 ```python
-genrule(
+filegroup(
     name = "clang",
-    outs = ["clang_wrapper.sh"],
-    cmd_bash = """
-cat > "$@" <<'EOF'
-#!/usr/bin/env bash
-exec /usr/bin/clang "$$@"
-EOF
-chmod +x "$@"
-""",
-    executable = True,
+    srcs = ["/usr/bin/clang"],
     visibility = ["//visibility:public"],
 )
 ```

--- a/README.md
+++ b/README.md
@@ -466,9 +466,17 @@ First, you will have to create or obtain labels for codechecker, clang and clang
 
 You may create such a label like this:
 ```python
-filegroup(
+genrule(
     name = "clang",
-    srcs = ["/usr/bin/clang"],
+    outs = ["clang_wrapper.sh"],
+    cmd_bash = """
+cat > "$@" <<'EOF'
+#!/usr/bin/env bash
+exec /usr/bin/clang "$$@"
+EOF
+chmod +x "$@"
+""",
+    executable = True,
     visibility = ["//visibility:public"],
 )
 ```


### PR DESCRIPTION
Why:
We want the examples in the `README.md` to work.

What:
- Added missing @rules_codechecker prefix in the workspace file example.
- Fixed syntax of bazel test command.
- ~~Fixed clang binary example for toolchain target.~~

Addresses:
none
