### PR TITLE
Add more from compile_commands.bzl to public API

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -41,10 +41,13 @@ load(
     _codechecker_toolchain = "codechecker_toolchain",
 )
 
-# Compilation database (compile_commands.json) rule
+# Compilation database (compile_commands.json) rule, aspect and provider
 load(
     "//src:compile_commands.bzl",
+    _SourceFilesInfo = "SourceFilesInfo",
     _compile_commands = "compile_commands",
+    _compile_commands_aspect = "compile_commands_aspect",
+    _platforms_transition = "platforms_transition",
 )
 
 codechecker_test = _codechecker_test
@@ -57,3 +60,8 @@ clang_analyze_test = _clang_analyze_test
 
 # Helper for the platform suffix codechecker_suite() adds to its test names
 get_platform_alias = _get_platform_alias
+
+# Building blocks for rules collecting the compilation database
+compile_commands_aspect = _compile_commands_aspect
+platforms_transition = _platforms_transition
+SourceFilesInfo = _SourceFilesInfo

--- a/src/compile_commands.bzl
+++ b/src/compile_commands.bzl
@@ -48,7 +48,7 @@ load(
 )
 
 SourceFilesInfo = provider(
-    doc = "Source files and corresponding compilation database (or compile commands)",
+    doc = "Source files and compilation database, returned by compile_commands_aspect",
     fields = {
         "compilation_db": "list of compile commands with parameters: file, command, directory",
         "headers": "list of required header files",
@@ -373,6 +373,7 @@ def _platforms_transition_impl(settings, attr):
         "//command_line_option:platforms": platforms,
     }
 
+# Requires a "platform" attribute on the rule using it
 platforms_transition = transition(
     implementation = _platforms_transition_impl,
     inputs = [


### PR DESCRIPTION
Why:
Users write their own rules on top of our compilation database collection,
but compile_commands_aspect, SourceFilesInfo and platforms_transition were
only reachable from src/compile_commands.bzl.

What:
- Add compile_commands_aspect, SourceFilesInfo and platforms_transition to defs.bzl
