### PR TITLE
Fix minor issues with toolchain

### DIFF
--- a/src/codechecker_toolchain.bzl
+++ b/src/codechecker_toolchain.bzl
@@ -27,21 +27,18 @@ codechecker_toolchain = rule(
         "clang_tidy": attr.label(
             default = "@default_codechecker_tools//:clang_tidy",
             doc = "Executable target for `clang-tidy`.",
-            allow_single_file = True,
             executable = True,
             cfg = "exec",
         ),
         "clangsa": attr.label(
             default = "@default_codechecker_tools//:clang",
             doc = "Executable target for `clang`, used for Clang Static Analyzer.",
-            allow_single_file = True,
             executable = True,
             cfg = "exec",
         ),
         "codechecker": attr.label(
-            default = "@default_codechecker_tools//:codechecker",
+            default = "@default_codechecker_tools//:CodeChecker",
             doc = "Executable target for `CodeChecker`.",
-            allow_single_file = True,
             executable = True,
             cfg = "exec",
         ),


### PR DESCRIPTION
Why:
We want the toolchain to be correct.

What:
- Fixed the wrong default value for CodeChecker.
- Removed `allow_single_file = True` from each target. This attribute prevents users from using `sh_binary` or similar targets to provide their tools. (This is why I needed a mock rule for my test in #277.) 

Addresses:
none
