### PR TITLE
Apply buildifier lint suggestions

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -17,6 +17,7 @@ limitations under the License.
 module(name = "rules_codechecker")
 
 bazel_dep(name = "rules_cc", version = "0.2.3")
+bazel_dep(name = "rules_python", version = "0.38.0")
 
 bazel_dep(
     name = "buildifier_prebuilt",

--- a/src/BUILD
+++ b/src/BUILD
@@ -11,12 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+load("@rules_python//python:py_binary.bzl", "py_binary")
 load(":codechecker_toolchain.bzl", "codechecker_toolchain")
 
 # Tool filter compile_commands.json file
-# We use the built in python toolchain,
-# therefore we cannot load from rules_python.
-# buildifier: disable=native-py
 py_binary(
     name = "compile_commands_filter",
     srcs = ["compile_commands_filter.py"],

--- a/src/clang.bzl
+++ b/src/clang.bzl
@@ -18,6 +18,8 @@ Rulesets for running clang-tidy and the clang static analyzer.
 
 load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
+load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
+load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load("common.bzl", "SOURCE_ATTR", "version_specific_attributes")
 load("compile_commands.bzl", "platforms_transition")
 

--- a/src/clang_ctu.bzl
+++ b/src/clang_ctu.bzl
@@ -18,6 +18,8 @@ Ruleset for running the clang static analyzer with CTU analysis.
 
 load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
+load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
+load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load("common.bzl", "SOURCE_ATTR")
 
 CLANG_CTU_WRAPPER_SCRIPT = """#!/usr/bin/env bash

--- a/src/compile_commands.bzl
+++ b/src/compile_commands.bzl
@@ -39,6 +39,8 @@ load(
     "@bazel_tools//tools/cpp:toolchain_utils.bzl",
     "find_cpp_toolchain",
 )
+load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
+load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load(
     "common.bzl",
     "SOURCE_ATTR",

--- a/src/per_file.bzl
+++ b/src/per_file.bzl
@@ -17,6 +17,7 @@ Rulesets for running codechecker in a different Bazel action
 for each translation unit.
 """
 
+load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load("codechecker_config.bzl", "get_config_file")
 load(
     "compile_commands.bzl",

--- a/test/unit/unit_test.bzl
+++ b/test/unit/unit_test.bzl
@@ -28,6 +28,8 @@ Example:
     )
 """
 
+load("@rules_python//python:py_test.bzl", "py_test")
+
 def unit_test(
         name,
         files,
@@ -82,10 +84,7 @@ def unit_test(
     if not require_patterns_in_each_file:
         python_args.append("--any")
 
-    # Since we use a custom python toolchain instead of rules_python in WORKSPACE
-    # we cannot include py_test
-    # buildifier: disable=native-pys
-    native.py_test(
+    py_test(
         name = name,
         srcs = ["//test/unit:grep_check.py"],
         main = "//test/unit:grep_check.py",


### PR DESCRIPTION
Why:
Following buildifier's lint suggestions greatly improves Bazel version compatibility.

What:
- Added load statements where we use elements from `rules_cc`. (Ran `buildifier -lint=fix -r .`).
- Did the same changes for `rules_python`. (This means rules_python is again a dependency of the project.)

Addresses:
none