### PR TITLE
Document CodeChecker skip limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,29 @@ codechecker_test(
 )
 ```
 
+#### Skipping files
+
+The `skip` argument accepts a list of patterns using the
+[CodeChecker skip-file syntax](https://codechecker.readthedocs.io/en/latest/analyzer/user_guide/#skip-file).
+Because CodeChecker runs inside the Bazel sandbox, skip patterns cannot use
+absolute paths from the host system. Use workspace-relative patterns instead,
+with a leading wildcard when the sandbox path prefix can vary:
+
+```python
+codechecker_test(
+    name = "your_codechecker_rule_name",
+    skip = [
+        "-*path/to/skipped/files/*",
+    ],
+    targets = [
+        "your_target",
+    ],
+)
+```
+
+The `skip` argument is supported by both the standard analysis and the
+experimental per-file analysis enabled with `per_file = True`.
+
 #### Per-file CodeChecker analysis:
 > [!IMPORTANT]
 > The option is still in prototype status and is subject to changes or removal without notice. See [#31](https://github.com/Ericsson/rules_codechecker/issues/31).

--- a/README.md
+++ b/README.md
@@ -189,29 +189,6 @@ codechecker_test(
 )
 ```
 
-#### Skipping files
-
-The `skip` argument accepts a list of patterns using the
-[CodeChecker skip-file syntax](https://codechecker.readthedocs.io/en/latest/analyzer/user_guide/#skip-file).
-Because CodeChecker runs inside the Bazel sandbox, skip patterns cannot use
-absolute paths from the host system. Use workspace-relative patterns instead,
-with a leading wildcard when the sandbox path prefix can vary:
-
-```python
-codechecker_test(
-    name = "your_codechecker_rule_name",
-    skip = [
-        "-*path/to/skipped/files/*",
-    ],
-    targets = [
-        "your_target",
-    ],
-)
-```
-
-The `skip` argument is supported by both the standard analysis and the
-experimental per-file analysis enabled with `per_file = True`.
-
 #### Per-file CodeChecker analysis:
 > [!IMPORTANT]
 > The option is still in prototype status and is subject to changes or removal without notice. See [#31](https://github.com/Ericsson/rules_codechecker/issues/31).
@@ -274,6 +251,29 @@ load(
 ```
 
 -->
+
+#### Skipping files
+
+The `skip` argument accepts a list of patterns using the
+[CodeChecker skip-file syntax](https://codechecker.readthedocs.io/en/latest/analyzer/user_guide/#skip-file).
+Because CodeChecker runs inside the Bazel sandbox, skip patterns cannot use
+absolute paths from the host system. Use workspace-relative patterns instead,
+with a leading wildcard when the sandbox path prefix can vary:
+
+```python
+codechecker_test(
+    name = "your_codechecker_rule_name",
+    skip = [
+        "-*path/to/skipped/files/*",
+    ],
+    targets = [
+        "your_target",
+    ],
+)
+```
+
+The `skip` argument is supported by both the standard analysis and the
+experimental per-file analysis enabled with `per_file = True`.
 
 ### Multi-platform CodeChecker analysis: `codechecker_suite()`
 _TODO: Describe this rule: see issue [#44](https://github.com/Ericsson/rules_codechecker/issues/44)._


### PR DESCRIPTION
Why:
The `skip` argument was not documented, so users could reasonably try absolute host paths that cannot match files inside Bazel's sandbox.

What:
- document the CodeChecker skip-file syntax
- explain why workspace-relative patterns are required
- add an example matching the repository's skip tests
- note that current standard and per-file analysis both support `skip`

Validation:
- `git diff --check`
- compared the example with `test/unit/skip/BUILD`
- verified both rule implementations pass `skip` to CodeChecker

Addresses:
Fixes #193

🤖 Generated with AI