### PR TITLE
Use bazel's built in symlink instead of cp for config files

### DIFF
--- a/src/codechecker_config.bzl
+++ b/src/codechecker_config.bzl
@@ -63,19 +63,13 @@ def get_config_file(ctx):
         else:
             config_info = ctx.attr.config[CodeCheckerConfigInfo]
         if config_info.config_file:
-            # Create a copy of CodeChecker configuration file
+            # Symlink CodeChecker configuration file
             # provided via codechecker_config(config_file)
             config_file = config_info.config_file.files.to_list()[0]
-            ctx.actions.run(
-                inputs = [config_file],
-                outputs = [ctx_config_file],
-                mnemonic = "CopyFile",
-                progress_message = "Copying CodeChecker config file",
-                executable = "cp",
-                arguments = [
-                    config_file.path,
-                    ctx_config_file.path,
-                ],
+            ctx.actions.symlink(
+                output = ctx_config_file,
+                target_file = config_file,
+                progress_message = "Symlinking CodeChecker config file",
             )
         else:
             # Create CodeChecker configuration file in JSON format


### PR DESCRIPTION
Why:
The `codechecker_config` rule uses `cp` to duplicate the user-provided config file. This is an unnecessary dependency on `cp`, and may not work correctly with remote executors.
Using `ctx.actions.symlink` is the idiomatic Bazel approach, so it should work with remote execution and remote caching.

What:
- Replace the `ctx.actions.run(executable = "cp", ...)` call in `src/codechecker_config.bzl` with `ctx.actions.symlink(output, target_file)`.

Addresses:
none
