### PR TITLE
feat: Add option to override toolchain on a per target basis

### DIFF
--- a/src/codechecker.bzl
+++ b/src/codechecker.bzl
@@ -23,6 +23,7 @@ load(
 )
 load(
     "common.bzl",
+    "resolve_toolchain_info",
     "version_specific_attributes",
 )
 load(
@@ -92,7 +93,7 @@ def _codechecker_impl(ctx):
 
     config_file, codechecker_env = get_config_file(ctx)
 
-    info = ctx.toolchains["//:toolchain_type"].codecheckerinfo
+    info = resolve_toolchain_info(ctx)
 
     codechecker_files = ctx.actions.declare_directory(ctx.label.name + "/codechecker-files")
 
@@ -171,6 +172,12 @@ codechecker = rule(
             default = [],
             doc = "List of analyze command arguments, e.g.; --ctu.",
         ),
+        "codechecker_toolchain": attr.label(
+            default = None,
+            doc = "Optional codechecker_toolchain() target. " +
+                  "When set, tools from this target are used instead of " +
+                  "Bazel's toolchain resolution.",
+        ),
         "config": attr.label(
             default = None,
             doc = "CodeChecker configuration",
@@ -227,7 +234,7 @@ def _codechecker_test_impl(ctx):
     if not codechecker_files:
         fail("Execution results required for codechecker test are not available")
 
-    info = ctx.toolchains["//:toolchain_type"].codecheckerinfo
+    info = resolve_toolchain_info(ctx)
 
     # Create test script
     codechecker_test_script = ctx.actions.declare_file(ctx.label.name + "/codechecker_test_script")
@@ -275,6 +282,12 @@ _codechecker_test = rule(
         "analyze": attr.string_list(
             default = [],
             doc = "List of analyze command arguments, e.g. --ctu",
+        ),
+        "codechecker_toolchain": attr.label(
+            default = None,
+            doc = "Optional codechecker_toolchain() target. " +
+                  "When set, tools from this target are used instead of " +
+                  "Bazel's toolchain resolution.",
         ),
         "config": attr.label(
             default = None,
@@ -337,6 +350,7 @@ def codechecker_test(
         analyze = [],
         tags = [],
         per_file = False,
+        codechecker_toolchain = None,
         **kwargs):
     """
     Macro to choose the appropriate codechecker rule
@@ -352,6 +366,9 @@ def codechecker_test(
         tags: Bazel tags
         per_file: Boolean value, toggles wether to run the analysis
                   with the experimental per_file rule.
+        codechecker_toolchain: Optional codechecker_toolchain() target.
+                  When set, tools from this target are used instead of
+                  Bazel's toolchain resolution.
         **kwargs: Other miscellaneous arguments.
     Returns:
         none
@@ -366,6 +383,7 @@ def codechecker_test(
             options = analyze,
             skip = skip,
             config = config,
+            codechecker_toolchain = codechecker_toolchain,
             tags = codechecker_tags,
             **kwargs
         )
@@ -378,6 +396,7 @@ def codechecker_test(
             skip = skip,
             config = config,
             analyze = analyze,
+            codechecker_toolchain = codechecker_toolchain,
             tags = codechecker_tags,
             **kwargs
         )

--- a/src/codechecker.bzl
+++ b/src/codechecker.bzl
@@ -23,7 +23,6 @@ load(
 )
 load(
     "common.bzl",
-    "resolve_toolchain_info",
     "version_specific_attributes",
 )
 load(
@@ -93,7 +92,10 @@ def _codechecker_impl(ctx):
 
     config_file, codechecker_env = get_config_file(ctx)
 
-    info = resolve_toolchain_info(ctx)
+    if ctx.attr.toolchain:
+        info = ctx.attr.toolchain[platform_common.ToolchainInfo].codecheckerinfo
+    else:
+        info = ctx.toolchains["//:toolchain_type"].codecheckerinfo
 
     codechecker_files = ctx.actions.declare_directory(ctx.label.name + "/codechecker-files")
 
@@ -234,7 +236,10 @@ def _codechecker_test_impl(ctx):
     if not codechecker_files:
         fail("Execution results required for codechecker test are not available")
 
-    info = resolve_toolchain_info(ctx)
+    if ctx.attr.toolchain:
+        info = ctx.attr.toolchain[platform_common.ToolchainInfo].codecheckerinfo
+    else:
+        info = ctx.toolchains["//:toolchain_type"].codecheckerinfo
 
     # Create test script
     codechecker_test_script = ctx.actions.declare_file(ctx.label.name + "/codechecker_test_script")

--- a/src/codechecker.bzl
+++ b/src/codechecker.bzl
@@ -172,12 +172,6 @@ codechecker = rule(
             default = [],
             doc = "List of analyze command arguments, e.g.; --ctu.",
         ),
-        "codechecker_toolchain": attr.label(
-            default = None,
-            doc = "Optional codechecker_toolchain() target. " +
-                  "When set, tools from this target are used instead of " +
-                  "Bazel's toolchain resolution.",
-        ),
         "config": attr.label(
             default = None,
             doc = "CodeChecker configuration",
@@ -192,6 +186,12 @@ codechecker = rule(
                 compile_commands_aspect,
             ],
             doc = "List of compilable targets which should be checked.",
+        ),
+        "toolchain": attr.label(
+            default = None,
+            doc = "Optional toolchain() target. " +
+                  "When set, tools from this target are used instead of " +
+                  "Bazel's toolchain resolution.",
         ),
         "_codechecker_script": attr.label(
             allow_files = True,
@@ -283,12 +283,6 @@ _codechecker_test = rule(
             default = [],
             doc = "List of analyze command arguments, e.g. --ctu",
         ),
-        "codechecker_toolchain": attr.label(
-            default = None,
-            doc = "Optional codechecker_toolchain() target. " +
-                  "When set, tools from this target are used instead of " +
-                  "Bazel's toolchain resolution.",
-        ),
         "config": attr.label(
             default = None,
             cfg = platforms_transition,
@@ -313,6 +307,12 @@ _codechecker_test = rule(
             ],
             cfg = platforms_transition,
             doc = "List of compilable targets which should be checked.",
+        ),
+        "toolchain": attr.label(
+            default = None,
+            doc = "Optional toolchain() target. " +
+                  "When set, tools from this target are used instead of " +
+                  "Bazel's toolchain resolution.",
         ),
         "_codechecker_script": attr.label(
             allow_files = True,
@@ -350,7 +350,7 @@ def codechecker_test(
         analyze = [],
         tags = [],
         per_file = False,
-        codechecker_toolchain = None,
+        toolchain = None,
         **kwargs):
     """
     Macro to choose the appropriate codechecker rule
@@ -366,7 +366,7 @@ def codechecker_test(
         tags: Bazel tags
         per_file: Boolean value, toggles wether to run the analysis
                   with the experimental per_file rule.
-        codechecker_toolchain: Optional codechecker_toolchain() target.
+        toolchain: Optional toolchain() target.
                   When set, tools from this target are used instead of
                   Bazel's toolchain resolution.
         **kwargs: Other miscellaneous arguments.
@@ -383,7 +383,7 @@ def codechecker_test(
             options = analyze,
             skip = skip,
             config = config,
-            codechecker_toolchain = codechecker_toolchain,
+            toolchain = toolchain,
             tags = codechecker_tags,
             **kwargs
         )
@@ -396,7 +396,7 @@ def codechecker_test(
             skip = skip,
             config = config,
             analyze = analyze,
-            codechecker_toolchain = codechecker_toolchain,
+            toolchain = toolchain,
             tags = codechecker_tags,
             **kwargs
         )

--- a/src/common.bzl
+++ b/src/common.bzl
@@ -45,18 +45,18 @@ def version_specific_attributes():
 def resolve_toolchain_info(ctx):
     """Resolve CodeCheckerInfo from explicit attribute or Bazel toolchain resolution.
 
-    If the user specified a `codechecker_toolchain` attribute pointing to a
-    `codechecker_toolchain()` target, use its provider directly. Otherwise,
+    If the user specified a `toolchain` attribute pointing to a
+    `toolchain()` target, use its provider directly. Otherwise,
     fall back to Bazel's standard toolchain resolution.
 
     Args:
-        ctx: The rule context. Must have a `codechecker_toolchain` attribute
+        ctx: The rule context. Must have a `toolchain` attribute
              and the `//src:toolchain_type` toolchain declared.
     Returns:
         A CodeCheckerInfo provider instance.
     """
-    if ctx.attr.codechecker_toolchain:
-        return ctx.attr.codechecker_toolchain[platform_common.ToolchainInfo].codecheckerinfo
+    if ctx.attr.toolchain:
+        return ctx.attr.toolchain[platform_common.ToolchainInfo].codecheckerinfo
 
     # TODO: Consider using aliases so we don't have to type //src: everywhere.
     return ctx.toolchains["//:toolchain_type"].codecheckerinfo

--- a/src/common.bzl
+++ b/src/common.bzl
@@ -42,25 +42,6 @@ def version_specific_attributes():
         )})
     return {}
 
-def resolve_toolchain_info(ctx):
-    """Resolve CodeCheckerInfo from explicit attribute or Bazel toolchain resolution.
-
-    If the user specified a `toolchain` attribute pointing to a
-    `toolchain()` target, use its provider directly. Otherwise,
-    fall back to Bazel's standard toolchain resolution.
-
-    Args:
-        ctx: The rule context. Must have a `toolchain` attribute
-             and the `//src:toolchain_type` toolchain declared.
-    Returns:
-        A CodeCheckerInfo provider instance.
-    """
-    if ctx.attr.toolchain:
-        return ctx.attr.toolchain[platform_common.ToolchainInfo].codecheckerinfo
-
-    # TODO: Consider using aliases so we don't have to type //src: everywhere.
-    return ctx.toolchains["//:toolchain_type"].codecheckerinfo
-
 def warning(ctx, msg):
     """
     Prints message if the debug tag is enabled.

--- a/src/common.bzl
+++ b/src/common.bzl
@@ -42,6 +42,25 @@ def version_specific_attributes():
         )})
     return {}
 
+def resolve_toolchain_info(ctx):
+    """Resolve CodeCheckerInfo from explicit attribute or Bazel toolchain resolution.
+
+    If the user specified a `codechecker_toolchain` attribute pointing to a
+    `codechecker_toolchain()` target, use its provider directly. Otherwise,
+    fall back to Bazel's standard toolchain resolution.
+
+    Args:
+        ctx: The rule context. Must have a `codechecker_toolchain` attribute
+             and the `//src:toolchain_type` toolchain declared.
+    Returns:
+        A CodeCheckerInfo provider instance.
+    """
+    if ctx.attr.codechecker_toolchain:
+        return ctx.attr.codechecker_toolchain[platform_common.ToolchainInfo].codecheckerinfo
+
+    # TODO: Consider using aliases so we don't have to type //src: everywhere.
+    return ctx.toolchains["//:toolchain_type"].codecheckerinfo
+
 def warning(ctx, msg):
     """
     Prints message if the debug tag is enabled.

--- a/src/per_file.bzl
+++ b/src/per_file.bzl
@@ -20,6 +20,10 @@ for each translation unit.
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load("codechecker_config.bzl", "get_config_file")
 load(
+    "common.bzl",
+    "resolve_toolchain_info",
+)
+load(
     "compile_commands.bzl",
     "SourceFilesInfo",
     "compile_commands_aspect",
@@ -187,7 +191,7 @@ def _per_file_impl(ctx):
         target_file = ctx.executable._per_file_script,
     )
 
-    info = ctx.toolchains["//:toolchain_type"].codecheckerinfo
+    info = resolve_toolchain_info(ctx)
     for target in ctx.attr.targets:
         if not CcInfo in target:
             continue
@@ -245,6 +249,12 @@ def _per_file_impl(ctx):
 per_file_test = rule(
     implementation = _per_file_impl,
     attrs = {
+        "codechecker_toolchain": attr.label(
+            default = None,
+            doc = "Optional codechecker_toolchain() target. " +
+                  "When set, tools from this target are used instead of " +
+                  "Bazel's toolchain resolution.",
+        ),
         "config": attr.label(
             default = None,
             doc = "CodeChecker configuration",

--- a/src/per_file.bzl
+++ b/src/per_file.bzl
@@ -249,12 +249,6 @@ def _per_file_impl(ctx):
 per_file_test = rule(
     implementation = _per_file_impl,
     attrs = {
-        "codechecker_toolchain": attr.label(
-            default = None,
-            doc = "Optional codechecker_toolchain() target. " +
-                  "When set, tools from this target are used instead of " +
-                  "Bazel's toolchain resolution.",
-        ),
         "config": attr.label(
             default = None,
             doc = "CodeChecker configuration",
@@ -280,6 +274,12 @@ per_file_test = rule(
                 compile_commands_aspect,
             ],
             doc = "List of compilable targets which should be checked.",
+        ),
+        "toolchain": attr.label(
+            default = None,
+            doc = "Optional toolchain() target. " +
+                  "When set, tools from this target are used instead of " +
+                  "Bazel's toolchain resolution.",
         ),
         "_per_file_script": attr.label(
             allow_files = True,

--- a/src/per_file.bzl
+++ b/src/per_file.bzl
@@ -20,10 +20,6 @@ for each translation unit.
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load("codechecker_config.bzl", "get_config_file")
 load(
-    "common.bzl",
-    "resolve_toolchain_info",
-)
-load(
     "compile_commands.bzl",
     "SourceFilesInfo",
     "compile_commands_aspect",
@@ -191,7 +187,10 @@ def _per_file_impl(ctx):
         target_file = ctx.executable._per_file_script,
     )
 
-    info = resolve_toolchain_info(ctx)
+    if ctx.attr.toolchain:
+        info = ctx.attr.toolchain[platform_common.ToolchainInfo].codecheckerinfo
+    else:
+        info = ctx.toolchains["//:toolchain_type"].codecheckerinfo
     for target in ctx.attr.targets:
         if not CcInfo in target:
             continue

--- a/test/unit/toolchain/BUILD
+++ b/test/unit/toolchain/BUILD
@@ -111,7 +111,12 @@ codechecker_test(
     toolchain = ":runfiles_mock_toolchain",
 )
 
-per_target_toolchain_test_suite(name = "per_target")
+per_target_toolchain_test_suite(
+    name = "per_target",
+    expected_clang = "mock_clang",
+    expected_clang_tidy = "mock_clang_tidy",
+    expected_codechecker = "mock_codechecker",
+)
 
 codechecker_test(
     name = "per_target_2_monolithic_subject",
@@ -128,4 +133,9 @@ codechecker_test(
     toolchain = ":runfiles_mock_toolchain_2",
 )
 
-per_target_toolchain_test_suite(name = "per_target_2")
+per_target_toolchain_test_suite(
+    name = "per_target_2",
+    expected_clang = "mock_clang_2",
+    expected_clang_tidy = "mock_clang_tidy_2",
+    expected_codechecker = "mock_codechecker_2",
+)

--- a/test/unit/toolchain/BUILD
+++ b/test/unit/toolchain/BUILD
@@ -89,9 +89,6 @@ codechecker_toolchain(
 runfiles_test_suite(name = "runfiles")
 
 # --- Per-target toolchain selection tests ---
-# TODO(per-target-toolchain): When the `toolchain` attribute is added,
-# uncomment the `toolchain` lines below and flip the assertions in
-# per_target_toolchain_test.bzl (change asserts.false to asserts.true).
 
 cc_library(
     name = "toolchain_test_lib",
@@ -103,7 +100,7 @@ codechecker_test(
     name = "per_target_monolithic_subject",
     tags = ["manual"],
     targets = [":toolchain_test_lib"],
-    # toolchain = ":runfiles_mock_toolchain",
+    toolchain = ":runfiles_mock_toolchain",
 )
 
 codechecker_test(
@@ -111,7 +108,7 @@ codechecker_test(
     per_file = True,
     tags = ["manual"],
     targets = [":toolchain_test_lib"],
-    # toolchain = ":runfiles_mock_toolchain",
+    toolchain = ":runfiles_mock_toolchain",
 )
 
 per_target_toolchain_test_suite(name = "per_target")
@@ -120,7 +117,7 @@ codechecker_test(
     name = "per_target_2_monolithic_subject",
     tags = ["manual"],
     targets = [":toolchain_test_lib"],
-    # toolchain = ":runfiles_mock_toolchain_2",
+    toolchain = ":runfiles_mock_toolchain_2",
 )
 
 codechecker_test(
@@ -128,7 +125,7 @@ codechecker_test(
     per_file = True,
     tags = ["manual"],
     targets = [":toolchain_test_lib"],
-    # toolchain = ":runfiles_mock_toolchain_2",
+    toolchain = ":runfiles_mock_toolchain_2",
 )
 
 per_target_toolchain_test_suite(name = "per_target_2")

--- a/test/unit/toolchain/per_target_toolchain_test.bzl
+++ b/test/unit/toolchain/per_target_toolchain_test.bzl
@@ -19,11 +19,6 @@ When a codechecker_test or per_file_test target sets the `toolchain` attribute,
 the rule must use tools from that toolchain (not the registered default).
 This test asserts that the mock toolchain's tools appear in the target's
 runfiles and action inputs.
-
-TODO(per-target-toolchain): When the `toolchain` attribute is added:
-  1. Uncomment `toolchain` in the subject targets in the BUILD file.
-  2. Flip the assertions below: change `asserts.false` to `asserts.true`
-     (mock tools SHOULD appear when the feature works).
 """
 
 load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
@@ -61,23 +56,22 @@ def _test_monolithic_uses_explicit_toolchain_impl(ctx):
         for f in target[DefaultInfo].default_runfiles.files.to_list()
     ]
 
-    # TODO(per-target-toolchain): Flip to asserts.true when feature is added.
-    asserts.false(
+    asserts.true(
         env,
         _contains_basename(runfile_basenames, "mock_codechecker"),
-        "NOT Expected mock_codechecker in runfiles, got: %s" % runfile_basenames,
+        "Expected mock_codechecker in runfiles, got: %s" % runfile_basenames,
     )
 
-    asserts.false(
+    asserts.true(
         env,
         _contains_basename(runfile_basenames, "mock_clang"),
-        "NOT Expected mock_clang in runfiles, got: %s" % runfile_basenames,
+        "Expected mock_clang in runfiles, got: %s" % runfile_basenames,
     )
 
-    asserts.false(
+    asserts.true(
         env,
         _contains_basename(runfile_basenames, "mock_clang_tidy"),
-        "NOT Expected mock_clang_tidy in runfiles, got: %s" % runfile_basenames,
+        "Expected mock_clang_tidy in runfiles, got: %s" % runfile_basenames,
     )
 
     return analysistest.end(env)
@@ -97,25 +91,24 @@ def _test_per_file_uses_explicit_toolchain_impl(ctx):
 
     action_basenames = _get_action_input_basenames(target)
 
-    # TODO(per-target-toolchain): Flip to asserts.true when feature is added.
-    asserts.false(
+    asserts.true(
         env,
         _contains_basename(action_basenames, "mock_codechecker"),
-        "NOT Expected mock_codechecker in action inputs, got: %s" %
+        "Expected mock_codechecker in action inputs, got: %s" %
         action_basenames,
     )
 
-    asserts.false(
+    asserts.true(
         env,
         _contains_basename(action_basenames, "mock_clang"),
-        "NOT Expected mock_clang in action inputs, got: %s" %
+        "Expected mock_clang in action inputs, got: %s" %
         action_basenames,
     )
 
-    asserts.false(
+    asserts.true(
         env,
         _contains_basename(action_basenames, "mock_clang_tidy"),
-        "NOT Expected mock_clang_tidy in action inputs, got: %s" %
+        "Expected mock_clang_tidy in action inputs, got: %s" %
         action_basenames,
     )
 

--- a/test/unit/toolchain/per_target_toolchain_test.bzl
+++ b/test/unit/toolchain/per_target_toolchain_test.bzl
@@ -51,6 +51,10 @@ def _test_monolithic_uses_explicit_toolchain_impl(ctx):
 
     target = analysistest.target_under_test(env)
 
+    expected_codechecker = ctx.attr.expected_codechecker
+    expected_clang = ctx.attr.expected_clang
+    expected_clang_tidy = ctx.attr.expected_clang_tidy
+
     runfile_basenames = [
         f.basename
         for f in target[DefaultInfo].default_runfiles.files.to_list()
@@ -58,26 +62,40 @@ def _test_monolithic_uses_explicit_toolchain_impl(ctx):
 
     asserts.true(
         env,
-        _contains_basename(runfile_basenames, "mock_codechecker"),
-        "Expected mock_codechecker in runfiles, got: %s" % runfile_basenames,
+        _contains_basename(runfile_basenames, expected_codechecker),
+        "Expected %s in runfiles, got: %s" % (
+            expected_codechecker,
+            runfile_basenames,
+        ),
     )
 
     asserts.true(
         env,
-        _contains_basename(runfile_basenames, "mock_clang"),
-        "Expected mock_clang in runfiles, got: %s" % runfile_basenames,
+        _contains_basename(runfile_basenames, expected_clang),
+        "Expected %s in runfiles, got: %s" % (
+            expected_clang,
+            runfile_basenames,
+        ),
     )
 
     asserts.true(
         env,
-        _contains_basename(runfile_basenames, "mock_clang_tidy"),
-        "Expected mock_clang_tidy in runfiles, got: %s" % runfile_basenames,
+        _contains_basename(runfile_basenames, expected_clang_tidy),
+        "Expected %s in runfiles, got: %s" % (
+            expected_clang_tidy,
+            runfile_basenames,
+        ),
     )
 
     return analysistest.end(env)
 
 monolithic_uses_explicit_toolchain_test = analysistest.make(
     _test_monolithic_uses_explicit_toolchain_impl,
+    attrs = {
+        "expected_clang": attr.string(default = "mock_clang"),
+        "expected_clang_tidy": attr.string(default = "mock_clang_tidy"),
+        "expected_codechecker": attr.string(default = "mock_codechecker"),
+    },
 )
 
 # ---------------------------------------------------------------------------
@@ -89,40 +107,59 @@ def _test_per_file_uses_explicit_toolchain_impl(ctx):
 
     target = analysistest.target_under_test(env)
 
+    expected_codechecker = ctx.attr.expected_codechecker
+    expected_clang = ctx.attr.expected_clang
+    expected_clang_tidy = ctx.attr.expected_clang_tidy
+
     action_basenames = _get_action_input_basenames(target)
 
     asserts.true(
         env,
-        _contains_basename(action_basenames, "mock_codechecker"),
-        "Expected mock_codechecker in action inputs, got: %s" %
-        action_basenames,
+        _contains_basename(action_basenames, expected_codechecker),
+        "Expected %s in action inputs, got: %s" % (
+            expected_codechecker,
+            action_basenames,
+        ),
     )
 
     asserts.true(
         env,
-        _contains_basename(action_basenames, "mock_clang"),
-        "Expected mock_clang in action inputs, got: %s" %
-        action_basenames,
+        _contains_basename(action_basenames, expected_clang),
+        "Expected %s in action inputs, got: %s" % (
+            expected_clang,
+            action_basenames,
+        ),
     )
 
     asserts.true(
         env,
-        _contains_basename(action_basenames, "mock_clang_tidy"),
-        "Expected mock_clang_tidy in action inputs, got: %s" %
-        action_basenames,
+        _contains_basename(action_basenames, expected_clang_tidy),
+        "Expected %s in action inputs, got: %s" % (
+            expected_clang_tidy,
+            action_basenames,
+        ),
     )
 
     return analysistest.end(env)
 
 per_file_uses_explicit_toolchain_test = analysistest.make(
     _test_per_file_uses_explicit_toolchain_impl,
+    attrs = {
+        "expected_clang": attr.string(default = "mock_clang"),
+        "expected_clang_tidy": attr.string(default = "mock_clang_tidy"),
+        "expected_codechecker": attr.string(default = "mock_codechecker"),
+    },
 )
 
 # ---------------------------------------------------------------------------
 # Test suite macro
 # ---------------------------------------------------------------------------
 
-def per_target_toolchain_test_suite(name):
+def per_target_toolchain_test_suite(
+        name,
+        expected_codechecker,
+        expected_clang,
+        expected_clang_tidy):
     """Wires analysis tests to the subject targets defined in BUILD.
 
     Expects the BUILD file to define:
@@ -131,16 +168,25 @@ def per_target_toolchain_test_suite(name):
 
     Args:
         name: Name prefix matching the subject targets.
+        expected_codechecker: Expected codechecker tool basename.
+        expected_clang: Expected clang tool basename.
+        expected_clang_tidy: Expected clang-tidy tool basename.
     """
 
     monolithic_uses_explicit_toolchain_test(
         name = name + "_monolithic_test",
         target_under_test = name + "_monolithic_subject",
+        expected_codechecker = expected_codechecker,
+        expected_clang = expected_clang,
+        expected_clang_tidy = expected_clang_tidy,
     )
 
     per_file_uses_explicit_toolchain_test(
         name = name + "_per_file_test",
         target_under_test = name + "_per_file_subject",
+        expected_codechecker = expected_codechecker,
+        expected_clang = expected_clang,
+        expected_clang_tidy = expected_clang_tidy,
     )
 
     native.test_suite(


### PR DESCRIPTION
Why:
Users want the ability to use different versions of CodeChecker (or analyzers) on a per-target basis.

What:
- Added a `codechecker_toolchain` parameter to `codechecker_test`, through which users can override Bazel's toolchain resolution. (Preserves previous behaviour if not specified.)

Addresses:
Fixes: #278