### PR TITLE
test: Add skylib tests for compile_commands.bzl

### DIFF
--- a/test/unit/compile_commands/BUILD
+++ b/test/unit/compile_commands/BUILD
@@ -1,0 +1,138 @@
+# Copyright 2026 Ericsson AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_cc//cc:defs.bzl", "cc_library")
+load(
+    ":compile_commands_analysis_test.bzl",
+    "custom_ccinfo",
+    "get_compile_flags_no_duplicates_test",
+    "get_compile_flags_quote_includes_from_deps_test",
+    "get_compile_flags_test_suite",
+)
+
+# =============================================================================
+# Analysis tests
+# =============================================================================
+
+# get_compile_flags
+# -----------------
+
+cc_library(
+    name = "compile_flags_tests_with_defines",
+    srcs = ["testdata/foo.cc"],
+    hdrs = ["testdata/foo.h"],
+    defines = ["MY_DEFINE=1"],
+    tags = ["manual"],
+)
+
+cc_library(
+    name = "compile_flags_tests_with_local_defines",
+    srcs = ["testdata/foo.cc"],
+    hdrs = ["testdata/foo.h"],
+    local_defines = ["LOCAL_DEF=1"],
+    tags = ["manual"],
+)
+
+cc_library(
+    name = "compile_flags_tests_with_includes",
+    srcs = ["testdata/foo.cc"],
+    hdrs = ["testdata/foo.h"],
+    includes = ["my/include/path"],
+    tags = ["manual"],
+)
+
+cc_library(
+    name = "compile_flags_tests_with_copts",
+    srcs = ["testdata/foo.cc"],
+    hdrs = ["testdata/foo.h"],
+    copts = [
+        "-Wall",
+        "-Wextra",
+    ],
+    tags = ["manual"],
+)
+
+cc_library(
+    name = "compile_flags_tests_dep_with_includes",
+    srcs = ["testdata/bar.cc"],
+    hdrs = ["testdata/bar.h"],
+    includes = ["dep/include"],
+    tags = ["manual"],
+)
+
+cc_library(
+    name = "compile_flags_tests_with_dep_includes",
+    srcs = ["testdata/foo.cc"],
+    hdrs = ["testdata/foo.h"],
+    tags = ["manual"],
+    deps = [":compile_flags_tests_dep_with_includes"],
+)
+
+custom_ccinfo(
+    name = "compile_flags_tests_sys_include_provider",
+    system_includes = ["my/sys/include"],
+    tags = ["manual"],
+)
+
+cc_library(
+    name = "compile_flags_tests_with_system_includes",
+    srcs = ["testdata/foo.cc"],
+    hdrs = ["testdata/foo.h"],
+    tags = ["manual"],
+    deps = [":compile_flags_tests_sys_include_provider"],
+)
+
+custom_ccinfo(
+    name = "compile_flags_tests_quote_include_provider",
+    quote_includes = ["my/quote/include"],
+    tags = ["manual"],
+)
+
+cc_library(
+    name = "compile_flags_tests_with_quote_includes",
+    srcs = ["testdata/foo.cc"],
+    hdrs = ["testdata/foo.h"],
+    tags = ["manual"],
+    deps = [":compile_flags_tests_quote_include_provider"],
+)
+
+get_compile_flags_test_suite(name = "compile_flags_tests")
+
+# BUG (manual): compile commands should not contain duplicate flags.
+get_compile_flags_no_duplicates_test(
+    name = "get_compile_flags_no_duplicates",
+    tags = ["manual"],
+    target_under_test = ":compile_flags_tests_with_dep_includes",
+)
+
+# BUG (manual): quote_includes from implementation_deps are not collected.
+custom_ccinfo(
+    name = "compile_flags_tests_dep_quote_include_provider",
+    quote_includes = ["dep/quote/path"],
+    tags = ["manual"],
+)
+
+cc_library(
+    name = "compile_flags_tests_with_dep_quote_includes",
+    srcs = ["testdata/foo.cc"],
+    hdrs = ["testdata/foo.h"],
+    implementation_deps = [":compile_flags_tests_dep_quote_include_provider"],
+    tags = ["manual"],
+)
+
+get_compile_flags_quote_includes_from_deps_test(
+    name = "get_compile_flags_quote_includes_from_deps",
+    tags = ["manual"],
+    target_under_test = ":compile_flags_tests_with_dep_quote_includes",
+)

--- a/test/unit/compile_commands/BUILD
+++ b/test/unit/compile_commands/BUILD
@@ -40,6 +40,29 @@ cc_library(
     tags = ["manual"],
 )
 
+# BUG (manual): defines from implementation_deps are not collected.
+cc_library(
+    name = "compile_flags_tests_impl_dep_with_defines",
+    srcs = ["testdata/bar.cc"],
+    hdrs = ["testdata/bar.h"],
+    defines = ["IMPL_DEP_DEFINE=1"],
+    tags = ["manual"],
+)
+
+cc_library(
+    name = "compile_flags_tests_with_impl_dep_defines",
+    srcs = ["testdata/foo.cc"],
+    hdrs = ["testdata/foo.h"],
+    implementation_deps = [":compile_flags_tests_impl_dep_with_defines"],
+    tags = ["manual"],
+)
+
+get_compile_flags_defines_from_impl_deps_test(
+    name = "get_compile_flags_defines_from_impl_deps",
+    tags = ["manual"],
+    target_under_test = ":compile_flags_tests_with_impl_dep_defines",
+)
+
 cc_library(
     name = "compile_flags_tests_with_local_defines",
     srcs = ["testdata/foo.cc"],
@@ -48,12 +71,57 @@ cc_library(
     tags = ["manual"],
 )
 
+# BUG (manual): local_defines from implementation_deps are not collected.
+cc_library(
+    name = "compile_flags_tests_impl_dep_with_local_defines",
+    srcs = ["testdata/bar.cc"],
+    hdrs = ["testdata/bar.h"],
+    local_defines = ["IMPL_DEP_LOCAL_DEF=1"],
+    tags = ["manual"],
+)
+
+cc_library(
+    name = "compile_flags_tests_with_impl_dep_local_defines",
+    srcs = ["testdata/foo.cc"],
+    hdrs = ["testdata/foo.h"],
+    implementation_deps = [":compile_flags_tests_impl_dep_with_local_defines"],
+    tags = ["manual"],
+)
+
+get_compile_flags_local_defines_from_impl_deps_test(
+    name = "get_compile_flags_local_defines_from_impl_deps",
+    tags = ["manual"],
+    target_under_test = ":compile_flags_tests_with_impl_dep_local_defines",
+)
+
 cc_library(
     name = "compile_flags_tests_with_includes",
     srcs = ["testdata/foo.cc"],
     hdrs = ["testdata/foo.h"],
     includes = ["my/include/path"],
     tags = ["manual"],
+)
+
+# includes from implementation_deps should be collected.
+cc_library(
+    name = "compile_flags_tests_impl_dep_with_includes",
+    srcs = ["testdata/bar.cc"],
+    hdrs = ["testdata/bar.h"],
+    includes = ["impl_dep/include"],
+    tags = ["manual"],
+)
+
+cc_library(
+    name = "compile_flags_tests_with_impl_dep_includes",
+    srcs = ["testdata/foo.cc"],
+    hdrs = ["testdata/foo.h"],
+    implementation_deps = [":compile_flags_tests_impl_dep_with_includes"],
+    tags = ["manual"],
+)
+
+get_compile_flags_includes_from_impl_deps_test(
+    name = "get_compile_flags_includes_from_impl_deps",
+    target_under_test = ":compile_flags_tests_with_impl_dep_includes",
 )
 
 cc_library(
@@ -97,6 +165,26 @@ cc_library(
     deps = [":compile_flags_tests_sys_include_provider"],
 )
 
+# system_includes from implementation_deps should be collected.
+custom_ccinfo(
+    name = "compile_flags_tests_impl_dep_sys_include_provider",
+    system_includes = ["impl_dep/sys/include"],
+    tags = ["manual"],
+)
+
+cc_library(
+    name = "compile_flags_tests_with_impl_dep_system_includes",
+    srcs = ["testdata/foo.cc"],
+    hdrs = ["testdata/foo.h"],
+    implementation_deps = [":compile_flags_tests_impl_dep_sys_include_provider"],
+    tags = ["manual"],
+)
+
+get_compile_flags_system_includes_from_impl_deps_test(
+    name = "get_compile_flags_system_includes_from_impl_deps",
+    target_under_test = ":compile_flags_tests_with_impl_dep_system_includes",
+)
+
 custom_ccinfo(
     name = "compile_flags_tests_quote_include_provider",
     quote_includes = ["my/quote/include"],
@@ -109,15 +197,6 @@ cc_library(
     hdrs = ["testdata/foo.h"],
     tags = ["manual"],
     deps = [":compile_flags_tests_quote_include_provider"],
-)
-
-get_compile_flags_test_suite(name = "compile_flags_tests")
-
-# BUG (manual): compile commands should not contain duplicate flags.
-get_compile_flags_no_duplicates_test(
-    name = "get_compile_flags_no_duplicates",
-    tags = ["manual"],
-    target_under_test = ":compile_flags_tests_with_dep_includes",
 )
 
 # BUG (manual): quote_includes from implementation_deps are not collected.
@@ -141,90 +220,11 @@ get_compile_flags_quote_includes_from_deps_test(
     target_under_test = ":compile_flags_tests_with_dep_quote_includes",
 )
 
-# includes from implementation_deps should be collected.
-cc_library(
-    name = "compile_flags_tests_impl_dep_with_includes",
-    srcs = ["testdata/bar.cc"],
-    hdrs = ["testdata/bar.h"],
-    includes = ["impl_dep/include"],
+get_compile_flags_test_suite(name = "compile_flags_tests")
+
+# BUG (manual): compile commands should not contain duplicate flags.
+get_compile_flags_no_duplicates_test(
+    name = "get_compile_flags_no_duplicates",
     tags = ["manual"],
-)
-
-cc_library(
-    name = "compile_flags_tests_with_impl_dep_includes",
-    srcs = ["testdata/foo.cc"],
-    hdrs = ["testdata/foo.h"],
-    implementation_deps = [":compile_flags_tests_impl_dep_with_includes"],
-    tags = ["manual"],
-)
-
-get_compile_flags_includes_from_impl_deps_test(
-    name = "get_compile_flags_includes_from_impl_deps",
-    target_under_test = ":compile_flags_tests_with_impl_dep_includes",
-)
-
-# system_includes from implementation_deps should be collected.
-custom_ccinfo(
-    name = "compile_flags_tests_impl_dep_sys_include_provider",
-    system_includes = ["impl_dep/sys/include"],
-    tags = ["manual"],
-)
-
-cc_library(
-    name = "compile_flags_tests_with_impl_dep_system_includes",
-    srcs = ["testdata/foo.cc"],
-    hdrs = ["testdata/foo.h"],
-    implementation_deps = [":compile_flags_tests_impl_dep_sys_include_provider"],
-    tags = ["manual"],
-)
-
-get_compile_flags_system_includes_from_impl_deps_test(
-    name = "get_compile_flags_system_includes_from_impl_deps",
-    target_under_test = ":compile_flags_tests_with_impl_dep_system_includes",
-)
-
-# BUG (manual): defines from implementation_deps are not collected.
-cc_library(
-    name = "compile_flags_tests_impl_dep_with_defines",
-    srcs = ["testdata/bar.cc"],
-    hdrs = ["testdata/bar.h"],
-    defines = ["IMPL_DEP_DEFINE=1"],
-    tags = ["manual"],
-)
-
-cc_library(
-    name = "compile_flags_tests_with_impl_dep_defines",
-    srcs = ["testdata/foo.cc"],
-    hdrs = ["testdata/foo.h"],
-    implementation_deps = [":compile_flags_tests_impl_dep_with_defines"],
-    tags = ["manual"],
-)
-
-get_compile_flags_defines_from_impl_deps_test(
-    name = "get_compile_flags_defines_from_impl_deps",
-    tags = ["manual"],
-    target_under_test = ":compile_flags_tests_with_impl_dep_defines",
-)
-
-# BUG (manual): local_defines from implementation_deps are not collected.
-cc_library(
-    name = "compile_flags_tests_impl_dep_with_local_defines",
-    srcs = ["testdata/bar.cc"],
-    hdrs = ["testdata/bar.h"],
-    local_defines = ["IMPL_DEP_LOCAL_DEF=1"],
-    tags = ["manual"],
-)
-
-cc_library(
-    name = "compile_flags_tests_with_impl_dep_local_defines",
-    srcs = ["testdata/foo.cc"],
-    hdrs = ["testdata/foo.h"],
-    implementation_deps = [":compile_flags_tests_impl_dep_with_local_defines"],
-    tags = ["manual"],
-)
-
-get_compile_flags_local_defines_from_impl_deps_test(
-    name = "get_compile_flags_local_defines_from_impl_deps",
-    tags = ["manual"],
-    target_under_test = ":compile_flags_tests_with_impl_dep_local_defines",
+    target_under_test = ":compile_flags_tests_with_dep_includes",
 )

--- a/test/unit/compile_commands/BUILD
+++ b/test/unit/compile_commands/BUILD
@@ -16,8 +16,12 @@ load("@rules_cc//cc:defs.bzl", "cc_library")
 load(
     ":compile_commands_analysis_test.bzl",
     "custom_ccinfo",
+    "get_compile_flags_defines_from_impl_deps_test",
+    "get_compile_flags_includes_from_impl_deps_test",
+    "get_compile_flags_local_defines_from_impl_deps_test",
     "get_compile_flags_no_duplicates_test",
     "get_compile_flags_quote_includes_from_deps_test",
+    "get_compile_flags_system_includes_from_impl_deps_test",
     "get_compile_flags_test_suite",
 )
 
@@ -135,4 +139,92 @@ get_compile_flags_quote_includes_from_deps_test(
     name = "get_compile_flags_quote_includes_from_deps",
     tags = ["manual"],
     target_under_test = ":compile_flags_tests_with_dep_quote_includes",
+)
+
+# includes from implementation_deps should be collected.
+cc_library(
+    name = "compile_flags_tests_impl_dep_with_includes",
+    srcs = ["testdata/bar.cc"],
+    hdrs = ["testdata/bar.h"],
+    includes = ["impl_dep/include"],
+    tags = ["manual"],
+)
+
+cc_library(
+    name = "compile_flags_tests_with_impl_dep_includes",
+    srcs = ["testdata/foo.cc"],
+    hdrs = ["testdata/foo.h"],
+    implementation_deps = [":compile_flags_tests_impl_dep_with_includes"],
+    tags = ["manual"],
+)
+
+get_compile_flags_includes_from_impl_deps_test(
+    name = "get_compile_flags_includes_from_impl_deps",
+    target_under_test = ":compile_flags_tests_with_impl_dep_includes",
+)
+
+# system_includes from implementation_deps should be collected.
+custom_ccinfo(
+    name = "compile_flags_tests_impl_dep_sys_include_provider",
+    system_includes = ["impl_dep/sys/include"],
+    tags = ["manual"],
+)
+
+cc_library(
+    name = "compile_flags_tests_with_impl_dep_system_includes",
+    srcs = ["testdata/foo.cc"],
+    hdrs = ["testdata/foo.h"],
+    implementation_deps = [":compile_flags_tests_impl_dep_sys_include_provider"],
+    tags = ["manual"],
+)
+
+get_compile_flags_system_includes_from_impl_deps_test(
+    name = "get_compile_flags_system_includes_from_impl_deps",
+    target_under_test = ":compile_flags_tests_with_impl_dep_system_includes",
+)
+
+# BUG (manual): defines from implementation_deps are not collected.
+cc_library(
+    name = "compile_flags_tests_impl_dep_with_defines",
+    srcs = ["testdata/bar.cc"],
+    hdrs = ["testdata/bar.h"],
+    defines = ["IMPL_DEP_DEFINE=1"],
+    tags = ["manual"],
+)
+
+cc_library(
+    name = "compile_flags_tests_with_impl_dep_defines",
+    srcs = ["testdata/foo.cc"],
+    hdrs = ["testdata/foo.h"],
+    implementation_deps = [":compile_flags_tests_impl_dep_with_defines"],
+    tags = ["manual"],
+)
+
+get_compile_flags_defines_from_impl_deps_test(
+    name = "get_compile_flags_defines_from_impl_deps",
+    tags = ["manual"],
+    target_under_test = ":compile_flags_tests_with_impl_dep_defines",
+)
+
+# BUG (manual): local_defines from implementation_deps are not collected.
+cc_library(
+    name = "compile_flags_tests_impl_dep_with_local_defines",
+    srcs = ["testdata/bar.cc"],
+    hdrs = ["testdata/bar.h"],
+    local_defines = ["IMPL_DEP_LOCAL_DEF=1"],
+    tags = ["manual"],
+)
+
+cc_library(
+    name = "compile_flags_tests_with_impl_dep_local_defines",
+    srcs = ["testdata/foo.cc"],
+    hdrs = ["testdata/foo.h"],
+    implementation_deps = [":compile_flags_tests_impl_dep_with_local_defines"],
+    tags = ["manual"],
+)
+
+get_compile_flags_local_defines_from_impl_deps_test(
+    name = "get_compile_flags_local_defines_from_impl_deps",
+    tags = ["manual"],
+    target_under_test = ":compile_flags_tests_with_impl_dep_local_defines",
 )

--- a/test/unit/compile_commands/BUILD
+++ b/test/unit/compile_commands/BUILD
@@ -19,7 +19,7 @@ load(
     "custom_ccinfo",
     "defines_from_impl_deps_test",
     "includes_from_impl_deps_test",
-    "local_defines_from_impl_deps_test",
+    "local_defines_in_impl_deps_test",
     "no_duplicates_test",
     "quote_includes_from_deps_test",
     "system_includes_from_impl_deps_test",
@@ -85,8 +85,8 @@ cc_library(
     tags = ["manual"],
 )
 
-local_defines_from_impl_deps_test(
-    name = "local_defines_from_impl_deps",
+local_defines_in_impl_deps_test(
+    name = "local_defines_in_impl_deps",
     target_under_test = ":compile_flags_tests_with_impl_dep_local_defines",
 )
 

--- a/test/unit/compile_commands/BUILD
+++ b/test/unit/compile_commands/BUILD
@@ -40,7 +40,6 @@ cc_library(
     tags = ["manual"],
 )
 
-# BUG (manual): defines from implementation_deps are not collected.
 cc_library(
     name = "compile_flags_tests_impl_dep_with_defines",
     srcs = ["testdata/bar.cc"],
@@ -59,7 +58,6 @@ cc_library(
 
 get_compile_flags_defines_from_impl_deps_test(
     name = "get_compile_flags_defines_from_impl_deps",
-    tags = ["manual"],
     target_under_test = ":compile_flags_tests_with_impl_dep_defines",
 )
 
@@ -71,7 +69,6 @@ cc_library(
     tags = ["manual"],
 )
 
-# BUG (manual): local_defines from implementation_deps are not collected.
 cc_library(
     name = "compile_flags_tests_impl_dep_with_local_defines",
     srcs = ["testdata/bar.cc"],
@@ -90,7 +87,6 @@ cc_library(
 
 get_compile_flags_local_defines_from_impl_deps_test(
     name = "get_compile_flags_local_defines_from_impl_deps",
-    tags = ["manual"],
     target_under_test = ":compile_flags_tests_with_impl_dep_local_defines",
 )
 
@@ -199,7 +195,6 @@ cc_library(
     deps = [":compile_flags_tests_quote_include_provider"],
 )
 
-# BUG (manual): quote_includes from implementation_deps are not collected.
 custom_ccinfo(
     name = "compile_flags_tests_dep_quote_include_provider",
     quote_includes = ["dep/quote/path"],
@@ -216,15 +211,12 @@ cc_library(
 
 get_compile_flags_quote_includes_from_deps_test(
     name = "get_compile_flags_quote_includes_from_deps",
-    tags = ["manual"],
     target_under_test = ":compile_flags_tests_with_dep_quote_includes",
 )
 
 get_compile_flags_test_suite(name = "compile_flags_tests")
 
-# BUG (manual): compile commands should not contain duplicate flags.
 get_compile_flags_no_duplicates_test(
     name = "get_compile_flags_no_duplicates",
-    tags = ["manual"],
     target_under_test = ":compile_flags_tests_with_dep_includes",
 )

--- a/test/unit/compile_commands/BUILD
+++ b/test/unit/compile_commands/BUILD
@@ -14,15 +14,15 @@
 
 load("@rules_cc//cc:defs.bzl", "cc_library")
 load(
-    ":compile_commands_analysis_test.bzl",
+    ":analysis_test.bzl",
+    "compile_flags_test_suite",
     "custom_ccinfo",
-    "get_compile_flags_defines_from_impl_deps_test",
-    "get_compile_flags_includes_from_impl_deps_test",
-    "get_compile_flags_local_defines_from_impl_deps_test",
-    "get_compile_flags_no_duplicates_test",
-    "get_compile_flags_quote_includes_from_deps_test",
-    "get_compile_flags_system_includes_from_impl_deps_test",
-    "get_compile_flags_test_suite",
+    "defines_from_impl_deps_test",
+    "includes_from_impl_deps_test",
+    "local_defines_from_impl_deps_test",
+    "no_duplicates_test",
+    "quote_includes_from_deps_test",
+    "system_includes_from_impl_deps_test",
 )
 
 # =============================================================================
@@ -56,8 +56,8 @@ cc_library(
     tags = ["manual"],
 )
 
-get_compile_flags_defines_from_impl_deps_test(
-    name = "get_compile_flags_defines_from_impl_deps",
+defines_from_impl_deps_test(
+    name = "defines_from_impl_deps",
     target_under_test = ":compile_flags_tests_with_impl_dep_defines",
 )
 
@@ -85,8 +85,8 @@ cc_library(
     tags = ["manual"],
 )
 
-get_compile_flags_local_defines_from_impl_deps_test(
-    name = "get_compile_flags_local_defines_from_impl_deps",
+local_defines_from_impl_deps_test(
+    name = "local_defines_from_impl_deps",
     target_under_test = ":compile_flags_tests_with_impl_dep_local_defines",
 )
 
@@ -115,8 +115,8 @@ cc_library(
     tags = ["manual"],
 )
 
-get_compile_flags_includes_from_impl_deps_test(
-    name = "get_compile_flags_includes_from_impl_deps",
+includes_from_impl_deps_test(
+    name = "includes_from_impl_deps",
     target_under_test = ":compile_flags_tests_with_impl_dep_includes",
 )
 
@@ -176,8 +176,8 @@ cc_library(
     tags = ["manual"],
 )
 
-get_compile_flags_system_includes_from_impl_deps_test(
-    name = "get_compile_flags_system_includes_from_impl_deps",
+system_includes_from_impl_deps_test(
+    name = "system_includes_from_impl_deps",
     target_under_test = ":compile_flags_tests_with_impl_dep_system_includes",
 )
 
@@ -209,14 +209,14 @@ cc_library(
     tags = ["manual"],
 )
 
-get_compile_flags_quote_includes_from_deps_test(
-    name = "get_compile_flags_quote_includes_from_deps",
+quote_includes_from_deps_test(
+    name = "quote_includes_from_deps",
     target_under_test = ":compile_flags_tests_with_dep_quote_includes",
 )
 
-get_compile_flags_test_suite(name = "compile_flags_tests")
+compile_flags_test_suite(name = "compile_flags_tests")
 
-get_compile_flags_no_duplicates_test(
-    name = "get_compile_flags_no_duplicates",
+no_duplicates_test(
+    name = "no_duplicates",
     target_under_test = ":compile_flags_tests_with_dep_includes",
 )

--- a/test/unit/compile_commands/analysis_test.bzl
+++ b/test/unit/compile_commands/analysis_test.bzl
@@ -65,7 +65,7 @@ def _get_compile_commands(source_files_info):
 # get_compile_flags
 # =============================================================================
 
-def _get_compile_flags_defines_test_impl(ctx):
+def _defines_test_impl(ctx):
     """defines appear as -D in the compile command."""
     env = analysistest.begin(ctx)
     commands = _get_compile_commands(analysistest.target_under_test(env)[SourceFilesInfo])
@@ -79,12 +79,12 @@ def _get_compile_flags_defines_test_impl(ctx):
 
     return analysistest.end(env)
 
-get_compile_flags_defines_test = analysistest.make(
-    _get_compile_flags_defines_test_impl,
+defines_test = analysistest.make(
+    _defines_test_impl,
     extra_target_under_test_aspects = [compile_commands_aspect],
 )
 
-def _get_compile_flags_defines_from_impl_deps_test_impl(ctx):
+def _defines_from_impl_deps_test_impl(ctx):
     """BUG: defines from implementation_deps are missing in compile commands. #305
 
     get_compile_flags iterates over deps in SOURCE_ATTR and collects includes,
@@ -105,12 +105,12 @@ def _get_compile_flags_defines_from_impl_deps_test_impl(ctx):
 
     return analysistest.end(env)
 
-get_compile_flags_defines_from_impl_deps_test = analysistest.make(
-    _get_compile_flags_defines_from_impl_deps_test_impl,
+defines_from_impl_deps_test = analysistest.make(
+    _defines_from_impl_deps_test_impl,
     extra_target_under_test_aspects = [compile_commands_aspect],
 )
 
-def _get_compile_flags_local_defines_test_impl(ctx):
+def _local_defines_test_impl(ctx):
     """local_defines appear as -D in the compile command."""
     env = analysistest.begin(ctx)
     commands = _get_compile_commands(analysistest.target_under_test(env)[SourceFilesInfo])
@@ -124,12 +124,12 @@ def _get_compile_flags_local_defines_test_impl(ctx):
 
     return analysistest.end(env)
 
-get_compile_flags_local_defines_test = analysistest.make(
-    _get_compile_flags_local_defines_test_impl,
+local_defines_test = analysistest.make(
+    _local_defines_test_impl,
     extra_target_under_test_aspects = [compile_commands_aspect],
 )
 
-def _get_compile_flags_local_defines_from_impl_deps_test_impl(ctx):
+def _local_defines_from_impl_deps_test_impl(ctx):
     """BUG: local_defines from implementation_deps are missing in compile commands. #306
 
     get_compile_flags iterates over deps in SOURCE_ATTR and collects includes,
@@ -151,12 +151,12 @@ def _get_compile_flags_local_defines_from_impl_deps_test_impl(ctx):
 
     return analysistest.end(env)
 
-get_compile_flags_local_defines_from_impl_deps_test = analysistest.make(
-    _get_compile_flags_local_defines_from_impl_deps_test_impl,
+local_defines_from_impl_deps_test = analysistest.make(
+    _local_defines_from_impl_deps_test_impl,
     extra_target_under_test_aspects = [compile_commands_aspect],
 )
 
-def _get_compile_flags_includes_test_impl(ctx):
+def _includes_test_impl(ctx):
     """includes appear as -I in the compile command."""
     env = analysistest.begin(ctx)
     commands = _get_compile_commands(analysistest.target_under_test(env)[SourceFilesInfo])
@@ -170,12 +170,12 @@ def _get_compile_flags_includes_test_impl(ctx):
 
     return analysistest.end(env)
 
-get_compile_flags_includes_test = analysistest.make(
-    _get_compile_flags_includes_test_impl,
+includes_test = analysistest.make(
+    _includes_test_impl,
     extra_target_under_test_aspects = [compile_commands_aspect],
 )
 
-def _get_compile_flags_includes_from_impl_deps_test_impl(ctx):
+def _includes_from_impl_deps_test_impl(ctx):
     """includes from implementation_deps propagate to the compile command."""
     env = analysistest.begin(ctx)
     commands = _get_compile_commands(analysistest.target_under_test(env)[SourceFilesInfo])
@@ -190,12 +190,12 @@ def _get_compile_flags_includes_from_impl_deps_test_impl(ctx):
 
     return analysistest.end(env)
 
-get_compile_flags_includes_from_impl_deps_test = analysistest.make(
-    _get_compile_flags_includes_from_impl_deps_test_impl,
+includes_from_impl_deps_test = analysistest.make(
+    _includes_from_impl_deps_test_impl,
     extra_target_under_test_aspects = [compile_commands_aspect],
 )
 
-def _get_compile_flags_copts_test_impl(ctx):
+def _copts_test_impl(ctx):
     """The copts flags are passed through to the compile command."""
     env = analysistest.begin(ctx)
     commands = _get_compile_commands(analysistest.target_under_test(env)[SourceFilesInfo])
@@ -214,12 +214,12 @@ def _get_compile_flags_copts_test_impl(ctx):
 
     return analysistest.end(env)
 
-get_compile_flags_copts_test = analysistest.make(
-    _get_compile_flags_copts_test_impl,
+copts_test = analysistest.make(
+    _copts_test_impl,
     extra_target_under_test_aspects = [compile_commands_aspect],
 )
 
-def _get_compile_flags_dep_includes_test_impl(ctx):
+def _dep_includes_test_impl(ctx):
     """includes from deps propagate to the compile command."""
     env = analysistest.begin(ctx)
     commands = _get_compile_commands(analysistest.target_under_test(env)[SourceFilesInfo])
@@ -234,12 +234,12 @@ def _get_compile_flags_dep_includes_test_impl(ctx):
 
     return analysistest.end(env)
 
-get_compile_flags_dep_includes_test = analysistest.make(
-    _get_compile_flags_dep_includes_test_impl,
+dep_includes_test = analysistest.make(
+    _dep_includes_test_impl,
     extra_target_under_test_aspects = [compile_commands_aspect],
 )
 
-def _get_compile_flags_system_includes_test_impl(ctx):
+def _system_includes_test_impl(ctx):
     """system_includes appear as -isystem in the compile command."""
     env = analysistest.begin(ctx)
     commands = _get_compile_commands(analysistest.target_under_test(env)[SourceFilesInfo])
@@ -253,12 +253,12 @@ def _get_compile_flags_system_includes_test_impl(ctx):
 
     return analysistest.end(env)
 
-get_compile_flags_system_includes_test = analysistest.make(
-    _get_compile_flags_system_includes_test_impl,
+system_includes_test = analysistest.make(
+    _system_includes_test_impl,
     extra_target_under_test_aspects = [compile_commands_aspect],
 )
 
-def _get_compile_flags_system_includes_from_impl_deps_test_impl(ctx):
+def _system_includes_from_impl_deps_test_impl(ctx):
     """system_includes from implementation_deps appear as -isystem in the compile command."""
     env = analysistest.begin(ctx)
     commands = _get_compile_commands(analysistest.target_under_test(env)[SourceFilesInfo])
@@ -273,12 +273,12 @@ def _get_compile_flags_system_includes_from_impl_deps_test_impl(ctx):
 
     return analysistest.end(env)
 
-get_compile_flags_system_includes_from_impl_deps_test = analysistest.make(
-    _get_compile_flags_system_includes_from_impl_deps_test_impl,
+system_includes_from_impl_deps_test = analysistest.make(
+    _system_includes_from_impl_deps_test_impl,
     extra_target_under_test_aspects = [compile_commands_aspect],
 )
 
-def _get_compile_flags_quote_includes_test_impl(ctx):
+def _quote_includes_test_impl(ctx):
     """quote_includes appear as -iquote in the compile command."""
     env = analysistest.begin(ctx)
     commands = _get_compile_commands(analysistest.target_under_test(env)[SourceFilesInfo])
@@ -292,12 +292,12 @@ def _get_compile_flags_quote_includes_test_impl(ctx):
 
     return analysistest.end(env)
 
-get_compile_flags_quote_includes_test = analysistest.make(
-    _get_compile_flags_quote_includes_test_impl,
+quote_includes_test = analysistest.make(
+    _quote_includes_test_impl,
     extra_target_under_test_aspects = [compile_commands_aspect],
 )
 
-def _get_compile_flags_quote_includes_from_deps_test_impl(ctx):
+def _quote_includes_from_deps_test_impl(ctx):
     """BUG: quote_includes from implementation_deps are missing in compile commands. #304
 
     get_compile_flags iterates over deps in SOURCE_ATTR and collects includes,
@@ -318,12 +318,12 @@ def _get_compile_flags_quote_includes_from_deps_test_impl(ctx):
 
     return analysistest.end(env)
 
-get_compile_flags_quote_includes_from_deps_test = analysistest.make(
-    _get_compile_flags_quote_includes_from_deps_test_impl,
+quote_includes_from_deps_test = analysistest.make(
+    _quote_includes_from_deps_test_impl,
     extra_target_under_test_aspects = [compile_commands_aspect],
 )
 
-def _get_compile_flags_no_duplicates_test_impl(ctx):
+def _no_duplicates_test_impl(ctx):
     """BUG: Compile flags should not contain duplicates. #307
 
     get_compile_flags may add the same include path multiple times — once
@@ -357,8 +357,8 @@ def _get_compile_flags_no_duplicates_test_impl(ctx):
 
     return analysistest.end(env)
 
-get_compile_flags_no_duplicates_test = analysistest.make(
-    _get_compile_flags_no_duplicates_test_impl,
+no_duplicates_test = analysistest.make(
+    _no_duplicates_test_impl,
     extra_target_under_test_aspects = [compile_commands_aspect],
 )
 
@@ -366,37 +366,37 @@ get_compile_flags_no_duplicates_test = analysistest.make(
 # Test suites
 # =============================================================================
 
-def get_compile_flags_test_suite(name):
+def compile_flags_test_suite(name):
     """Analysis tests for get_compile_flags.
 
     Args:
         name: the name prefix for the test suite.
     """
-    get_compile_flags_defines_test(
+    defines_test(
         name = name + "_defines_test",
         target_under_test = ":" + name + "_with_defines",
     )
-    get_compile_flags_local_defines_test(
+    local_defines_test(
         name = name + "_local_defines_test",
         target_under_test = ":" + name + "_with_local_defines",
     )
-    get_compile_flags_includes_test(
+    includes_test(
         name = name + "_includes_test",
         target_under_test = ":" + name + "_with_includes",
     )
-    get_compile_flags_copts_test(
+    copts_test(
         name = name + "_copts_test",
         target_under_test = ":" + name + "_with_copts",
     )
-    get_compile_flags_dep_includes_test(
+    dep_includes_test(
         name = name + "_dep_includes_test",
         target_under_test = ":" + name + "_with_dep_includes",
     )
-    get_compile_flags_system_includes_test(
+    system_includes_test(
         name = name + "_system_includes_test",
         target_under_test = ":" + name + "_with_system_includes",
     )
-    get_compile_flags_quote_includes_test(
+    quote_includes_test(
         name = name + "_quote_includes_test",
         target_under_test = ":" + name + "_with_quote_includes",
     )

--- a/test/unit/compile_commands/analysis_test.bzl
+++ b/test/unit/compile_commands/analysis_test.bzl
@@ -129,30 +129,35 @@ local_defines_test = analysistest.make(
     extra_target_under_test_aspects = [compile_commands_aspect],
 )
 
-def _local_defines_from_impl_deps_test_impl(ctx):
-    """BUG: local_defines from implementation_deps are missing in compile commands. #306
-
-    get_compile_flags iterates over deps in SOURCE_ATTR and collects includes,
-    system_includes, and external_includes — but NOT local_defines.
-    """
+def _local_defines_in_impl_deps_test_impl(ctx):
+    """local_defines from implementation_deps are local to the dep's own sources."""
     env = analysistest.begin(ctx)
     commands = _get_compile_commands(analysistest.target_under_test(env)[SourceFilesInfo])
 
     foo_commands = [c for c in commands if "foo.cc" in c]
     asserts.true(env, len(foo_commands) > 0, "Should have a command for foo.cc")
 
-    # FIXME: Change to true
     asserts.false(
         env,
         "IMPL_DEP_LOCAL_DEF" in foo_commands[0],
-        "Should contain local_define IMPL_DEP_LOCAL_DEF from " +
+        "Should not contain local_define IMPL_DEP_LOCAL_DEF from " +
         "implementation_dep, got: %s" % foo_commands[0],
+    )
+
+    bar_commands = [c for c in commands if "bar.cc" in c]
+    asserts.true(env, len(bar_commands) > 0, "Should have a command for bar.cc")
+
+    asserts.true(
+        env,
+        "IMPL_DEP_LOCAL_DEF" in bar_commands[0],
+        "Should contain local_define IMPL_DEP_LOCAL_DEF from " +
+        "implementation_dep, got: %s" % bar_commands[0],
     )
 
     return analysistest.end(env)
 
-local_defines_from_impl_deps_test = analysistest.make(
-    _local_defines_from_impl_deps_test_impl,
+local_defines_in_impl_deps_test = analysistest.make(
+    _local_defines_in_impl_deps_test_impl,
     extra_target_under_test_aspects = [compile_commands_aspect],
 )
 

--- a/test/unit/compile_commands/analysis_test.bzl
+++ b/test/unit/compile_commands/analysis_test.bzl
@@ -342,13 +342,22 @@ def _no_duplicates_test_impl(ctx):
     foo_commands = [c for c in commands if "foo.cc" in c]
     asserts.true(env, len(foo_commands) > 0, "Should have a command for foo.cc")
 
-    # Split command into flags and check for duplicates
-    flags = foo_commands[0].split(" ")
+    # Split command into flag+value pairs and check for duplicates.
+    # If a token starts with "-" it begins a new flag; otherwise it's the
+    # value of the previous flag (e.g. "-I /path" becomes one entry).
+    tokens = foo_commands[0].split(" ")
+    flags = []
+    for t in tokens:
+        if t == "":
+            continue
+        if t.startswith("-") or len(flags) == 0:
+            flags.append(t)
+        else:
+            flags[-1] = flags[-1] + " " + t
+
     seen = []
     duplicates = []
     for f in flags:
-        if f == "":
-            continue
         if f in seen and f not in duplicates:
             duplicates.append(f)
         seen.append(f)

--- a/test/unit/compile_commands/analysis_test.bzl
+++ b/test/unit/compile_commands/analysis_test.bzl
@@ -62,7 +62,7 @@ def _get_compile_commands(source_files_info):
     return [entry.command for entry in source_files_info.compilation_db.to_list()]
 
 # =============================================================================
-# get_compile_flags
+# Compilation flag collection tests
 # =============================================================================
 
 def _defines_test_impl(ctx):
@@ -85,10 +85,11 @@ defines_test = analysistest.make(
 )
 
 def _defines_from_impl_deps_test_impl(ctx):
-    """BUG: defines from implementation_deps are missing in compile commands. #305
+    """BUG: defines from implementation_deps are missing. #305
 
-    get_compile_flags iterates over deps in SOURCE_ATTR and collects includes,
-    system_includes, and external_includes — but NOT defines.
+    Compile command generation iterates over deps in SOURCE_ATTR and
+    collects includes, system_includes, and external_includes — but
+    NOT defines.
     """
     env = analysistest.begin(ctx)
     commands = _get_compile_commands(analysistest.target_under_test(env)[SourceFilesInfo])
@@ -303,10 +304,11 @@ quote_includes_test = analysistest.make(
 )
 
 def _quote_includes_from_deps_test_impl(ctx):
-    """BUG: quote_includes from implementation_deps are missing in compile commands. #304
+    """BUG: quote_includes from implementation_deps are missing. #304
 
-    get_compile_flags iterates over deps in SOURCE_ATTR and collects includes,
-    system_includes, and external_includes — but NOT quote_includes.
+    Compile command generation iterates over deps in SOURCE_ATTR and
+    collects includes, system_includes, and external_includes — but
+    NOT quote_includes.
     """
     env = analysistest.begin(ctx)
     commands = _get_compile_commands(analysistest.target_under_test(env)[SourceFilesInfo])
@@ -331,10 +333,11 @@ quote_includes_from_deps_test = analysistest.make(
 def _no_duplicates_test_impl(ctx):
     """BUG: Compile flags should not contain duplicates. #307
 
-    get_compile_flags may add the same include path multiple times — once
-    from the target's own CcInfo compilation_context, and again when iterating
-    over deps in SOURCE_ATTR. This test asserts the desired behavior:
-    no flag should appear more than once in a compile command.
+    Compile command generation may add the same include path multiple
+    times — once from the target's own CcInfo compilation_context,
+    and again when iterating over deps in SOURCE_ATTR. This test
+    asserts the desired behavior: no flag should appear more than
+    once in a compile command.
     """
     env = analysistest.begin(ctx)
     commands = _get_compile_commands(analysistest.target_under_test(env)[SourceFilesInfo])
@@ -381,7 +384,7 @@ no_duplicates_test = analysistest.make(
 # =============================================================================
 
 def compile_flags_test_suite(name):
-    """Analysis tests for get_compile_flags.
+    """Analysis tests for compile command generation.
 
     Args:
         name: the name prefix for the test suite.

--- a/test/unit/compile_commands/analysis_test.bzl
+++ b/test/unit/compile_commands/analysis_test.bzl
@@ -85,20 +85,14 @@ defines_test = analysistest.make(
 )
 
 def _defines_from_impl_deps_test_impl(ctx):
-    """BUG: defines from implementation_deps are missing. #305
-
-    Compile command generation iterates over deps in SOURCE_ATTR and
-    collects includes, system_includes, and external_includes — but
-    NOT defines.
-    """
+    """defines from implementation_deps appear as -D in the compile command."""
     env = analysistest.begin(ctx)
     commands = _get_compile_commands(analysistest.target_under_test(env)[SourceFilesInfo])
 
     foo_commands = [c for c in commands if "foo.cc" in c]
     asserts.true(env, len(foo_commands) > 0, "Should have a command for foo.cc")
 
-    # FIXME: Change to true
-    asserts.false(
+    asserts.true(
         env,
         "IMPL_DEP_DEFINE" in foo_commands[0],
         "Should contain define IMPL_DEP_DEFINE from implementation_dep, got: %s" % foo_commands[0],
@@ -304,20 +298,14 @@ quote_includes_test = analysistest.make(
 )
 
 def _quote_includes_from_deps_test_impl(ctx):
-    """BUG: quote_includes from implementation_deps are missing. #304
-
-    Compile command generation iterates over deps in SOURCE_ATTR and
-    collects includes, system_includes, and external_includes — but
-    NOT quote_includes.
-    """
+    """quote_includes from implementation_deps appear as -iquote in the compile command."""
     env = analysistest.begin(ctx)
     commands = _get_compile_commands(analysistest.target_under_test(env)[SourceFilesInfo])
 
     foo_commands = [c for c in commands if "foo.cc" in c]
     asserts.true(env, len(foo_commands) > 0, "Should have a command for foo.cc")
 
-    # FIXME: Change to true
-    asserts.false(
+    asserts.true(
         env,
         "-iquote dep/quote/path" in foo_commands[0],
         "Should contain -iquote dep/quote/path from implementation_dep, got: %s" % foo_commands[0],
@@ -331,14 +319,7 @@ quote_includes_from_deps_test = analysistest.make(
 )
 
 def _no_duplicates_test_impl(ctx):
-    """BUG: Compile flags should not contain duplicates. #307
-
-    Compile command generation may add the same include path multiple
-    times — once from the target's own CcInfo compilation_context,
-    and again when iterating over deps in SOURCE_ATTR. This test
-    asserts the desired behavior: no flag should appear more than
-    once in a compile command.
-    """
+    """Compile flags should not contain duplicates."""
     env = analysistest.begin(ctx)
     commands = _get_compile_commands(analysistest.target_under_test(env)[SourceFilesInfo])
 
@@ -365,8 +346,7 @@ def _no_duplicates_test_impl(ctx):
             duplicates.append(f)
         seen.append(f)
 
-    # FIXME: Change to true
-    asserts.false(
+    asserts.true(
         env,
         len(duplicates) == 0,
         "Compile command should not have duplicate flags, found: %s" % duplicates,

--- a/test/unit/compile_commands/compile_commands_analysis_test.bzl
+++ b/test/unit/compile_commands/compile_commands_analysis_test.bzl
@@ -1,0 +1,317 @@
+# Copyright 2026 Ericsson AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Analysis-phase tests for compile_commands.bzl.
+
+Tests the following functions indirectly via compile_commands_aspect:
+  - collect_headers
+  - get_sources
+  - get_compile_flags
+  - _cc_compiler_info
+"""
+
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+load(
+    "//src:compile_commands.bzl",
+    "SourceFilesInfo",
+    "compile_commands_aspect",
+)
+
+# =============================================================================
+# Helper rules
+# =============================================================================
+
+def _custom_ccinfo_impl(ctx):
+    """Rule that provides a CcInfo with custom include paths."""
+    compilation_context = cc_common.create_compilation_context(
+        system_includes = depset(ctx.attr.system_includes),
+        quote_includes = depset(ctx.attr.quote_includes),
+        includes = depset(ctx.attr.includes),
+    )
+    return [CcInfo(compilation_context = compilation_context)]
+
+custom_ccinfo = rule(
+    implementation = _custom_ccinfo_impl,
+    attrs = {
+        "includes": attr.string_list(default = []),
+        "quote_includes": attr.string_list(default = []),
+        "system_includes": attr.string_list(default = []),
+    },
+)
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+def _get_compile_commands(source_files_info):
+    """Extract command strings from SourceFilesInfo.compilation_db."""
+    return [entry.command for entry in source_files_info.compilation_db.to_list()]
+
+# =============================================================================
+# get_compile_flags
+# =============================================================================
+
+def _get_compile_flags_defines_test_impl(ctx):
+    """defines appear as -D in the compile command."""
+    env = analysistest.begin(ctx)
+    commands = _get_compile_commands(analysistest.target_under_test(env)[SourceFilesInfo])
+
+    asserts.true(env, len(commands) > 0, "Should have at least one compile command")
+    asserts.true(
+        env,
+        "MY_DEFINE" in commands[0],
+        "Should contain define MY_DEFINE, got: %s" % commands[0],
+    )
+
+    return analysistest.end(env)
+
+get_compile_flags_defines_test = analysistest.make(
+    _get_compile_flags_defines_test_impl,
+    extra_target_under_test_aspects = [compile_commands_aspect],
+)
+
+def _get_compile_flags_local_defines_test_impl(ctx):
+    """local_defines appear as -D in the compile command."""
+    env = analysistest.begin(ctx)
+    commands = _get_compile_commands(analysistest.target_under_test(env)[SourceFilesInfo])
+
+    asserts.true(env, len(commands) > 0, "Should have at least one compile command")
+    asserts.true(
+        env,
+        "LOCAL_DEF" in commands[0],
+        "Should contain local_define LOCAL_DEF, got: %s" % commands[0],
+    )
+
+    return analysistest.end(env)
+
+get_compile_flags_local_defines_test = analysistest.make(
+    _get_compile_flags_local_defines_test_impl,
+    extra_target_under_test_aspects = [compile_commands_aspect],
+)
+
+def _get_compile_flags_includes_test_impl(ctx):
+    """includes appear as -I in the compile command."""
+    env = analysistest.begin(ctx)
+    commands = _get_compile_commands(analysistest.target_under_test(env)[SourceFilesInfo])
+
+    asserts.true(env, len(commands) > 0, "Should have at least one compile command")
+    asserts.true(
+        env,
+        "my/include/path" in commands[0],
+        "Should contain include path, got: %s" % commands[0],
+    )
+
+    return analysistest.end(env)
+
+get_compile_flags_includes_test = analysistest.make(
+    _get_compile_flags_includes_test_impl,
+    extra_target_under_test_aspects = [compile_commands_aspect],
+)
+
+def _get_compile_flags_copts_test_impl(ctx):
+    """copts are passed through to the compile command."""
+    env = analysistest.begin(ctx)
+    commands = _get_compile_commands(analysistest.target_under_test(env)[SourceFilesInfo])
+
+    asserts.true(env, len(commands) > 0, "Should have at least one compile command")
+    asserts.true(
+        env,
+        "-Wall" in commands[0],
+        "Should contain -Wall, got: %s" % commands[0],
+    )
+    asserts.true(
+        env,
+        "-Wextra" in commands[0],
+        "Should contain -Wextra, got: %s" % commands[0],
+    )
+
+    return analysistest.end(env)
+
+get_compile_flags_copts_test = analysistest.make(
+    _get_compile_flags_copts_test_impl,
+    extra_target_under_test_aspects = [compile_commands_aspect],
+)
+
+def _get_compile_flags_dep_includes_test_impl(ctx):
+    """includes from deps propagate to the compile command."""
+    env = analysistest.begin(ctx)
+    commands = _get_compile_commands(analysistest.target_under_test(env)[SourceFilesInfo])
+
+    foo_commands = [c for c in commands if "foo.cc" in c]
+    asserts.true(env, len(foo_commands) > 0, "Should have a command for foo.cc")
+    asserts.true(
+        env,
+        "dep/include" in foo_commands[0],
+        "Should contain dep's include path, got: %s" % foo_commands[0],
+    )
+
+    return analysistest.end(env)
+
+get_compile_flags_dep_includes_test = analysistest.make(
+    _get_compile_flags_dep_includes_test_impl,
+    extra_target_under_test_aspects = [compile_commands_aspect],
+)
+
+def _get_compile_flags_system_includes_test_impl(ctx):
+    """system_includes appear as -isystem in the compile command."""
+    env = analysistest.begin(ctx)
+    commands = _get_compile_commands(analysistest.target_under_test(env)[SourceFilesInfo])
+
+    asserts.true(env, len(commands) > 0, "Should have at least one compile command")
+    asserts.true(
+        env,
+        "-isystem my/sys/include" in commands[0],
+        "Should contain -isystem my/sys/include, got: %s" % commands[0],
+    )
+
+    return analysistest.end(env)
+
+get_compile_flags_system_includes_test = analysistest.make(
+    _get_compile_flags_system_includes_test_impl,
+    extra_target_under_test_aspects = [compile_commands_aspect],
+)
+
+def _get_compile_flags_quote_includes_test_impl(ctx):
+    """quote_includes appear as -iquote in the compile command."""
+    env = analysistest.begin(ctx)
+    commands = _get_compile_commands(analysistest.target_under_test(env)[SourceFilesInfo])
+
+    asserts.true(env, len(commands) > 0, "Should have at least one compile command")
+    asserts.true(
+        env,
+        "-iquote my/quote/include" in commands[0],
+        "Should contain -iquote my/quote/include, got: %s" % commands[0],
+    )
+
+    return analysistest.end(env)
+
+get_compile_flags_quote_includes_test = analysistest.make(
+    _get_compile_flags_quote_includes_test_impl,
+    extra_target_under_test_aspects = [compile_commands_aspect],
+)
+
+def _get_compile_flags_quote_includes_from_deps_test_impl(ctx):
+    """BUG: quote_includes from implementation_deps are missing in compile commands.
+
+    get_compile_flags iterates over deps in SOURCE_ATTR and collects includes,
+    system_includes, and external_includes — but NOT quote_includes.
+    """
+    env = analysistest.begin(ctx)
+    commands = _get_compile_commands(analysistest.target_under_test(env)[SourceFilesInfo])
+
+    foo_commands = [c for c in commands if "foo.cc" in c]
+    asserts.true(env, len(foo_commands) > 0, "Should have a command for foo.cc")
+
+    asserts.true(
+        env,
+        "-iquote dep/quote/path" in foo_commands[0],
+        "Should contain -iquote dep/quote/path from implementation_dep, got: %s" % foo_commands[0],
+    )
+
+    return analysistest.end(env)
+
+get_compile_flags_quote_includes_from_deps_test = analysistest.make(
+    _get_compile_flags_quote_includes_from_deps_test_impl,
+    extra_target_under_test_aspects = [compile_commands_aspect],
+)
+
+def _get_compile_flags_no_duplicates_test_impl(ctx):
+    """BUG: Compile flags should not contain duplicates.
+
+    get_compile_flags may add the same include path multiple times — once
+    from the target's own CcInfo compilation_context, and again when iterating
+    over deps in SOURCE_ATTR. This test asserts the desired fixed behavior:
+    no flag should appear more than once in a compile command.
+    """
+    env = analysistest.begin(ctx)
+    commands = _get_compile_commands(analysistest.target_under_test(env)[SourceFilesInfo])
+
+    foo_commands = [c for c in commands if "foo.cc" in c]
+    asserts.true(env, len(foo_commands) > 0, "Should have a command for foo.cc")
+
+    # Split command into flags and check for duplicates
+    flags = foo_commands[0].split(" ")
+    seen = []
+    duplicates = []
+    for f in flags:
+        if f == "":
+            continue
+        if f in seen and f not in duplicates:
+            duplicates.append(f)
+        seen.append(f)
+    asserts.true(
+        env,
+        len(duplicates) == 0,
+        "Compile command should not have duplicate flags, found: %s" % duplicates,
+    )
+
+    return analysistest.end(env)
+
+get_compile_flags_no_duplicates_test = analysistest.make(
+    _get_compile_flags_no_duplicates_test_impl,
+    extra_target_under_test_aspects = [compile_commands_aspect],
+)
+
+# =============================================================================
+# Test suites
+# =============================================================================
+
+def get_compile_flags_test_suite(name):
+    """Analysis tests for get_compile_flags.
+
+    Args:
+        name: the name prefix for the test suite.
+    """
+    get_compile_flags_defines_test(
+        name = name + "_defines_test",
+        target_under_test = ":" + name + "_with_defines",
+    )
+    get_compile_flags_local_defines_test(
+        name = name + "_local_defines_test",
+        target_under_test = ":" + name + "_with_local_defines",
+    )
+    get_compile_flags_includes_test(
+        name = name + "_includes_test",
+        target_under_test = ":" + name + "_with_includes",
+    )
+    get_compile_flags_copts_test(
+        name = name + "_copts_test",
+        target_under_test = ":" + name + "_with_copts",
+    )
+    get_compile_flags_dep_includes_test(
+        name = name + "_dep_includes_test",
+        target_under_test = ":" + name + "_with_dep_includes",
+    )
+    get_compile_flags_system_includes_test(
+        name = name + "_system_includes_test",
+        target_under_test = ":" + name + "_with_system_includes",
+    )
+    get_compile_flags_quote_includes_test(
+        name = name + "_quote_includes_test",
+        target_under_test = ":" + name + "_with_quote_includes",
+    )
+
+    native.test_suite(
+        name = name,
+        tests = [
+            ":" + name + "_defines_test",
+            ":" + name + "_local_defines_test",
+            ":" + name + "_includes_test",
+            ":" + name + "_copts_test",
+            ":" + name + "_dep_includes_test",
+            ":" + name + "_system_includes_test",
+            ":" + name + "_quote_includes_test",
+        ],
+    )

--- a/test/unit/compile_commands/compile_commands_analysis_test.bzl
+++ b/test/unit/compile_commands/compile_commands_analysis_test.bzl
@@ -34,8 +34,9 @@ load(
 # =============================================================================
 
 def _custom_ccinfo_impl(ctx):
-    """Rule that provides a CcInfo with custom include paths."""
+    """Rule that provides a CcInfo with custom include paths and defines."""
     compilation_context = cc_common.create_compilation_context(
+        defines = depset(ctx.attr.defines),
         system_includes = depset(ctx.attr.system_includes),
         quote_includes = depset(ctx.attr.quote_includes),
         includes = depset(ctx.attr.includes),
@@ -45,6 +46,7 @@ def _custom_ccinfo_impl(ctx):
 custom_ccinfo = rule(
     implementation = _custom_ccinfo_impl,
     attrs = {
+        "defines": attr.string_list(default = []),
         "includes": attr.string_list(default = []),
         "quote_includes": attr.string_list(default = []),
         "system_includes": attr.string_list(default = []),
@@ -82,6 +84,30 @@ get_compile_flags_defines_test = analysistest.make(
     extra_target_under_test_aspects = [compile_commands_aspect],
 )
 
+def _get_compile_flags_defines_from_impl_deps_test_impl(ctx):
+    """BUG: defines from implementation_deps are missing in compile commands.
+
+    get_compile_flags iterates over deps in SOURCE_ATTR and collects includes,
+    system_includes, and external_includes — but NOT defines.
+    """
+    env = analysistest.begin(ctx)
+    commands = _get_compile_commands(analysistest.target_under_test(env)[SourceFilesInfo])
+
+    foo_commands = [c for c in commands if "foo.cc" in c]
+    asserts.true(env, len(foo_commands) > 0, "Should have a command for foo.cc")
+    asserts.true(
+        env,
+        "IMPL_DEP_DEFINE" in foo_commands[0],
+        "Should contain define IMPL_DEP_DEFINE from implementation_dep, got: %s" % foo_commands[0],
+    )
+
+    return analysistest.end(env)
+
+get_compile_flags_defines_from_impl_deps_test = analysistest.make(
+    _get_compile_flags_defines_from_impl_deps_test_impl,
+    extra_target_under_test_aspects = [compile_commands_aspect],
+)
+
 def _get_compile_flags_local_defines_test_impl(ctx):
     """local_defines appear as -D in the compile command."""
     env = analysistest.begin(ctx)
@@ -101,6 +127,30 @@ get_compile_flags_local_defines_test = analysistest.make(
     extra_target_under_test_aspects = [compile_commands_aspect],
 )
 
+def _get_compile_flags_local_defines_from_impl_deps_test_impl(ctx):
+    """BUG: local_defines from implementation_deps are missing in compile commands.
+
+    get_compile_flags iterates over deps in SOURCE_ATTR and collects includes,
+    system_includes, and external_includes — but NOT local_defines.
+    """
+    env = analysistest.begin(ctx)
+    commands = _get_compile_commands(analysistest.target_under_test(env)[SourceFilesInfo])
+
+    foo_commands = [c for c in commands if "foo.cc" in c]
+    asserts.true(env, len(foo_commands) > 0, "Should have a command for foo.cc")
+    asserts.true(
+        env,
+        "IMPL_DEP_LOCAL_DEF" in foo_commands[0],
+        "Should contain local_define IMPL_DEP_LOCAL_DEF from implementation_dep, got: %s" % foo_commands[0],
+    )
+
+    return analysistest.end(env)
+
+get_compile_flags_local_defines_from_impl_deps_test = analysistest.make(
+    _get_compile_flags_local_defines_from_impl_deps_test_impl,
+    extra_target_under_test_aspects = [compile_commands_aspect],
+)
+
 def _get_compile_flags_includes_test_impl(ctx):
     """includes appear as -I in the compile command."""
     env = analysistest.begin(ctx)
@@ -117,6 +167,26 @@ def _get_compile_flags_includes_test_impl(ctx):
 
 get_compile_flags_includes_test = analysistest.make(
     _get_compile_flags_includes_test_impl,
+    extra_target_under_test_aspects = [compile_commands_aspect],
+)
+
+def _get_compile_flags_includes_from_impl_deps_test_impl(ctx):
+    """includes from implementation_deps propagate to the compile command."""
+    env = analysistest.begin(ctx)
+    commands = _get_compile_commands(analysistest.target_under_test(env)[SourceFilesInfo])
+
+    foo_commands = [c for c in commands if "foo.cc" in c]
+    asserts.true(env, len(foo_commands) > 0, "Should have a command for foo.cc")
+    asserts.true(
+        env,
+        "impl_dep/include" in foo_commands[0],
+        "Should contain impl_dep's include path, got: %s" % foo_commands[0],
+    )
+
+    return analysistest.end(env)
+
+get_compile_flags_includes_from_impl_deps_test = analysistest.make(
+    _get_compile_flags_includes_from_impl_deps_test_impl,
     extra_target_under_test_aspects = [compile_commands_aspect],
 )
 
@@ -183,6 +253,26 @@ get_compile_flags_system_includes_test = analysistest.make(
     extra_target_under_test_aspects = [compile_commands_aspect],
 )
 
+def _get_compile_flags_system_includes_from_impl_deps_test_impl(ctx):
+    """system_includes from implementation_deps appear as -isystem in the compile command."""
+    env = analysistest.begin(ctx)
+    commands = _get_compile_commands(analysistest.target_under_test(env)[SourceFilesInfo])
+
+    foo_commands = [c for c in commands if "foo.cc" in c]
+    asserts.true(env, len(foo_commands) > 0, "Should have a command for foo.cc")
+    asserts.true(
+        env,
+        "-isystem impl_dep/sys/include" in foo_commands[0],
+        "Should contain -isystem impl_dep/sys/include from implementation_dep, got: %s" % foo_commands[0],
+    )
+
+    return analysistest.end(env)
+
+get_compile_flags_system_includes_from_impl_deps_test = analysistest.make(
+    _get_compile_flags_system_includes_from_impl_deps_test_impl,
+    extra_target_under_test_aspects = [compile_commands_aspect],
+)
+
 def _get_compile_flags_quote_includes_test_impl(ctx):
     """quote_includes appear as -iquote in the compile command."""
     env = analysistest.begin(ctx)
@@ -232,7 +322,7 @@ def _get_compile_flags_no_duplicates_test_impl(ctx):
 
     get_compile_flags may add the same include path multiple times — once
     from the target's own CcInfo compilation_context, and again when iterating
-    over deps in SOURCE_ATTR. This test asserts the desired fixed behavior:
+    over deps in SOURCE_ATTR. This test asserts the desired behavior:
     no flag should appear more than once in a compile command.
     """
     env = analysistest.begin(ctx)

--- a/test/unit/compile_commands/compile_commands_analysis_test.bzl
+++ b/test/unit/compile_commands/compile_commands_analysis_test.bzl
@@ -85,7 +85,7 @@ get_compile_flags_defines_test = analysistest.make(
 )
 
 def _get_compile_flags_defines_from_impl_deps_test_impl(ctx):
-    """BUG: defines from implementation_deps are missing in compile commands.
+    """BUG: defines from implementation_deps are missing in compile commands. #305
 
     get_compile_flags iterates over deps in SOURCE_ATTR and collects includes,
     system_includes, and external_includes — but NOT defines.
@@ -130,7 +130,7 @@ get_compile_flags_local_defines_test = analysistest.make(
 )
 
 def _get_compile_flags_local_defines_from_impl_deps_test_impl(ctx):
-    """BUG: local_defines from implementation_deps are missing in compile commands.
+    """BUG: local_defines from implementation_deps are missing in compile commands. #306
 
     get_compile_flags iterates over deps in SOURCE_ATTR and collects includes,
     system_includes, and external_includes — but NOT local_defines.
@@ -298,7 +298,7 @@ get_compile_flags_quote_includes_test = analysistest.make(
 )
 
 def _get_compile_flags_quote_includes_from_deps_test_impl(ctx):
-    """BUG: quote_includes from implementation_deps are missing in compile commands.
+    """BUG: quote_includes from implementation_deps are missing in compile commands. #304
 
     get_compile_flags iterates over deps in SOURCE_ATTR and collects includes,
     system_includes, and external_includes — but NOT quote_includes.
@@ -324,7 +324,7 @@ get_compile_flags_quote_includes_from_deps_test = analysistest.make(
 )
 
 def _get_compile_flags_no_duplicates_test_impl(ctx):
-    """BUG: Compile flags should not contain duplicates.
+    """BUG: Compile flags should not contain duplicates. #307
 
     get_compile_flags may add the same include path multiple times — once
     from the target's own CcInfo compilation_context, and again when iterating

--- a/test/unit/compile_commands/compile_commands_analysis_test.bzl
+++ b/test/unit/compile_commands/compile_commands_analysis_test.bzl
@@ -85,7 +85,9 @@ get_compile_flags_defines_test = analysistest.make(
 )
 
 def _get_compile_flags_defines_from_impl_deps_test_impl(ctx):
-    """BUG: defines from implementation_deps are missing in compile commands. #305
+    """
+    BUG: defines from implementation_deps are missing in compile commands. 
+    GitHub issue #305
 
     get_compile_flags iterates over deps in SOURCE_ATTR and collects includes,
     system_includes, and external_includes — but NOT defines.
@@ -130,7 +132,9 @@ get_compile_flags_local_defines_test = analysistest.make(
 )
 
 def _get_compile_flags_local_defines_from_impl_deps_test_impl(ctx):
-    """BUG: local_defines from implementation_deps are missing in compile commands. #306
+    """
+    BUG: local_defines from implementation_deps are missing in compile commands.
+    GitHub issue #306
 
     get_compile_flags iterates over deps in SOURCE_ATTR and collects includes,
     system_includes, and external_includes — but NOT local_defines.
@@ -298,7 +302,9 @@ get_compile_flags_quote_includes_test = analysistest.make(
 )
 
 def _get_compile_flags_quote_includes_from_deps_test_impl(ctx):
-    """BUG: quote_includes from implementation_deps are missing in compile commands. #304
+    """
+    BUG: quote_includes from implementation_deps are missing in compile commands.
+    GitHub issue #304
 
     get_compile_flags iterates over deps in SOURCE_ATTR and collects includes,
     system_includes, and external_includes — but NOT quote_includes.
@@ -324,7 +330,9 @@ get_compile_flags_quote_includes_from_deps_test = analysistest.make(
 )
 
 def _get_compile_flags_no_duplicates_test_impl(ctx):
-    """BUG: Compile flags should not contain duplicates. #307
+    """
+    BUG: Compile flags should not contain duplicates.
+    GitHub issue #307
 
     get_compile_flags may add the same include path multiple times — once
     from the target's own CcInfo compilation_context, and again when iterating

--- a/test/unit/compile_commands/compile_commands_analysis_test.bzl
+++ b/test/unit/compile_commands/compile_commands_analysis_test.bzl
@@ -95,7 +95,9 @@ def _get_compile_flags_defines_from_impl_deps_test_impl(ctx):
 
     foo_commands = [c for c in commands if "foo.cc" in c]
     asserts.true(env, len(foo_commands) > 0, "Should have a command for foo.cc")
-    asserts.true(
+
+    # FIXME: Change to true
+    asserts.false(
         env,
         "IMPL_DEP_DEFINE" in foo_commands[0],
         "Should contain define IMPL_DEP_DEFINE from implementation_dep, got: %s" % foo_commands[0],
@@ -138,7 +140,9 @@ def _get_compile_flags_local_defines_from_impl_deps_test_impl(ctx):
 
     foo_commands = [c for c in commands if "foo.cc" in c]
     asserts.true(env, len(foo_commands) > 0, "Should have a command for foo.cc")
-    asserts.true(
+
+    # FIXME: Change to true
+    asserts.false(
         env,
         "IMPL_DEP_LOCAL_DEF" in foo_commands[0],
         "Should contain local_define IMPL_DEP_LOCAL_DEF from implementation_dep, got: %s" % foo_commands[0],
@@ -304,7 +308,8 @@ def _get_compile_flags_quote_includes_from_deps_test_impl(ctx):
     foo_commands = [c for c in commands if "foo.cc" in c]
     asserts.true(env, len(foo_commands) > 0, "Should have a command for foo.cc")
 
-    asserts.true(
+    # FIXME: Change to true
+    asserts.false(
         env,
         "-iquote dep/quote/path" in foo_commands[0],
         "Should contain -iquote dep/quote/path from implementation_dep, got: %s" % foo_commands[0],
@@ -341,7 +346,9 @@ def _get_compile_flags_no_duplicates_test_impl(ctx):
         if f in seen and f not in duplicates:
             duplicates.append(f)
         seen.append(f)
-    asserts.true(
+
+    # FIXME: Change to true
+    asserts.false(
         env,
         len(duplicates) == 0,
         "Compile command should not have duplicate flags, found: %s" % duplicates,

--- a/test/unit/compile_commands/compile_commands_analysis_test.bzl
+++ b/test/unit/compile_commands/compile_commands_analysis_test.bzl
@@ -85,9 +85,7 @@ get_compile_flags_defines_test = analysistest.make(
 )
 
 def _get_compile_flags_defines_from_impl_deps_test_impl(ctx):
-    """
-    BUG: defines from implementation_deps are missing in compile commands. 
-    GitHub issue #305
+    """BUG: defines from implementation_deps are missing in compile commands. #305
 
     get_compile_flags iterates over deps in SOURCE_ATTR and collects includes,
     system_includes, and external_includes — but NOT defines.
@@ -132,9 +130,7 @@ get_compile_flags_local_defines_test = analysistest.make(
 )
 
 def _get_compile_flags_local_defines_from_impl_deps_test_impl(ctx):
-    """
-    BUG: local_defines from implementation_deps are missing in compile commands.
-    GitHub issue #306
+    """BUG: local_defines from implementation_deps are missing in compile commands. #306
 
     get_compile_flags iterates over deps in SOURCE_ATTR and collects includes,
     system_includes, and external_includes — but NOT local_defines.
@@ -302,9 +298,7 @@ get_compile_flags_quote_includes_test = analysistest.make(
 )
 
 def _get_compile_flags_quote_includes_from_deps_test_impl(ctx):
-    """
-    BUG: quote_includes from implementation_deps are missing in compile commands.
-    GitHub issue #304
+    """BUG: quote_includes from implementation_deps are missing in compile commands. #304
 
     get_compile_flags iterates over deps in SOURCE_ATTR and collects includes,
     system_includes, and external_includes — but NOT quote_includes.
@@ -330,9 +324,7 @@ get_compile_flags_quote_includes_from_deps_test = analysistest.make(
 )
 
 def _get_compile_flags_no_duplicates_test_impl(ctx):
-    """
-    BUG: Compile flags should not contain duplicates.
-    GitHub issue #307
+    """BUG: Compile flags should not contain duplicates. #307
 
     get_compile_flags may add the same include path multiple times — once
     from the target's own CcInfo compilation_context, and again when iterating

--- a/test/unit/compile_commands/compile_commands_analysis_test.bzl
+++ b/test/unit/compile_commands/compile_commands_analysis_test.bzl
@@ -145,7 +145,8 @@ def _get_compile_flags_local_defines_from_impl_deps_test_impl(ctx):
     asserts.false(
         env,
         "IMPL_DEP_LOCAL_DEF" in foo_commands[0],
-        "Should contain local_define IMPL_DEP_LOCAL_DEF from implementation_dep, got: %s" % foo_commands[0],
+        "Should contain local_define IMPL_DEP_LOCAL_DEF from " +
+        "implementation_dep, got: %s" % foo_commands[0],
     )
 
     return analysistest.end(env)
@@ -195,7 +196,7 @@ get_compile_flags_includes_from_impl_deps_test = analysistest.make(
 )
 
 def _get_compile_flags_copts_test_impl(ctx):
-    """copts are passed through to the compile command."""
+    """The copts flags are passed through to the compile command."""
     env = analysistest.begin(ctx)
     commands = _get_compile_commands(analysistest.target_under_test(env)[SourceFilesInfo])
 

--- a/test/unit/compile_commands/testdata/bar.c
+++ b/test/unit/compile_commands/testdata/bar.c
@@ -1,0 +1,2 @@
+#include "bar.h"
+void bar(void) {}

--- a/test/unit/compile_commands/testdata/bar.cc
+++ b/test/unit/compile_commands/testdata/bar.cc
@@ -1,0 +1,2 @@
+#include "bar.h"
+void bar(void) {}

--- a/test/unit/compile_commands/testdata/bar.h
+++ b/test/unit/compile_commands/testdata/bar.h
@@ -1,0 +1,4 @@
+#ifndef BAR_H
+#define BAR_H
+void bar(void);
+#endif

--- a/test/unit/compile_commands/testdata/foo.cc
+++ b/test/unit/compile_commands/testdata/foo.cc
@@ -1,0 +1,2 @@
+#include "foo.h"
+void foo(void) {}

--- a/test/unit/compile_commands/testdata/foo.h
+++ b/test/unit/compile_commands/testdata/foo.h
@@ -1,0 +1,4 @@
+#ifndef FOO_H
+#define FOO_H
+void foo(void);
+#endif


### PR DESCRIPTION
Why:
We want to properly test compile_commands generation.

What:
- Added skylib tests to check whether compile flags have been correctly obtained.
- Have 4 bug, tests:
	- implementation_deps does not collect defines
	- implementation_deps does not collect local_defines
	- implementaion_deps does not collect qoute_includes
	- Compile flags are duplicated

Addresses:
https://github.com/Ericsson/rules_codechecker/issues/304 https://github.com/Ericsson/rules_codechecker/issues/305 https://github.com/Ericsson/rules_codechecker/issues/307
