### PR TITLE
Set use_default_shell_env = False on per_file rule

### DIFF
--- a/src/codechecker_script.py
+++ b/src/codechecker_script.py
@@ -251,8 +251,9 @@ def analyze(cfg):
         if env_list:
             codechecker_env = dict(item.split("=", 1) for item in env_list)
             env.update(codechecker_env)
+    # Note: This is a workaround, CodeChecker requires the PATH to be set
     if "PATH" not in env:
-        env["PATH"] = "/bin"  # NOTE: this is workaround for CodeChecker 6.24.4
+        env["PATH"] = "/bin"
     env["CC_ANALYZER_BIN"] = generate_analyzer_executables(cfg)
     logging.debug("env: %s", str(env))
 

--- a/src/per_file.bzl
+++ b/src/per_file.bzl
@@ -97,6 +97,7 @@ def _run_code_checker(
     # Action to run CodeChecker for a file
     # env_vars are unused for now, since
     # use_default_shell_env and env are incompatible
+    # TODO: use env for environment variables, instead of passing it as argument
     ctx.actions.run(
         inputs = inputs,
         outputs = outputs,
@@ -119,7 +120,6 @@ def _run_code_checker(
             analyzer_executables,
         ],
         mnemonic = "CodeChecker",
-        use_default_shell_env = True,
         progress_message = "CodeChecker analyze {}".format(src.short_path),
     )
     return outputs

--- a/src/per_file_script.py
+++ b/src/per_file_script.py
@@ -93,6 +93,9 @@ def _get_codechecker_env() -> dict[str, str]:
     Returns the environment for running CodeChecker
     """
     cc_env = os.environ.copy()
+    # Note: This is a workaround, CodeChecker requires the PATH to be set
+    if "PATH" not in cc_env:
+        cc_env["PATH"] = "/bin"
     # Overwrite analyzer paths
     cc_env["CC_ANALYZER_BIN"] = ANALYZER_EXECUTABLES_ENV_VAR
     return cc_env


### PR DESCRIPTION
Why:
We want our actions to run without `use_default_shell_env = True`.

What:
- Update the comment on the workaround.
- Set `use_default_shell_env` to false on per_file rule.

Note:
 Fails on Jenkins.

Addresses:
none
