### PR TITLE
Remove dead code

### DIFF
--- a/src/common.bzl
+++ b/src/common.bzl
@@ -42,14 +42,6 @@ def version_specific_attributes():
         )})
     return {}
 
-def python_toolchain_type():
-    """
-    Returns version specific Python toolchain type
-    """
-    if BAZEL_VERSION.split(".")[0] in "01234567":
-        return "@bazel_tools//tools/python:toolchain_type"
-    return "@rules_python//python:toolchain_type"
-
 def warning(ctx, msg):
     """
     Prints message if the debug tag is enabled.


### PR DESCRIPTION
Why:
We have abandoned the two different Python toolchain approaches. Therefore, we do not need this helper function to determine which one we should use.

What:
- Removed `python_toolchain_type` function from `common.bzl`

Addresses:
none
