### PR TITLE
Refactor compile_commands generation

### DIFF
--- a/src/compile_commands.bzl
+++ b/src/compile_commands.bzl
@@ -117,6 +117,22 @@ def _compilation_context_flags(compilation_context):
 
     return options
 
+def _remove_duplicate_flags(flags):
+    """ Remove duplicate flags while preserving order.
+
+    Args:
+        flags: A list of compile flag strings.
+    Returns:
+      List of compile flags with duplicates removed.
+    """
+    seen = {}
+    unique_flags = []
+    for flag in flags:
+        if flag not in seen:
+            seen[flag] = True
+            unique_flags.append(flag)
+    return unique_flags
+
 def get_compile_flags(ctx, dep):
     """ Return a list of compile options for a target.
 
@@ -141,7 +157,7 @@ def get_compile_flags(ctx, dep):
                     impl_dep[CcInfo].compilation_context,
                 )
 
-    return options
+    return _remove_duplicate_flags(options)
 
 def get_sources(ctx):
     """ Return a list of source files

--- a/src/compile_commands.bzl
+++ b/src/compile_commands.bzl
@@ -78,19 +78,15 @@ SYSTEM_INCLUDE = "-isystem "
 QUOTE_INCLUDE = "-iquote "
 EXTERNAL_INCLUDE = "-isystem "
 
-# Function copied from https://gist.github.com/oquenchil/7e2c2bd761aa1341b458cc25608da50c
-# NOTE: added local_defines
-def get_compile_flags(ctx, dep):
-    """ Return a list of compile options
+def _compilation_context_flags(compilation_context):
+    """ Return a list of compile options from a compilation_context.
 
     Args:
-        ctx: The context variable.
-        dep: A target with CcInfo.
+        compilation_context: A CcInfo.compilation_context object.
     Returns:
       List of compile options.
     """
     options = []
-    compilation_context = dep[CcInfo].compilation_context
 
     for define in compilation_context.defines.to_list():
         options.append("-D'{}'".format(define))
@@ -112,40 +108,38 @@ def get_compile_flags(ctx, dep):
         if len(quote_include) == 0:
             quote_include = "."
         options.append(QUOTE_INCLUDE + quote_include)
+
     if hasattr(compilation_context, "external_includes"):
         for external_include in compilation_context.external_includes.to_list():
             if len(external_include) == 0:
                 external_include = "."
             options.append(EXTERNAL_INCLUDE + external_include)
 
-    for attr in SOURCE_ATTR:
-        if not hasattr(ctx.rule.attr, attr):
-            continue
+    return options
 
-        deps = getattr(ctx.rule.attr, attr)
-        if not type(deps) == "list":
-            continue
+def get_compile_flags(ctx, dep):
+    """ Return a list of compile options for a target.
 
-        for dep in deps:
-            if CcInfo not in dep:
-                continue
+    Args:
+        ctx: The context variable.
+        dep: A target with CcInfo.
+    Returns:
+      List of compile options.
+    """
+    options = _compilation_context_flags(dep[CcInfo].compilation_context)
 
-            compilation_context = dep[CcInfo].compilation_context
-            for include in compilation_context.includes.to_list():
-                if len(include) == 0:
-                    include = "."
-                options.append("-I{}".format(include))
-
-            for system_include in compilation_context.system_includes.to_list():
-                if len(system_include) == 0:
-                    system_include = "."
-                options.append(SYSTEM_INCLUDE + system_include)
-
-            if hasattr(compilation_context, "external_includes"):
-                for external_include in compilation_context.external_includes.to_list():
-                    if len(external_include) == 0:
-                        external_include = "."
-                    options.append(EXTERNAL_INCLUDE + external_include)
+    # implementation_deps intentionally does not propagate its includes
+    # into the target's CcInfo.compilation_context, so we must extract
+    # them explicitly. This may produce duplication.
+    if hasattr(ctx.rule.attr, "implementation_deps"):
+        impl_deps = getattr(ctx.rule.attr, "implementation_deps")
+        if type(impl_deps) == "list":
+            for impl_dep in impl_deps:
+                if CcInfo not in impl_dep:
+                    continue
+                options += _compilation_context_flags(
+                    impl_dep[CcInfo].compilation_context,
+                )
 
     return options
 


### PR DESCRIPTION
Why:
The get_compile_flags function contained duplicated flag-gathering logic (inline loops repeated for the target and its deps). Additionally, when implementation_deps includes overlap with the target's own compilation context, the generated compile_commands.json can contain repeated flags, which can cause performance issues.
What:
 - Create a helper function to eliminate duplicated code.
  - Rewrites get_compile_flags to use the helper function to get the flags for normal and implementation_deps targets.
  - Now we only iterate over implementation deps, not normal deps; this minimises the number of duplicated flags.
  - Adds a `_remove_duplicate_flags` function to remove flags that still got duplicated.

Addresses:
none
