### PR TITLE
ci: Add github action for tagging every merged PR

### DIFF
--- a/.github/workflows/pr-tag.yaml
+++ b/.github/workflows/pr-tag.yaml
@@ -16,9 +16,9 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       # Optionally create releases too.
-      #- name: Create a GitHub release
-      #  uses: ncipollo/release-action@v1
-      #  with:
-      #    tag: ${{ steps.tag_version.outputs.new_tag }}
-      #    name: Release ${{ steps.tag_version.outputs.new_tag }}
-      #    body: ${{ steps.tag_version.outputs.changelog }}
+      - name: Create a GitHub release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ steps.tag_version.outputs.new_tag }}
+          name: Release ${{ steps.tag_version.outputs.new_tag }}
+          body: ${{ steps.tag_version.outputs.changelog }}

--- a/.github/workflows/pr-tag.yaml
+++ b/.github/workflows/pr-tag.yaml
@@ -1,0 +1,24 @@
+name: Create Tag on Merge
+
+on:
+    pull_request:
+        types: [closed]
+
+jobs:
+    tag:
+        if: github.event.pull_request.merged == true
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  ref: main
+
+            - name: Create and push tag
+              run: |
+                  TAG_NAME="v$(date +%Y.%m.%d.%H%M%S)"
+                  git config user.name "github-actions"
+                  git config user.email "github-actions@github.com"
+                  git tag $TAG_NAME
+                  git push origin $TAG_NAME
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-tag.yaml
+++ b/.github/workflows/pr-tag.yaml
@@ -1,24 +1,28 @@
-name: Create Tag on Merge
-
+name: Tag commits on main
 on:
-    pull_request:
-        types: [closed]
-
+  push:
+    branches:
+      - master
 jobs:
-    tag:
-        if: github.event.pull_request.merged == true
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v4
-              with:
-                  ref: main
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
 
-            - name: Create and push tag
-              run: |
-                  TAG_NAME="v$(date +%Y.%m.%d.%H%M%S)"
-                  git config user.name "github-actions"
-                  git config user.email "github-actions@github.com"
-                  git tag $TAG_NAME
-                  git push origin $TAG_NAME
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Get Current Release
+        id: get_current_release
+        uses: joutvhu/get-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get date and time
+        id: datetime
+        run: echo "value=$(date -u +'%Y%m%d-%H%M%S')" >> "$GITHUB_OUTPUT"
+
+      - name: Bump version and push tag
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          custom_tag: ${{ steps.get_current_release.outputs.tag_name }}-${{ steps.datetime.outputs.value }}
+          tag_prefix: ""

--- a/.github/workflows/pr-tag.yaml
+++ b/.github/workflows/pr-tag.yaml
@@ -9,20 +9,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Get Current Release
-        id: get_current_release
-        uses: joutvhu/get-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Get date and time
-        id: datetime
-        run: echo "value=$(date -u +'%Y%m%d-%H%M%S')" >> "$GITHUB_OUTPUT"
-
       - name: Bump version and push tag
         id: tag_version
         uses: mathieudutour/github-tag-action@v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          custom_tag: ${{ steps.get_current_release.outputs.tag_name }}-${{ steps.datetime.outputs.value }}
-          tag_prefix: ""
+
+      # Optionally create releases too.
+      #- name: Create a GitHub release
+      #  uses: ncipollo/release-action@v1
+      #  with:
+      #    tag: ${{ steps.tag_version.outputs.new_tag }}
+      #    name: Release ${{ steps.tag_version.outputs.new_tag }}
+      #    body: ${{ steps.tag_version.outputs.changelog }}


### PR DESCRIPTION
Why:
We want to tag every commit made to main for easier integration and testing for end users.

What:
- Added a GitHub Action that creates a tag for every merged PR.
	Use the date and time for the tag name.

Addresses:
#285
