### PR TITLE
Add skylib analysis test for runfiles for the toolchain

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -20,6 +20,11 @@ bazel_dep(name = "rules_cc", version = "0.2.3")
 bazel_dep(name = "rules_python", version = "0.38.0")
 
 bazel_dep(
+    name = "bazel_skylib",
+    version = "1.7.1",
+    dev_dependency = True,
+)
+bazel_dep(
     name = "buildifier_prebuilt",
     version = "7.3.1",
     dev_dependency = True,

--- a/test/unit/toolchain/BUILD
+++ b/test/unit/toolchain/BUILD
@@ -18,27 +18,26 @@ load(
 )
 load(
     "//test/unit/toolchain:toolchain_runfiles_test.bzl",
-    "mock_executable",
     "runfiles_test_suite",
 )
 
 # --- Mock tools ---
 
 # Mock CodeChecker with a runtime data dependency on helper_data.txt.
-mock_executable(
+sh_binary(
     name = "mock_codechecker",
-    src = "mock_codechecker.sh",
+    srcs = ["mock_codechecker.sh"],
     data = ["helper_data.txt"],
 )
 
-mock_executable(
+sh_binary(
     name = "mock_clang",
-    src = "mock_clang.sh",
+    srcs = ["mock_clang.sh"],
 )
 
-mock_executable(
+sh_binary(
     name = "mock_clang_tidy",
-    src = "mock_clang_tidy.sh",
+    srcs = ["mock_clang_tidy.sh"],
 )
 
 # --- Mock toolchain ---

--- a/test/unit/toolchain/BUILD
+++ b/test/unit/toolchain/BUILD
@@ -1,0 +1,55 @@
+# Copyright 2026 Ericsson AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load(
+    "//src:codechecker_toolchain.bzl",
+    "codechecker_toolchain",
+)
+load(
+    "//test/unit/toolchain:toolchain_runfiles_test.bzl",
+    "mock_executable",
+    "runfiles_test_suite",
+)
+
+# --- Mock tools ---
+
+# Mock CodeChecker with a runtime data dependency on helper_data.txt.
+mock_executable(
+    name = "mock_codechecker",
+    src = "mock_codechecker.sh",
+    data = ["helper_data.txt"],
+)
+
+mock_executable(
+    name = "mock_clang",
+    src = "mock_clang.sh",
+)
+
+mock_executable(
+    name = "mock_clang_tidy",
+    src = "mock_clang_tidy.sh",
+)
+
+# --- Mock toolchain ---
+
+codechecker_toolchain(
+    name = "runfiles_mock_toolchain",
+    clang_tidy = ":mock_clang_tidy",
+    clangsa = ":mock_clang",
+    codechecker = ":mock_codechecker",
+)
+
+# --- Tests ---
+
+runfiles_test_suite(name = "runfiles")

--- a/test/unit/toolchain/helper_data.txt
+++ b/test/unit/toolchain/helper_data.txt
@@ -1,1 +1,4 @@
-This file simulates a runtime data dependency of a tool in the toolchain.
+In the BUILD file, this text file is declared as a runfile dependency to the (mock) codechecker toolchain
+through the data field of sh_binary target.
+We expect this text file (and any other, similarly declared resources)
+to be available through the toolchain.

--- a/test/unit/toolchain/helper_data.txt
+++ b/test/unit/toolchain/helper_data.txt
@@ -1,0 +1,1 @@
+This file simulates a runtime data dependency of a tool in the toolchain.

--- a/test/unit/toolchain/mock_clang.sh
+++ b/test/unit/toolchain/mock_clang.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "mock clang"

--- a/test/unit/toolchain/mock_clang_tidy.sh
+++ b/test/unit/toolchain/mock_clang_tidy.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "mock clang-tidy"

--- a/test/unit/toolchain/mock_codechecker.sh
+++ b/test/unit/toolchain/mock_codechecker.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "mock codechecker"

--- a/test/unit/toolchain/toolchain_runfiles_test.bzl
+++ b/test/unit/toolchain/toolchain_runfiles_test.bzl
@@ -57,14 +57,23 @@ _RunfilesInfo = provider(
     doc = "Re-exports toolchain runfiles for test inspection.",
     fields = {
         "basenames": "Sorted list of basenames of files in the runfiles depset.",
+        "has_runfiles": "Whether the toolchain has a runfiles field.",
     },
 )
 
 def _subject_impl(ctx):
     tc_info = ctx.attr.toolchain[platform_common.ToolchainInfo]
     info = tc_info.codecheckerinfo
-    basenames = sorted([f.basename for f in info.runfiles.to_list()])
-    return [_RunfilesInfo(basenames = basenames)]
+
+    # TODO: remove hasattr guard once the fix is applied (direct access is safe).
+    if hasattr(info, "runfiles"):
+        basenames = sorted([f.basename for f in info.runfiles.to_list()])
+        has_runfiles = True
+    else:
+        basenames = []
+        has_runfiles = False
+
+    return [_RunfilesInfo(basenames = basenames, has_runfiles = has_runfiles)]
 
 subject_rule = rule(
     implementation = _subject_impl,
@@ -83,29 +92,47 @@ def _test_data_deps_in_runfiles_impl(ctx):
     target = analysistest.target_under_test(env)
     info = target[_RunfilesInfo]
 
+    # TODO: change asserts.false to asserts.true once the fix is applied.
+    # Remove NOT from fail message
+    asserts.false(
+        env,
+        info.has_runfiles,
+        "Expected CodeCheckerInfo to NOT have runfiles.",
+    )
+
     # helper_data.txt is declared as data dep of the mock codechecker tool.
-    asserts.true(
+    # TODO: change asserts.false to asserts.true once the fix is applied.
+    # Remove NOT from fail message
+    asserts.false(
         env,
         "helper_data.txt" in info.basenames,
-        "Expected helper_data.txt (data dep of mock tool) in runfiles, " +
+        "NOT Expected helper_data.txt (data dep of mock tool) in runfiles, " +
         "got: %s" % info.basenames,
     )
 
-    # The mock executables themselves should also be present.
-    asserts.true(
+    # The mock executables themselves.
+    # TODO: change asserts.false to asserts.true once the fix is applied.
+    # Remove NOT from fail message
+    asserts.false(
         env,
         "mock_codechecker" in info.basenames,
-        "Expected mock_codechecker in runfiles, got: %s" % info.basenames,
+        "NOT Expected mock_codechecker in runfiles, got: %s" % info.basenames,
     )
-    asserts.true(
+
+    # TODO: change asserts.false to asserts.true once the fix is applied.
+    # Remove NOT from fail message
+    asserts.false(
         env,
         "mock_clang" in info.basenames,
-        "Expected mock_clang in runfiles, got: %s" % info.basenames,
+        "NOT Expected mock_clang in runfiles, got: %s" % info.basenames,
     )
-    asserts.true(
+
+    # TODO: change asserts.false to asserts.true once the fix is applied.
+    # Remove NOT from fail message
+    asserts.false(
         env,
         "mock_clang_tidy" in info.basenames,
-        "Expected mock_clang_tidy in runfiles, got: %s" % info.basenames,
+        "NOT Expected mock_clang_tidy in runfiles, got: %s" % info.basenames,
     )
 
     return analysistest.end(env)

--- a/test/unit/toolchain/toolchain_runfiles_test.bzl
+++ b/test/unit/toolchain/toolchain_runfiles_test.bzl
@@ -24,31 +24,6 @@ runfiles depset.
 load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
 
 # ---------------------------------------------------------------------------
-# A minimal executable rule with data deps, used as a mock tool.
-# Needed because codechecker_toolchain requires allow_single_file = True
-# which is incompatible with sh_binary.
-# ---------------------------------------------------------------------------
-
-def _mock_executable_impl(ctx):
-    out = ctx.actions.declare_file(ctx.label.name)
-    ctx.actions.symlink(output = out, target_file = ctx.file.src, is_executable = True)
-    runfiles = ctx.runfiles(files = [out] + ctx.files.data)
-    return [DefaultInfo(
-        executable = out,
-        files = depset([out]),
-        data_runfiles = runfiles,
-    )]
-
-mock_executable = rule(
-    implementation = _mock_executable_impl,
-    attrs = {
-        "data": attr.label_list(allow_files = True),
-        "src": attr.label(mandatory = True, allow_single_file = True),
-    },
-    executable = True,
-)
-
-# ---------------------------------------------------------------------------
 # Subject rule: reads CodeCheckerInfo from a codechecker_toolchain target
 # and re-exports runfiles basenames for inspection by the analysis test.
 # ---------------------------------------------------------------------------
@@ -65,7 +40,7 @@ def _subject_impl(ctx):
     tc_info = ctx.attr.toolchain[platform_common.ToolchainInfo]
     info = tc_info.codecheckerinfo
 
-    # TODO: remove hasattr guard once the fix is applied (direct access is safe).
+    # TODO: remove hasattr guard once the fix is applied.
     if hasattr(info, "runfiles"):
         basenames = sorted([f.basename for f in info.runfiles.to_list()])
         has_runfiles = True
@@ -115,24 +90,24 @@ def _test_data_deps_in_runfiles_impl(ctx):
     # Remove NOT from fail message
     asserts.false(
         env,
-        "mock_codechecker" in info.basenames,
-        "NOT Expected mock_codechecker in runfiles, got: %s" % info.basenames,
+        "mock_codechecker.sh" in info.basenames,
+        "NOT Expected mock_codechecker.sh in runfiles, got: %s" % info.basenames,
     )
 
     # TODO: change asserts.false to asserts.true once the fix is applied.
     # Remove NOT from fail message
     asserts.false(
         env,
-        "mock_clang" in info.basenames,
-        "NOT Expected mock_clang in runfiles, got: %s" % info.basenames,
+        "mock_clang.sh" in info.basenames,
+        "NOT Expected mock_clang.sh in runfiles, got: %s" % info.basenames,
     )
 
     # TODO: change asserts.false to asserts.true once the fix is applied.
     # Remove NOT from fail message
     asserts.false(
         env,
-        "mock_clang_tidy" in info.basenames,
-        "NOT Expected mock_clang_tidy in runfiles, got: %s" % info.basenames,
+        "mock_clang_tidy.sh" in info.basenames,
+        "NOT Expected mock_clang_tidy.sh in runfiles, got: %s" % info.basenames,
     )
 
     return analysistest.end(env)

--- a/test/unit/toolchain/toolchain_runfiles_test.bzl
+++ b/test/unit/toolchain/toolchain_runfiles_test.bzl
@@ -1,0 +1,143 @@
+# Copyright 2026 Ericsson AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Analysis test verifying that codechecker_toolchain propagates data_runfiles
+of its tool targets into the `runfiles` depset of CodeCheckerInfo.
+
+The test wires mock executable tools (one with a data dependency) through
+codechecker_toolchain and asserts the data files appear in the resulting
+runfiles depset.
+"""
+
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+
+# ---------------------------------------------------------------------------
+# A minimal executable rule with data deps, used as a mock tool.
+# Needed because codechecker_toolchain requires allow_single_file = True
+# which is incompatible with sh_binary.
+# ---------------------------------------------------------------------------
+
+def _mock_executable_impl(ctx):
+    out = ctx.actions.declare_file(ctx.label.name)
+    ctx.actions.symlink(output = out, target_file = ctx.file.src, is_executable = True)
+    runfiles = ctx.runfiles(files = [out] + ctx.files.data)
+    return [DefaultInfo(
+        executable = out,
+        files = depset([out]),
+        data_runfiles = runfiles,
+    )]
+
+mock_executable = rule(
+    implementation = _mock_executable_impl,
+    attrs = {
+        "data": attr.label_list(allow_files = True),
+        "src": attr.label(mandatory = True, allow_single_file = True),
+    },
+    executable = True,
+)
+
+# ---------------------------------------------------------------------------
+# Subject rule: reads CodeCheckerInfo from a codechecker_toolchain target
+# and re-exports runfiles basenames for inspection by the analysis test.
+# ---------------------------------------------------------------------------
+
+_RunfilesInfo = provider(
+    doc = "Re-exports toolchain runfiles for test inspection.",
+    fields = {
+        "basenames": "Sorted list of basenames of files in the runfiles depset.",
+    },
+)
+
+def _subject_impl(ctx):
+    tc_info = ctx.attr.toolchain[platform_common.ToolchainInfo]
+    info = tc_info.codecheckerinfo
+    basenames = sorted([f.basename for f in info.runfiles.to_list()])
+    return [_RunfilesInfo(basenames = basenames)]
+
+subject_rule = rule(
+    implementation = _subject_impl,
+    attrs = {
+        "toolchain": attr.label(mandatory = True),
+    },
+)
+
+# ---------------------------------------------------------------------------
+# Test: data deps of tool targets appear in toolchain runfiles
+# ---------------------------------------------------------------------------
+
+def _test_data_deps_in_runfiles_impl(ctx):
+    env = analysistest.begin(ctx)
+
+    target = analysistest.target_under_test(env)
+    info = target[_RunfilesInfo]
+
+    # helper_data.txt is declared as data dep of the mock codechecker tool.
+    asserts.true(
+        env,
+        "helper_data.txt" in info.basenames,
+        "Expected helper_data.txt (data dep of mock tool) in runfiles, " +
+        "got: %s" % info.basenames,
+    )
+
+    # The mock executables themselves should also be present.
+    asserts.true(
+        env,
+        "mock_codechecker" in info.basenames,
+        "Expected mock_codechecker in runfiles, got: %s" % info.basenames,
+    )
+    asserts.true(
+        env,
+        "mock_clang" in info.basenames,
+        "Expected mock_clang in runfiles, got: %s" % info.basenames,
+    )
+    asserts.true(
+        env,
+        "mock_clang_tidy" in info.basenames,
+        "Expected mock_clang_tidy in runfiles, got: %s" % info.basenames,
+    )
+
+    return analysistest.end(env)
+
+data_deps_in_runfiles_test = analysistest.make(
+    _test_data_deps_in_runfiles_impl,
+)
+
+# ---------------------------------------------------------------------------
+# Test suite
+# ---------------------------------------------------------------------------
+
+def runfiles_test_suite(name):
+    """Instantiates targets and test for toolchain runfiles propagation.
+
+    Args:
+        name: Name prefix for the generated targets.
+    """
+    subject_rule(
+        name = name + "_subject",
+        toolchain = name + "_mock_toolchain",
+        tags = ["manual"],
+    )
+
+    data_deps_in_runfiles_test(
+        name = name + "_data_deps_in_runfiles_test",
+        target_under_test = name + "_subject",
+    )
+
+    native.test_suite(
+        name = name,
+        tests = [
+            name + "_data_deps_in_runfiles_test",
+        ],
+    )


### PR DESCRIPTION
Why:
We want a test case for #274.

What:
- Added a skylib analysis test that checks whether runfile dependencies of toolchain binaries are present.

Addresses:
none
