### PR TITLE
Make bazel version query more robust

### DIFF
--- a/test/foss/yaml-cpp/init.sh
+++ b/test/foss/yaml-cpp/init.sh
@@ -25,7 +25,7 @@ if [ -z "$1" ]; then
 fi
 
 # Skip this test on bazel 8
-MAJOR_VERSION=$(bazel --version | cut -d' ' -f2 | cut -d'.' -f1)
+MAJOR_VERSION=$(bazel version | grep 'Build label' | cut -d' ' -f3 | cut -d'.' -f1)
 if [ "$MAJOR_VERSION" -ge 8 ]; then
     echo "" >> $1/.skipfosstest
     exit 0

--- a/test/foss/yaml-cpp/init.sh
+++ b/test/foss/yaml-cpp/init.sh
@@ -25,7 +25,7 @@ if [ -z "$1" ]; then
 fi
 
 # Skip this test on bazel 8
-MAJOR_VERSION=$(bazel version | grep 'Build label' | cut -d' ' -f3 | cut -d'.' -f1)
+MAJOR_VERSION=$(bazel version --gnu_format | grep 'bazel' | cut -d' ' -f2 | cut -d'.' -f1)
 if [ "$MAJOR_VERSION" -ge 8 ]; then
     echo "" >> $1/.skipfosstest
     exit 0

--- a/test/foss/zlib/init.sh
+++ b/test/foss/zlib/init.sh
@@ -25,7 +25,7 @@ if [ -z "$1" ]; then
 fi
 
 # Skip this test on bazel 8
-MAJOR_VERSION=$(bazel --version | cut -d' ' -f2 | cut -d'.' -f1)
+MAJOR_VERSION=$(bazel version | grep 'Build label' | cut -d' ' -f3 | cut -d'.' -f1)
 if [ "$MAJOR_VERSION" -ge 8 ]; then
     echo "" >> $1/.skipfosstest
     exit 0

--- a/test/foss/zlib/init.sh
+++ b/test/foss/zlib/init.sh
@@ -25,7 +25,7 @@ if [ -z "$1" ]; then
 fi
 
 # Skip this test on bazel 8
-MAJOR_VERSION=$(bazel version | grep 'Build label' | cut -d' ' -f3 | cut -d'.' -f1)
+MAJOR_VERSION=$(bazel version --gnu_format | grep 'bazel' | cut -d' ' -f2 | cut -d'.' -f1)
 if [ "$MAJOR_VERSION" -ge 8 ]; then
     echo "" >> $1/.skipfosstest
     exit 0


### PR DESCRIPTION
Why:
Over and over, we encounter a problem with the current version of querying the bazel version, resulting in failures.
We have already updated the method to use `bazel version --gnu_format` in the external unit test.
The relevant code snippet:
https://github.com/Ericsson/rules_codechecker/blob/f39b2687a8b6567e5b5ca30629308565d9b60091/test/unit/external_repository/test_external_repo.py#L60-L66

What:
- Made bazel version detection more robust in FOSS tests.

Addresses:
none
