### PR TITLE
Fix toolchain path for per_file test action

### DIFF
--- a/src/per_file.bzl
+++ b/src/per_file.bzl
@@ -172,7 +172,7 @@ def _create_wrapper_script(ctx, options, compile_commands_json, config_file):
     )
 
 def _per_file_impl(ctx):
-    info = ctx.toolchains["//src:toolchain_type"].codecheckerinfo
+    info = ctx.toolchains["//:toolchain_type"].codecheckerinfo
     compile_commands = None
     for output in compile_commands_impl(ctx):
         if type(output) == "DefaultInfo":


### PR DESCRIPTION
Why:
The API change branch was created before #266 landed and was not rebased, so one instance of accessing the toolchain was not rewritten.

What:
- Updated the toolchain type location used in the per_file_test rule.

Addresses:
CI failing on main