### PR TITLE
Use sandboxed spawn strategy in testing

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -88,7 +88,7 @@ jobs:
       # Therefore: less wasted CI runtime.
       - name: Run unit tests
         run: |
-          bazel test //...
+          bazel test //... --spawn_strategy=sandboxed --test_tag_filters=-buildifier
           pytest test/unit ${{ runner.debug == '1' && '--log-cli-level=DEBUG' || '' }}
         shell: bash -el {0}
 
@@ -158,7 +158,7 @@ jobs:
       # Therefore: less wasted CI runtime.
       - name: Run unit tests
         run: |
-          runuser -u test -- bazel test //...
+          runuser -u test -- bazel test //... --spawn_strategy=sandboxed --test_tag_filters=-buildifier
           runuser -u test -- pytest test/unit ${{ runner.debug == '1' && '--log-cli-level=DEBUG' || '' }}
         shell: bash -el {0}
 

--- a/test/buildifier/BUILD
+++ b/test/buildifier/BUILD
@@ -34,6 +34,7 @@ buildifier_test(
     lint_warnings = ["all"],
     mode = "diff",
     no_sandbox = True,
+    tags = ["buildifier"],
     verbose = True,
     workspace = "//:MODULE.bazel",
 )

--- a/test/unit/unit_test.bzl
+++ b/test/unit/unit_test.bzl
@@ -89,7 +89,6 @@ def unit_test(
         srcs = ["//test/unit:grep_check.py"],
         main = "//test/unit:grep_check.py",
         args = python_args,
-        local = True,
         tags = ["unit"] + tags,
         size = size,
         **kwargs


### PR DESCRIPTION
Why:
The `spawn_strategy=sandboxed` is a much stricter testing environment. It can catch issues that can go unnoticed in some cases. (For example, setting the workaround PATH for codechecker to `/` works without this flag, even though it shouldn't.)
This strategy more closely mimics the restrictions of a remote worker.

What:
- Added the flag `--spawn_strategy=sandboxed` to CI tests. (Had to skip Buildifier since the sandboxed strategy is too restrictive for it.)
- Added a tag to Buildifier. (So that I can skip it.)
- Removed `local = True` from unit_test macro. (This flag prevents these kinds of tests from running with a sandboxed strategy.)

Notes:
This strategy may restrict what kind of tests we can use.

Addresses:
None
