### PR TITLE
Hotfix - Add default value to expected missing files parameter

### DIFF
--- a/test/unit/grep_check.py
+++ b/test/unit/grep_check.py
@@ -46,6 +46,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--missing_files",
+        default=[],
         nargs="+",
         required=False,
         help="Path or glob pattern to the file(s) that shouldn't exists.",


### PR DESCRIPTION
Why:
When the optional parameter `--missing_files` is not provided by the `unit_test` macro, the test fails.

What:
- Add a default value for expectedly missing files

Addresses:
none
