### PR TITLE
Update Public API

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,3 +1,46 @@
+# Copyright 2026 Ericsson AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//src:codechecker_toolchain.bzl", "codechecker_toolchain")
+
+# The public labels of rules_codechecker live here,
+# the implementation is in //src
+#
+# NOTE: only load from packages visible to our consumers here,
+# this package is loaded by everyone who resolves //:default_toolchain
+
+# Named by convention
+# https://bazel.build/extending/toolchains#writing-rules-toolchains
+toolchain_type(
+    name = "toolchain_type",
+    visibility = ["//visibility:public"],
+)
+
+# Tools found on PATH, provisioned by the default_codechecker_tools extension
+codechecker_toolchain(
+    name = "default_tools",
+    clang_tidy = "@default_codechecker_tools//:clang_tidy",
+    clangsa = "@default_codechecker_tools//:clang",
+    codechecker = "@default_codechecker_tools//:CodeChecker",
+)
+
+toolchain(
+    name = "default_toolchain",
+    toolchain = ":default_tools",
+    toolchain_type = ":toolchain_type",
+)
+
 # Repository root marker, used by the buildifier test to find the workspace
 exports_files(
     ["MODULE.bazel"],

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -17,7 +17,7 @@ limitations under the License.
 module(name = "rules_codechecker")
 
 bazel_dep(name = "rules_cc", version = "0.2.3")
-bazel_dep(name = "rules_python", version = "0.38.0")
+bazel_dep(name = "rules_python", version = "0.40.0")
 
 bazel_dep(
     name = "buildifier_prebuilt",
@@ -40,5 +40,5 @@ codechecker_extension = use_extension(
 use_repo(codechecker_extension, "default_codechecker_tools")
 
 register_toolchains(
-    "//src:codechecker_local_toolchain",
+    "//:default_toolchain",
 )

--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ codechecker_extension = use_extension(
     "module_register_default_codechecker_tools",
 )
 use_repo(codechecker_extension, "default_codechecker_tools")
-register_toolchains("@rules_codechecker//src:codechecker_local_toolchain")
+register_toolchains("@rules_codechecker//:default_toolchain")
 ```
 
 ### Providing your own tools
@@ -491,7 +491,7 @@ codechecker_toolchain(
 toolchain(
     name = "codechecker_custom_toolchain",
     toolchain = ":codechecker_custom",
-    toolchain_type = "@rules_codechecker//src:toolchain_type",
+    toolchain_type = "@rules_codechecker//:toolchain_type",
     # Optionally constrain which execution platform this applies to:
     # exec_compatible_with = ["@platforms//os:linux"],
 )

--- a/defs.bzl
+++ b/defs.bzl
@@ -32,6 +32,7 @@ load(
     _codechecker_config = "codechecker_config",
     _codechecker_suite = "codechecker_suite",
     _codechecker_test = "codechecker_test",
+    _get_platform_alias = "get_platform_alias",
 )
 
 # Toolchain rule, for providing custom tools
@@ -53,3 +54,6 @@ codechecker_toolchain = _codechecker_toolchain
 compile_commands = _compile_commands
 clang_tidy_test = _clang_tidy_test
 clang_analyze_test = _clang_analyze_test
+
+# Helper for the platform suffix codechecker_suite() adds to its test names
+get_platform_alias = _get_platform_alias

--- a/src/BUILD
+++ b/src/BUILD
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 load("@rules_python//python:py_binary.bzl", "py_binary")
-load(":codechecker_toolchain.bzl", "codechecker_toolchain")
 
 # Tool filter compile_commands.json file
 py_binary(
@@ -61,24 +60,4 @@ label_flag(
     name = "clang_tidy_additional_deps",
     build_setting_default = ":clang_tidy_additional_deps_default",
     visibility = ["//visibility:public"],
-)
-
-# named this by convention
-# https://bazel.build/extending/toolchains#:~:text=%23%20By%20convention%2C%20toolchain%5Ftype%20targets%20are%20named%20%22toolchain%5Ftype%22%20and
-toolchain_type(
-    name = "toolchain_type",
-    visibility = ["//visibility:public"],
-)
-
-codechecker_toolchain(
-    name = "codechecker_local",
-    clang_tidy = "@default_codechecker_tools//:clang_tidy",
-    clangsa = "@default_codechecker_tools//:clang",
-    codechecker = "@default_codechecker_tools//:CodeChecker",
-)
-
-toolchain(
-    name = "codechecker_local_toolchain",
-    toolchain = "codechecker_local",
-    toolchain_type = ":toolchain_type",
 )

--- a/src/codechecker.bzl
+++ b/src/codechecker.bzl
@@ -92,7 +92,7 @@ def _codechecker_impl(ctx):
 
     config_file, codechecker_env = get_config_file(ctx)
 
-    info = ctx.toolchains["//src:toolchain_type"].codecheckerinfo
+    info = ctx.toolchains["//:toolchain_type"].codecheckerinfo
 
     codechecker_files = ctx.actions.declare_directory(ctx.label.name + "/codechecker-files")
     ctx.actions.expand_template(
@@ -208,7 +208,7 @@ codechecker = rule(
         "compile_commands": "%{name}/compile_commands.json",
     },
     toolchains = [
-        "//src:toolchain_type",
+        "//:toolchain_type",
     ],
 )
 
@@ -229,7 +229,7 @@ def _codechecker_test_impl(ctx):
     if not codechecker_files:
         fail("Execution results required for codechecker test are not available")
 
-    info = ctx.toolchains["//src:toolchain_type"].codecheckerinfo
+    info = ctx.toolchains["//:toolchain_type"].codecheckerinfo
 
     # Create test script from template
     ctx.actions.expand_template(
@@ -314,7 +314,7 @@ _codechecker_test = rule(
         "compile_commands": "%{name}/compile_commands.json",
     },
     toolchains = [
-        "//src:toolchain_type",
+        "//:toolchain_type",
     ],
     test = True,
 )

--- a/src/per_file.bzl
+++ b/src/per_file.bzl
@@ -191,8 +191,7 @@ def _per_file_impl(ctx):
     all_files = [compile_commands, config_file]
     _create_wrapper_script(ctx, options, compile_commands, config_file)
 
-    # TODO: Consider using aliases so we don't have to type //src: everywhere.
-    info = ctx.toolchains["//src:toolchain_type"].codecheckerinfo
+    info = ctx.toolchains["//:toolchain_type"].codecheckerinfo
     for target in ctx.attr.targets:
         if not CcInfo in target:
             continue
@@ -284,5 +283,5 @@ per_file_test = rule(
         "test_script": "%{name}/test_script.sh",
     },
     test = True,
-    toolchains = ["//src:toolchain_type"],
+    toolchains = ["//:toolchain_type"],
 )

--- a/test/buildifier/BUILD
+++ b/test/buildifier/BUILD
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 load("@buildifier_prebuilt//:rules.bzl", "buildifier_test")
 
 # Patches applied to buildifier_prebuilt, see MODULE.bazel
@@ -19,11 +20,11 @@ exports_files([
     "template.patch",
 ])
 
-# The linter is declared here, and not in the root package, because
-# buildifier_prebuilt is a dev dependency and therefore not visible to our
-# consumers, while the root package has to stay loadable by them.
-# The whole repository is still checked, no_sandbox and the workspace
-# attribute make the test run from the repository root.
+# The buildifier linter is declared here, and not in the root package, because
+# buildifier_prebuilt is a dev dependency and therefore not visible to users,
+# while the root package is loaded by everyone who resolves //:default_toolchain.
+# The whole repository is still checked, no_sandbox and the workspace attribute
+# make the test run from the repository root.
 buildifier_test(
     name = "buildifier",
     exclude_patterns = [


### PR DESCRIPTION
Why:
Still we have to reach into the implementation (//src:) for the toolchain:
@rules_codechecker//src:toolchain_type when declaring own toolchain,
and //src:codechecker_local_toolchain when registering ours.
get_platform_alias() was not reachable from defs.bzl either,
so the public API was incomplete.

What:
- Define toolchain_type and the default toolchain in the root package
- Rename codechecker_local to default_tools and
  codechecker_local_toolchain to default_toolchain
- Refer to //:toolchain_type in the rules that resolve the toolchain
- Register //:default_toolchain in MODULE.bazel
- Export get_platform_alias() from defs.bzl

Addresses:
#288