### PR TITLE
Introduce public API of rules_codechecker

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ To use `codechecker_test()` include it to your BUILD file:
 
 ```python
 load(
-    "@rules_codechecker//src:codechecker.bzl",
+    "@rules_codechecker//:defs.bzl",
     "codechecker_test",
 )
 ```
@@ -239,7 +239,7 @@ You can include and use it similarly as well:
 
 ```python
 load(
-    "@rules_codechecker//src:codechecker.bzl",
+    "@rules_codechecker//:defs.bzl",
     "codechecker_suite"
 )
 ```
@@ -252,7 +252,7 @@ First, include the rule in your BUILD file:
 
 ```python
 load(
-    "@rules_codechecker//src:codechecker.bzl",
+    "@rules_codechecker//:defs.bzl",
     "codechecker_config"
 )
 ```
@@ -303,7 +303,7 @@ To use it, add the following to your BUILD file:
 
 ```python
 load(
-    "@rules_codechecker//src:clang.bzl",
+    "@rules_codechecker//:defs.bzl",
     "clang_tidy_test",
 )
 
@@ -323,7 +323,7 @@ To use it, add the following to your BUILD file:
 
 ```python
 load(
-    "@rules_codechecker//src:clang.bzl",
+    "@rules_codechecker//:defs.bzl",
     "clang_analyze_test",
 )
 
@@ -344,7 +344,7 @@ As generating a compilation database for C/C++ is a known pain point for bazel, 
 
 ```python
 load(
-    "@rules_codechecker//src:compile_commands.bzl",
+    "@rules_codechecker//:defs.bzl",
     "compile_commands",
 )
 ```
@@ -454,7 +454,7 @@ Then define an implementation in a BUILD file with `codechecker_toolchain()`:
 
 ```python
 load(
-    "@rules_codechecker//src:codechecker_toolchain.bzl",
+    "@rules_codechecker//:defs.bzl",
     "codechecker_toolchain",
 )
 

--- a/defs.bzl
+++ b/defs.bzl
@@ -1,0 +1,55 @@
+# Copyright 2026 Ericsson AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Public API of rules_codechecker.
+
+Usage:
+
+    load("@rules_codechecker//:defs.bzl", "codechecker_test")
+"""
+
+# Clang rules, running without CodeChecker
+load(
+    "//src:clang.bzl",
+    _clang_analyze_test = "clang_analyze_test",
+    _clang_tidy_test = "clang_tidy_test",
+)
+
+# CodeChecker rules
+load(
+    "//src:codechecker.bzl",
+    _codechecker_config = "codechecker_config",
+    _codechecker_suite = "codechecker_suite",
+    _codechecker_test = "codechecker_test",
+)
+
+# Toolchain rule, for providing custom tools
+load(
+    "//src:codechecker_toolchain.bzl",
+    _codechecker_toolchain = "codechecker_toolchain",
+)
+
+# Compilation database (compile_commands.json) rule
+load(
+    "//src:compile_commands.bzl",
+    _compile_commands = "compile_commands",
+)
+
+codechecker_test = _codechecker_test
+codechecker_suite = _codechecker_suite
+codechecker_config = _codechecker_config
+codechecker_toolchain = _codechecker_toolchain
+compile_commands = _compile_commands
+clang_tidy_test = _clang_tidy_test
+clang_analyze_test = _clang_analyze_test

--- a/test/foss/yaml-cpp/init.sh
+++ b/test/foss/yaml-cpp/init.sh
@@ -37,7 +37,7 @@ cat <<EOF >> "$1/BUILD.bazel"
 
 # codechecker rules
 load(
-    "@rules_codechecker//src:codechecker.bzl",
+    "@rules_codechecker//:defs.bzl",
     "codechecker_test",
 )
 

--- a/test/foss/zlib/init.sh
+++ b/test/foss/zlib/init.sh
@@ -37,7 +37,7 @@ cat <<EOF >> "$1/BUILD.bazel"
 
 # codechecker rules
 load(
-    "@rules_codechecker//src:codechecker.bzl",
+    "@rules_codechecker//:defs.bzl",
     "codechecker_test",
 )
 codechecker_test(

--- a/test/unit/basic/BUILD
+++ b/test/unit/basic/BUILD
@@ -17,7 +17,7 @@ load(
     "cc_library",
 )
 load(
-    "//src:codechecker.bzl",
+    "//:defs.bzl",
     "codechecker_test",
 )
 load(

--- a/test/unit/caching/BUILD
+++ b/test/unit/caching/BUILD
@@ -19,7 +19,7 @@ load(
     "cc_library",
 )
 load(
-    "//src:codechecker.bzl",
+    "//:defs.bzl",
     "codechecker_test",
 )
 

--- a/test/unit/compile_flags/BUILD
+++ b/test/unit/compile_flags/BUILD
@@ -18,13 +18,8 @@ load(
     "cc_library",
 )
 load(
-    "//src:codechecker.bzl",
+    "//:defs.bzl",
     "codechecker_test",
-)
-
-# compile_commands rule
-load(
-    "//src:compile_commands.bzl",
     "compile_commands",
 )
 

--- a/test/unit/config/BUILD
+++ b/test/unit/config/BUILD
@@ -20,10 +20,15 @@ load(
 
 # codechecker rules
 load(
-    "//src:codechecker.bzl",
-    "codechecker",
+    "//:defs.bzl",
     "codechecker_config",
     "codechecker_test",
+)
+
+# build only codechecker rule, internal
+load(
+    "//src:codechecker.bzl",
+    "codechecker",
 )
 load(
     "//test/unit:unit_test.bzl",

--- a/test/unit/external_repository/BUILD
+++ b/test/unit/external_repository/BUILD
@@ -18,11 +18,8 @@ load(
     "cc_library",
 )
 load(
-    "@rules_codechecker//src:codechecker.bzl",
+    "@rules_codechecker//:defs.bzl",
     "codechecker_test",
-)
-load(
-    "@rules_codechecker//src:compile_commands.bzl",
     "compile_commands",
 )
 

--- a/test/unit/generated_files/BUILD
+++ b/test/unit/generated_files/BUILD
@@ -18,11 +18,8 @@ load(
     "cc_binary",
 )
 load(
-    "//src:codechecker.bzl",
+    "//:defs.bzl",
     "codechecker_test",
-)
-load(
-    "//src:compile_commands.bzl",
     "compile_commands",
 )
 load(

--- a/test/unit/implementation_deps/BUILD
+++ b/test/unit/implementation_deps/BUILD
@@ -17,11 +17,8 @@ load(
     "cc_library",
 )
 load(
-    "//src:codechecker.bzl",
+    "//:defs.bzl",
     "codechecker_test",
-)
-load(
-    "//src:compile_commands.bzl",
     "compile_commands",
 )
 load(

--- a/test/unit/legacy/BUILD
+++ b/test/unit/legacy/BUILD
@@ -5,32 +5,27 @@ load(
     "cc_library",
 )
 
-# clang-tidy and clang -analyze rules
+# user facing rules
 load(
-    "//src:clang.bzl",
+    "//:defs.bzl",
     "clang_analyze_test",
     "clang_tidy_test",
+    "codechecker_config",
+    "codechecker_suite",
+    "codechecker_test",
+    "compile_commands",
 )
 
-# clang -analyze + CTU rule
+# clang -analyze + CTU rule, not user facing yet
 load(
     "//src:clang_ctu.bzl",
     "clang_ctu_test",
 )
 
-# codechecker rules
+# build only codechecker rule, internal
 load(
     "//src:codechecker.bzl",
     "codechecker",
-    "codechecker_config",
-    "codechecker_suite",
-    "codechecker_test",
-)
-
-# compile_commands rule
-load(
-    "//src:compile_commands.bzl",
-    "compile_commands",
 )
 
 # Test for strip_include_prefix

--- a/test/unit/metadata/BUILD
+++ b/test/unit/metadata/BUILD
@@ -17,7 +17,7 @@ load(
     "cc_library",
 )
 load(
-    "//src:codechecker.bzl",
+    "//:defs.bzl",
     "codechecker_test",
 )
 load(

--- a/test/unit/parse/BUILD
+++ b/test/unit/parse/BUILD
@@ -18,7 +18,7 @@ load(
     "cc_library",
 )
 load(
-    "//src:codechecker.bzl",
+    "//:defs.bzl",
     "codechecker_test",
 )
 

--- a/test/unit/skip/BUILD
+++ b/test/unit/skip/BUILD
@@ -18,7 +18,7 @@ load(
     "cc_library",
 )
 load(
-    "//src:codechecker.bzl",
+    "//:defs.bzl",
     "codechecker_test",
 )
 load(

--- a/test/unit/virtual_include/BUILD
+++ b/test/unit/virtual_include/BUILD
@@ -20,7 +20,7 @@ load(
 
 # codechecker rules
 load(
-    "//src:codechecker.bzl",
+    "//:defs.bzl",
     "codechecker_test",
 )
 load(


### PR DESCRIPTION
Why:
Users should not load rules from the implementation files under src/,
which exposes internals and deviates from the Bazel convention
of a single defs.bzl entry point per rules repository.

What:
- Add defs.bzl exporting the user facing rules and macros
- Switch README examples to @rules_codechecker//:defs.bzl
- Switch unit and foss test BUILD files to the new load path
- Keep clang_ctu_test and the internal codechecker rule in src/
