### PR TITLE
feat: Add PR title linting

### DIFF
--- a/.github/workflows/pr-lint.yaml
+++ b/.github/workflows/pr-lint.yaml
@@ -1,0 +1,20 @@
+name: 'Lint PR'
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - edited
+      # - synchronize (if you use required Actions)
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-slim
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-lint.yaml
+++ b/.github/workflows/pr-lint.yaml
@@ -1,4 +1,4 @@
-name: 'Lint PR'
+name: 'Lint PR title'
 
 on:
   pull_request_target:


### PR DESCRIPTION
Why:
We want to auto-tag every merged PR (maybe even auto-release). For this, we need PR titles (and maybe contents) to follow certain rules.

What:
- Added a CI job to check if the PR title follows guidelines.

Addresses:
#47 
