### PR TITLE
Add dependencies of tools from toolchain to runfiles

### DIFF
--- a/src/codechecker.bzl
+++ b/src/codechecker.bzl
@@ -118,15 +118,13 @@ def _codechecker_impl(ctx):
     ctx.actions.run(
         inputs = depset(
             [
-                info.codechecker,
-                info.clangsa,
-                info.clang_tidy,
                 ctx.outputs.codechecker_script,
                 ctx.outputs.codechecker_commands,
                 ctx.outputs.codechecker_skipfile,
                 config_file,
             ] + source_files,
         ),
+        tools = [info.runfiles],
         outputs = [
             codechecker_files,
             ctx.outputs.codechecker_log,
@@ -250,10 +248,7 @@ def _codechecker_test_impl(ctx):
     # Return test script and all required files
     run_files = default_runfiles + [
         ctx.outputs.codechecker_test_script,
-        info.codechecker,
-        info.clang_tidy,
-        info.clangsa,
-    ]
+    ] + info.runfiles.to_list()
     return [
         DefaultInfo(
             files = depset(all_files),

--- a/src/codechecker_toolchain.bzl
+++ b/src/codechecker_toolchain.bzl
@@ -8,15 +8,34 @@ CodeCheckerInfo = provider(
         "clang_tidy": "clang-tidy executable",
         "clangsa": "Clang executable",
         "codechecker": "CodeChecker executable",
+        "runfiles": "Depset of files needed to run the tools: the three executables " +
+                    "plus their transitive data_runfiles. Pass to `tools` in " +
+                    "ctx.actions.run and include in test runfiles.",
     },
 )
 
 def _codechecker_toolchain_impl(ctx):
+    runfiles = depset(
+        direct = [
+            ctx.executable.codechecker,
+            ctx.executable.clangsa,
+            ctx.executable.clang_tidy,
+        ],
+        transitive = [
+            # We also collect files necessary for these programs to run.
+            # Those files should be declared with `data = [...]`
+            # in the executable's target.
+            ctx.attr.codechecker[DefaultInfo].data_runfiles.files,
+            ctx.attr.clangsa[DefaultInfo].data_runfiles.files,
+            ctx.attr.clang_tidy[DefaultInfo].data_runfiles.files,
+        ],
+    )
     toolchain_info = platform_common.ToolchainInfo(
         codecheckerinfo = CodeCheckerInfo(
             codechecker = ctx.executable.codechecker,
             clang_tidy = ctx.executable.clang_tidy,
             clangsa = ctx.executable.clangsa,
+            runfiles = runfiles,
         ),
     )
     return [toolchain_info]

--- a/src/per_file.bzl
+++ b/src/per_file.bzl
@@ -69,9 +69,6 @@ def _run_code_checker(
             compile_commands_json,
             config_file,
             config,
-            info.codechecker,
-            info.clangsa,
-            info.clang_tidy,
         ] + sources_and_headers
     else:
         # NOTE: we collect only headers, so CTU may not work!
@@ -81,9 +78,6 @@ def _run_code_checker(
             config_file,
             src,
             config,
-            info.codechecker,
-            info.clangsa,
-            info.clang_tidy,
         ], transitive = [headers])
 
     outputs = [
@@ -104,6 +98,7 @@ def _run_code_checker(
         inputs = inputs,
         outputs = outputs,
         executable = ctx.outputs.per_file_script,
+        tools = [info.runfiles],
         arguments = [
             info.codechecker.path,
             data_dir,
@@ -177,6 +172,7 @@ def _create_wrapper_script(ctx, options, compile_commands_json, config_file):
     )
 
 def _per_file_impl(ctx):
+    info = ctx.toolchains["//src:toolchain_type"].codecheckerinfo
     compile_commands = None
     for output in compile_commands_impl(ctx):
         if type(output) == "DefaultInfo":
@@ -235,7 +231,9 @@ def _per_file_impl(ctx):
     files = depset(
         direct = all_files,
     )
-    run_files = [ctx.outputs.test_script, info.codechecker] + all_files
+    run_files = [
+        ctx.outputs.test_script,
+    ] + info.runfiles.to_list() + all_files
     return [
         DefaultInfo(
             files = files,

--- a/test/unit/toolchain/toolchain_runfiles_test.bzl
+++ b/test/unit/toolchain/toolchain_runfiles_test.bzl
@@ -40,15 +40,9 @@ def _subject_impl(ctx):
     tc_info = ctx.attr.toolchain[platform_common.ToolchainInfo]
     info = tc_info.codecheckerinfo
 
-    # TODO: remove hasattr guard once the fix is applied.
-    if hasattr(info, "runfiles"):
-        basenames = sorted([f.basename for f in info.runfiles.to_list()])
-        has_runfiles = True
-    else:
-        basenames = []
-        has_runfiles = False
+    basenames = sorted([f.basename for f in info.runfiles.to_list()])
 
-    return [_RunfilesInfo(basenames = basenames, has_runfiles = has_runfiles)]
+    return [_RunfilesInfo(basenames = basenames)]
 
 subject_rule = rule(
     implementation = _subject_impl,
@@ -67,47 +61,31 @@ def _test_data_deps_in_runfiles_impl(ctx):
     target = analysistest.target_under_test(env)
     info = target[_RunfilesInfo]
 
-    # TODO: change asserts.false to asserts.true once the fix is applied.
-    # Remove NOT from fail message
-    asserts.false(
-        env,
-        info.has_runfiles,
-        "Expected CodeCheckerInfo to NOT have runfiles.",
-    )
-
     # helper_data.txt is declared as data dep of the mock codechecker tool.
-    # TODO: change asserts.false to asserts.true once the fix is applied.
-    # Remove NOT from fail message
-    asserts.false(
+    asserts.true(
         env,
         "helper_data.txt" in info.basenames,
-        "NOT Expected helper_data.txt (data dep of mock tool) in runfiles, " +
+        "Expected helper_data.txt (data dep of mock tool) in runfiles, " +
         "got: %s" % info.basenames,
     )
 
     # The mock executables themselves.
-    # TODO: change asserts.false to asserts.true once the fix is applied.
-    # Remove NOT from fail message
-    asserts.false(
+    asserts.true(
         env,
         "mock_codechecker.sh" in info.basenames,
-        "NOT Expected mock_codechecker.sh in runfiles, got: %s" % info.basenames,
+        "Expected mock_codechecker.sh in runfiles, got: %s" % info.basenames,
     )
 
-    # TODO: change asserts.false to asserts.true once the fix is applied.
-    # Remove NOT from fail message
-    asserts.false(
+    asserts.true(
         env,
         "mock_clang.sh" in info.basenames,
-        "NOT Expected mock_clang.sh in runfiles, got: %s" % info.basenames,
+        "Expected mock_clang.sh in runfiles, got: %s" % info.basenames,
     )
 
-    # TODO: change asserts.false to asserts.true once the fix is applied.
-    # Remove NOT from fail message
-    asserts.false(
+    asserts.true(
         env,
         "mock_clang_tidy.sh" in info.basenames,
-        "NOT Expected mock_clang_tidy.sh in runfiles, got: %s" % info.basenames,
+        "Expected mock_clang_tidy.sh in runfiles, got: %s" % info.basenames,
     )
 
     return analysistest.end(env)


### PR DESCRIPTION
Why:
We currently only provide the single entry-script/binary to tools defined with our toolchain. (In CodeCheckers' case, this means only the entry script is available in the sandbox, not the entire installation of CodeChecker.)
This can cause trouble when users are trying to use the toolchain with their custom Bazel-provided CodeChecker versions.

What:
- Have the toolchain provide the necessary run_files for each target it was defined for. (So in the case of CodeChecker, every file of the project.)

Addresses:
Fixes: #292

Test: #277 