### PR TITLE
Experiment: FOSS as external modules

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -154,6 +154,11 @@ jobs:
           runuser -u test -- bazel test //test/buildifier --test_output=all
         shell: bash -el {0}
 
+      - name: Run foss tests
+        run: |
+          runuser -u test -- bazel test //test/bazel/... --test_output=all
+        shell: bash -el {0}
+
       # Splitting unit and FOSS tests, since unit tests fail faster.
       # Therefore: less wasted CI runtime.
       - name: Run unit tests

--- a/test/bazel/BUILD
+++ b/test/bazel/BUILD
@@ -1,0 +1,49 @@
+# Copyright 2026 Ericsson AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# -----------------------------------------------------------------------
+# FOSS integration tests for rules_codechecker
+#
+# Each test downloads a real FOSS project, sets up a standalone Bazel
+# project with rules_codechecker, and verifies the rules execute
+# successfully via "bazel build".
+#
+# Run all:   bazel test //test/bazel/...
+# Run one:   bazel test //test/bazel:zlib
+#
+# To add a new project: add a foss_test() call below.
+# -----------------------------------------------------------------------
+
+load(":foss_test.bzl", "foss_test")
+
+foss_test(
+    name = "zlib",
+    tests = [
+        ":codechecker_per_file",
+        ":codechecker_test",
+        ":compile_commands",
+    ],
+    url = "https://github.com/madler/zlib/releases/download/v1.3.2/zlib-1.3.2.tar.gz",
+)
+
+foss_test(
+    name = "yaml-cpp",
+    tests = [
+        ":codechecker_test",
+        ":compile_commands",
+        # FIXME: output 'analysis/codechecker_per_file/data/src-emit.cpp_clangsa.plist' was not created
+        # ":codechecker_per_file",
+    ],
+    url = "https://github.com/jbeder/yaml-cpp/archive/refs/tags/0.8.0.tar.gz",
+)

--- a/test/bazel/BUILD
+++ b/test/bazel/BUILD
@@ -40,10 +40,9 @@ foss_test(
 foss_test(
     name = "yaml-cpp",
     tests = [
+        ":codechecker_per_file",
         ":codechecker_test",
         ":compile_commands",
-        # FIXME: output 'analysis/codechecker_per_file/data/src-emit.cpp_clangsa.plist' was not created
-        # ":codechecker_per_file",
     ],
-    url = "https://github.com/jbeder/yaml-cpp/archive/refs/tags/0.8.0.tar.gz",
+    url = "https://github.com/jbeder/yaml-cpp/archive/refs/tags/yaml-cpp-0.9.0.tar.gz",
 )

--- a/test/bazel/BUILD
+++ b/test/bazel/BUILD
@@ -15,8 +15,8 @@
 # -----------------------------------------------------------------------
 # FOSS integration tests for rules_codechecker
 #
-# Each test downloads a real FOSS project, sets up a standalone Bazel
-# project with rules_codechecker, and verifies the rules execute
+# Each test creates a Bazel project that depends on a real FOSS module
+# from the Bazel Central Registry, and verifies the rules execute
 # successfully via "bazel build".
 #
 # Run all:   bazel test //test/bazel/...
@@ -34,7 +34,7 @@ foss_test(
         ":codechecker_test",
         ":compile_commands",
     ],
-    url = "https://github.com/madler/zlib/releases/download/v1.3.2/zlib-1.3.2.tar.gz",
+    version = "1.3.2",
 )
 
 foss_test(
@@ -44,7 +44,7 @@ foss_test(
         ":codechecker_test",
         ":compile_commands",
     ],
-    url = "https://github.com/jbeder/yaml-cpp/archive/refs/tags/yaml-cpp-0.9.0.tar.gz",
+    version = "0.9.0.bcr.1",
 )
 
 foss_test(
@@ -54,7 +54,7 @@ foss_test(
         ":codechecker_test",
         ":compile_commands",
     ],
-    url = "https://github.com/google/double-conversion/archive/refs/tags/v3.4.0.tar.gz",
+    version = "3.3.1",
 )
 
 foss_test(
@@ -64,5 +64,5 @@ foss_test(
         ":codechecker_test",
         ":compile_commands",
     ],
-    url = "https://github.com/pytorch/cpuinfo/archive/66ee79c0.tar.gz",
+    version = "0.0.0-20260312-7607ca5",
 )

--- a/test/bazel/BUILD
+++ b/test/bazel/BUILD
@@ -46,3 +46,23 @@ foss_test(
     ],
     url = "https://github.com/jbeder/yaml-cpp/archive/refs/tags/yaml-cpp-0.9.0.tar.gz",
 )
+
+foss_test(
+    name = "double-conversion",
+    tests = [
+        ":codechecker_per_file",
+        ":codechecker_test",
+        ":compile_commands",
+    ],
+    url = "https://github.com/google/double-conversion/archive/refs/tags/v3.4.0.tar.gz",
+)
+
+foss_test(
+    name = "cpuinfo",
+    tests = [
+        ":codechecker_per_file",
+        ":codechecker_test",
+        ":compile_commands",
+    ],
+    url = "https://github.com/pytorch/cpuinfo/archive/66ee79c0.tar.gz",
+)

--- a/test/bazel/foss_test.bzl
+++ b/test/bazel/foss_test.bzl
@@ -1,0 +1,70 @@
+# Copyright 2026 Ericsson AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Macro for generating FOSS integration tests for rules_codechecker.
+
+Each foss_test() generates a local py_test that:
+  1. Downloads a FOSS project into a temp directory
+  2. Sets up a standalone Bazel project with rules_codechecker
+  3. Runs "bazel build" on codechecker targets to verify the rules work
+  4. Validates the outputs (compile_commands.json, codechecker artifacts)
+
+Example:
+    foss_test(
+        name = "zlib",
+        url = "https://github.com/madler/zlib/archive/<commit>.tar.gz",
+        tests = [":codechecker_test", ":compile_commands"],
+    )
+"""
+
+load("@rules_python//python:defs.bzl", "py_test")
+
+def foss_test(
+        name,
+        url,
+        tests,
+        target = None,
+        tags = [],
+        size = "large",
+        **kwargs):
+    """Generate a py_test that runs rules_codechecker on a FOSS project.
+
+    Args:
+        name: Test name.
+        url: URL to the source archive (.tar.gz).
+        tests: Analysis targets to build (e.g. codechecker_test, compile_commands).
+        target: The cc_library target to analyze. Defaults to ":<name>".
+        tags: Additional test tags.
+        size: Test size (default: enormous, as these download + run bazel).
+        **kwargs: Forwarded to py_test.
+    """
+    if target == None:
+        target = ":" + name
+
+    py_test(
+        name = name,
+        srcs = ["foss_test_runner.py"],
+        main = "foss_test_runner.py",
+        args = [
+            "-vvv",
+            "--url=" + url,
+            "--target=" + target,
+            "--tests",
+        ] + tests,
+        local = True,
+        tags = ["foss", "external"] + tags,
+        size = size,
+        **kwargs
+    )

--- a/test/bazel/foss_test.bzl
+++ b/test/bazel/foss_test.bzl
@@ -16,15 +16,18 @@
 Macro for generating FOSS integration tests for rules_codechecker.
 
 Each foss_test() generates a local py_test that:
-  1. Downloads a FOSS project into a temp directory
-  2. Sets up a standalone Bazel project with rules_codechecker
-  3. Runs "bazel build" on codechecker targets to verify the rules work
-  4. Validates the outputs (compile_commands.json, codechecker artifacts)
+  1. Creates a Bazel project depending on the FOSS module and on our rules
+  2. Runs "bazel build" on codechecker targets to verify the rules work
+  3. Validates the outputs (compile_commands.json, codechecker artifacts)
+
+The FOSS project comes from the Bazel Central Registry, therefore Bazel
+downloads it, verifies it and resolves its dependencies, see
+https://registry.bazel.build
 
 Example:
     foss_test(
         name = "zlib",
-        url = "https://github.com/madler/zlib/archive/<commit>.tar.gz",
+        version = "1.3.1.bcr.7",
         tests = [":codechecker_test", ":compile_commands"],
     )
 """
@@ -33,8 +36,9 @@ load("@rules_python//python:defs.bzl", "py_test")
 
 def foss_test(
         name,
-        url,
+        version,
         tests,
+        module = None,
         target = None,
         tags = [],
         size = "large",
@@ -43,15 +47,18 @@ def foss_test(
 
     Args:
         name: Test name.
-        url: URL to the source archive (.tar.gz).
+        version: Version of the module in the Bazel Central Registry.
         tests: Analysis targets to build (e.g. codechecker_test, compile_commands).
-        target: The cc_library target to analyze. Defaults to ":<name>".
+        module: Name of the module. Defaults to <name>.
+        target: The cc_library target to analyze. Defaults to @<module>//:<module>.
         tags: Additional test tags.
-        size: Test size (default: enormous, as these download + run bazel).
+        size: Test size (default: large, as these download and run bazel).
         **kwargs: Forwarded to py_test.
     """
+    if module == None:
+        module = name
     if target == None:
-        target = ":" + name
+        target = "@%s//:%s" % (module, module)
 
     py_test(
         name = name,
@@ -59,7 +66,8 @@ def foss_test(
         main = "foss_test_runner.py",
         args = [
             "-vvv",
-            "--url=" + url,
+            "--module=" + module,
+            "--version=" + version,
             "--target=" + target,
             "--tests",
         ] + tests,

--- a/test/bazel/foss_test_runner.py
+++ b/test/bazel/foss_test_runner.py
@@ -1,0 +1,187 @@
+# Copyright 2026 Ericsson AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+FOSS integration test runner for rules_codechecker.
+
+Downloads a FOSS project, sets up a standalone Bazel project with
+rules_codechecker, builds codechecker targets, and verifies outputs.
+"""
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+import unittest
+from pathlib import Path
+
+MODULE_TEMPLATE = """
+local_path_override(
+    module_name = "rules_codechecker",
+    path = "{rules_path}",
+)
+bazel_dep(name = "rules_codechecker")
+"""
+
+BUILD_TEMPLATE = """
+load("@rules_codechecker//src:codechecker.bzl", "codechecker_test")
+load("@rules_codechecker//src:compile_commands.bzl", "compile_commands")
+
+codechecker_test(
+    name = "codechecker_test",
+    targets = ["//{target}"],
+)
+
+codechecker_test(
+    name = "codechecker_per_file",
+    targets = ["//{target}"],
+    per_file = True,
+)
+
+compile_commands(
+    name = "compile_commands",
+    targets = ["//{target}"],
+)
+"""
+
+
+class FossTest(unittest.TestCase):
+    """Base test that downloads a FOSS project and runs rules_codechecker."""
+
+    # Set by main()
+    url = None
+    target = None
+    tests = None
+
+    def setUp(self):
+        self.work_dir = Path(tempfile.mkdtemp())
+
+        # Resolve rules_codechecker path from the real script location
+        script_path = Path(os.path.realpath(__file__))
+        self.rules_path = script_path.parent.parent.parent
+
+        self._download_and_extract()
+        self._setup_bazel_project()
+
+    def tearDown(self):
+        if self.work_dir.exists():
+            subprocess.run(
+                ["bazel", f"--output_base={self.work_dir / '.bazel_output'}",
+                 "shutdown"],
+                capture_output=True,
+            )
+            subprocess.run(
+                ["chmod", "-R", "u+w", str(self.work_dir)],
+                capture_output=True,
+            )
+            shutil.rmtree(self.work_dir, ignore_errors=True)
+
+    def _download_and_extract(self):
+        archive = self.work_dir / "archive.tar.gz"
+        subprocess.run(
+            ["wget", "-q", "-O", str(archive), self.url],
+            check=True,
+        )
+        with tarfile.open(archive) as tar:
+            members = tar.getmembers()
+            prefix = members[0].name.split("/")[0]
+            for m in members:
+                m.name = m.name[len(prefix):].lstrip("/")
+                if m.name:
+                    tar.extract(m, self.work_dir / "src")
+        self.project_dir = self.work_dir / "src"
+
+    def _setup_bazel_project(self):
+        analysis_dir = self.project_dir / "analysis"
+        analysis_dir.mkdir()
+        (analysis_dir / "BUILD.bazel").write_text(
+            BUILD_TEMPLATE.format(target=self.target)
+        )
+
+        (self.project_dir / "MODULE.bazel").write_text(
+            MODULE_TEMPLATE.format(rules_path=self.rules_path)
+        )
+        (self.project_dir / "WORKSPACE").touch()
+
+    def _bazel_build(self):
+        prefixed = [f"//analysis{t}" for t in self.tests]
+        result = subprocess.run(
+            ["bazel",
+             f"--output_base={self.work_dir / '.bazel_output'}",
+             "build"] + prefixed,
+            cwd=self.project_dir,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0,
+                         f"bazel build failed:\n{result.stderr}")
+
+    def _bazel_bin(self):
+        result = subprocess.run(
+            ["bazel",
+             f"--output_base={self.work_dir / '.bazel_output'}",
+             "info", "bazel-bin"],
+            cwd=self.project_dir,
+            capture_output=True,
+            text=True,
+        )
+        return Path(result.stdout.strip())
+
+    def test_build_succeeds(self):
+        """Verify that codechecker rules build successfully."""
+        self._bazel_build()
+
+    def test_compile_commands_valid(self):
+        """Verify compile_commands.json is valid and non-empty."""
+        self._bazel_build()
+        bazel_bin = self._bazel_bin()
+        cc_json = bazel_bin / "analysis" / "compile_commands" / "compile_commands.json"
+        self.assertTrue(cc_json.exists(),
+                        f"compile_commands.json not found at {cc_json}")
+        data = json.loads(cc_json.read_text())
+        self.assertIsInstance(data, list)
+        self.assertGreater(len(data), 0,
+                           "compile_commands.json is empty")
+        for entry in data:
+            self.assertIn("file", entry)
+            self.assertIn("directory", entry)
+
+    def test_codechecker_outputs_exist(self):
+        """Verify codechecker produces expected output files."""
+        self._bazel_build()
+        bazel_bin = self._bazel_bin()
+        cc_dir = bazel_bin / "analysis" / "codechecker_test"
+        self.assertTrue(cc_dir.exists(),
+                        f"codechecker output dir not found at {cc_dir}")
+        cc_json = cc_dir / "compile_commands.json"
+        self.assertTrue(cc_json.exists(),
+                        "codechecker compile_commands.json not found")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--url", required=True)
+    parser.add_argument("--target", required=True)
+    parser.add_argument("--tests", nargs="+", required=True)
+    args, remaining = parser.parse_known_args()
+
+    FossTest.url = args.url
+    FossTest.target = args.target
+    FossTest.tests = args.tests
+
+    unittest.main(argv=[sys.argv[0]] + remaining)

--- a/test/bazel/foss_test_runner.py
+++ b/test/bazel/foss_test_runner.py
@@ -15,27 +15,27 @@
 """
 FOSS integration test runner for rules_codechecker.
 
-Downloads a FOSS project, sets up a standalone Bazel project with
-rules_codechecker, builds codechecker targets, and verifies outputs.
+Creates a Bazel project that depends on a FOSS module from the Bazel Central
+Registry, builds codechecker targets on it, and verifies the outputs.
 """
 
 import argparse
 import json
-import os
 import shutil
 import subprocess
 import sys
-import tarfile
 import tempfile
 import unittest
 from pathlib import Path
 
 MODULE_TEMPLATE = """
+bazel_dep(name = "{module}", version = "{version}")
+
+bazel_dep(name = "rules_codechecker")
 local_path_override(
     module_name = "rules_codechecker",
     path = "{rules_path}",
 )
-bazel_dep(name = "rules_codechecker")
 """
 
 BUILD_TEMPLATE = """
@@ -43,108 +43,72 @@ load("@rules_codechecker//:defs.bzl", "codechecker_test", "compile_commands")
 
 codechecker_test(
     name = "codechecker_test",
-    targets = ["//{target}"],
+    targets = ["{target}"],
 )
 
 codechecker_test(
     name = "codechecker_per_file",
-    targets = ["//{target}"],
     per_file = True,
+    targets = ["{target}"],
 )
 
 compile_commands(
     name = "compile_commands",
-    targets = ["//{target}"],
+    targets = ["{target}"],
 )
 """
 
 
 class FossTest(unittest.TestCase):
-    """Base test that downloads a FOSS project and runs rules_codechecker."""
+    """Runs rules_codechecker on a FOSS project from the registry."""
 
     # Set by main()
-    url = None
+    module = None
+    version = None
     target = None
-    tests = None
+    tests = []
 
     def setUp(self):
         self.work_dir = Path(tempfile.mkdtemp())
-
-        # Resolve rules_codechecker path from the real script location
-        script_path = Path(os.path.realpath(__file__))
-        self.rules_path = script_path.parent.parent.parent
-
-        self._download_and_extract()
+        self.output_base = self.work_dir / ".bazel_output"
+        self.rules_path = Path(__file__).resolve().parents[2]
         self._setup_bazel_project()
 
     def tearDown(self):
-        if self.work_dir.exists():
-            subprocess.run(
-                ["bazel", f"--output_base={self.work_dir / '.bazel_output'}",
-                 "shutdown"],
-                capture_output=True,
-            )
-            subprocess.run(
-                ["chmod", "-R", "u+w", str(self.work_dir)],
-                capture_output=True,
-            )
-            shutil.rmtree(self.work_dir, ignore_errors=True)
-
-    def _download_and_extract(self):
-        archive = self.work_dir / "archive.tar.gz"
-        subprocess.run(
-            ["wget", "-q", "-O", str(archive), self.url],
-            check=True,
-        )
-        with tarfile.open(archive) as tar:
-            members = tar.getmembers()
-            prefix = members[0].name.split("/")[0]
-            for m in members:
-                m.name = m.name[len(prefix):].lstrip("/")
-                if m.name:
-                    tar.extract(m, self.work_dir / "src")
-        self.project_dir = self.work_dir / "src"
-
-    def _build_file(self):
-        """The build file of the project, BUILD.bazel unless BUILD is used."""
-        for name in ("BUILD.bazel", "BUILD"):
-            build_file = self.project_dir / name
-            if build_file.exists():
-                return build_file
-        return self.project_dir / "BUILD.bazel"
+        self._bazel("shutdown")
+        shutil.rmtree(self.work_dir, ignore_errors=True)
 
     def _setup_bazel_project(self):
-        """Append to MODULE.bazel and BUILD.bazel (or BUILD)"""
-        with (self.project_dir / "MODULE.bazel").open("a") as module_file:
-            module_file.write(
-                MODULE_TEMPLATE.format(rules_path=self.rules_path)
+        """Write the project depending on the FOSS module and on our rules"""
+        (self.work_dir / "MODULE.bazel").write_text(
+            MODULE_TEMPLATE.format(
+                module=self.module,
+                version=self.version,
+                rules_path=self.rules_path,
             )
-        with self._build_file().open("a") as build_file:
-            build_file.write(BUILD_TEMPLATE.format(target=self.target))
+        )
+        (self.work_dir / "BUILD.bazel").write_text(
+            BUILD_TEMPLATE.format(target=self.target)
+        )
 
-    def _bazel_build(self):
-        targets = [f"//{t}" for t in self.tests]
-        result = subprocess.run(
-            ["bazel",
-             f"--output_base={self.work_dir / '.bazel_output'}",
-             "build"] + targets,
-            cwd=self.project_dir,
+    def _bazel(self, *arguments):
+        """Run bazel in the generated project, return the completed process"""
+        return subprocess.run(
+            ["bazel", f"--output_base={self.output_base}"] + list(arguments),
+            cwd=self.work_dir,
             capture_output=True,
+            check=False,
             text=True,
         )
+
+    def _bazel_build(self):
+        targets = [f"//{test}" for test in self.tests]
+        result = self._bazel("build", *targets)
         self.assertEqual(result.returncode, 0,
                          f"bazel build failed:\n{result.stderr}")
 
     def _bazel_bin(self):
-        result = subprocess.run(
-            ["bazel",
-             f"--output_base={self.work_dir / '.bazel_output'}",
-             "info", "bazel-bin"],
-            cwd=self.project_dir,
-            capture_output=True,
-            text=True,
-        )
-        return Path(result.stdout.strip())
+        return Path(self._bazel("info", "bazel-bin").stdout.strip())
 
     def test_build_succeeds(self):
         """Verify that codechecker rules build successfully."""
@@ -153,39 +117,38 @@ class FossTest(unittest.TestCase):
     def test_compile_commands_valid(self):
         """Verify compile_commands.json is valid and non-empty."""
         self._bazel_build()
-        bazel_bin = self._bazel_bin()
-        cc_json = bazel_bin / "compile_commands" / "compile_commands.json"
-        self.assertTrue(cc_json.exists(),
-                        f"compile_commands.json not found at {cc_json}")
-        data = json.loads(cc_json.read_text())
-        self.assertIsInstance(data, list)
-        self.assertGreater(len(data), 0,
-                           "compile_commands.json is empty")
-        for entry in data:
+        commands = (self._bazel_bin() / "compile_commands"
+                    / "compile_commands.json")
+        self.assertTrue(commands.exists(),
+                        f"compile_commands.json not found at {commands}")
+        entries = json.loads(commands.read_text())
+        self.assertIsInstance(entries, list)
+        self.assertGreater(len(entries), 0, "compile_commands.json is empty")
+        for entry in entries:
             self.assertIn("file", entry)
             self.assertIn("directory", entry)
 
     def test_codechecker_outputs_exist(self):
         """Verify codechecker produces expected output files."""
         self._bazel_build()
-        bazel_bin = self._bazel_bin()
-        cc_dir = bazel_bin / "codechecker_test"
-        self.assertTrue(cc_dir.exists(),
-                        f"codechecker output dir not found at {cc_dir}")
-        cc_json = cc_dir / "compile_commands.json"
-        self.assertTrue(cc_json.exists(),
+        analysis_dir = self._bazel_bin() / "codechecker_test"
+        self.assertTrue(analysis_dir.exists(),
+                        f"codechecker output dir not found at {analysis_dir}")
+        self.assertTrue((analysis_dir / "compile_commands.json").exists(),
                         "codechecker compile_commands.json not found")
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--url", required=True)
+    parser.add_argument("--module", required=True)
+    parser.add_argument("--version", required=True)
     parser.add_argument("--target", required=True)
     parser.add_argument("--tests", nargs="+", required=True)
-    args, remaining = parser.parse_known_args()
+    arguments, remaining = parser.parse_known_args()
 
-    FossTest.url = args.url
-    FossTest.target = args.target
-    FossTest.tests = args.tests
+    FossTest.module = arguments.module
+    FossTest.version = arguments.version
+    FossTest.target = arguments.target
+    FossTest.tests = arguments.tests
 
     unittest.main(argv=[sys.argv[0]] + remaining)

--- a/test/bazel/foss_test_runner.py
+++ b/test/bazel/foss_test_runner.py
@@ -39,8 +39,7 @@ bazel_dep(name = "rules_codechecker")
 """
 
 BUILD_TEMPLATE = """
-load("@rules_codechecker//src:codechecker.bzl", "codechecker_test")
-load("@rules_codechecker//src:compile_commands.bzl", "compile_commands")
+load("@rules_codechecker//:defs.bzl", "codechecker_test", "compile_commands")
 
 codechecker_test(
     name = "codechecker_test",
@@ -106,24 +105,29 @@ class FossTest(unittest.TestCase):
                     tar.extract(m, self.work_dir / "src")
         self.project_dir = self.work_dir / "src"
 
-    def _setup_bazel_project(self):
-        analysis_dir = self.project_dir / "analysis"
-        analysis_dir.mkdir()
-        (analysis_dir / "BUILD.bazel").write_text(
-            BUILD_TEMPLATE.format(target=self.target)
-        )
+    def _build_file(self):
+        """The build file of the project, BUILD.bazel unless BUILD is used."""
+        for name in ("BUILD.bazel", "BUILD"):
+            build_file = self.project_dir / name
+            if build_file.exists():
+                return build_file
+        return self.project_dir / "BUILD.bazel"
 
-        (self.project_dir / "MODULE.bazel").write_text(
-            MODULE_TEMPLATE.format(rules_path=self.rules_path)
-        )
-        (self.project_dir / "WORKSPACE").touch()
+    def _setup_bazel_project(self):
+        """Append to MODULE.bazel and BUILD.bazel (or BUILD)"""
+        with (self.project_dir / "MODULE.bazel").open("a") as module_file:
+            module_file.write(
+                MODULE_TEMPLATE.format(rules_path=self.rules_path)
+            )
+        with self._build_file().open("a") as build_file:
+            build_file.write(BUILD_TEMPLATE.format(target=self.target))
 
     def _bazel_build(self):
-        prefixed = [f"//analysis{t}" for t in self.tests]
+        targets = [f"//{t}" for t in self.tests]
         result = subprocess.run(
             ["bazel",
              f"--output_base={self.work_dir / '.bazel_output'}",
-             "build"] + prefixed,
+             "build"] + targets,
             cwd=self.project_dir,
             capture_output=True,
             text=True,
@@ -150,7 +154,7 @@ class FossTest(unittest.TestCase):
         """Verify compile_commands.json is valid and non-empty."""
         self._bazel_build()
         bazel_bin = self._bazel_bin()
-        cc_json = bazel_bin / "analysis" / "compile_commands" / "compile_commands.json"
+        cc_json = bazel_bin / "compile_commands" / "compile_commands.json"
         self.assertTrue(cc_json.exists(),
                         f"compile_commands.json not found at {cc_json}")
         data = json.loads(cc_json.read_text())
@@ -165,7 +169,7 @@ class FossTest(unittest.TestCase):
         """Verify codechecker produces expected output files."""
         self._bazel_build()
         bazel_bin = self._bazel_bin()
-        cc_dir = bazel_bin / "analysis" / "codechecker_test"
+        cc_dir = bazel_bin / "codechecker_test"
         self.assertTrue(cc_dir.exists(),
                         f"codechecker output dir not found at {cc_dir}")
         cc_json = cc_dir / "compile_commands.json"


### PR DESCRIPTION
Experimenting with new approach: FOSS repos as external Bazel modules

Why:
The existing Python/Bash FOSS tests are hard to
understand and extend, they are also very slow
and cannot be integrated into Bazel environment.

What:
Add test/bazel/ with a foss_test() macro
that generates py_test() targets for FOSS projects.

Test:
bazel test //test/bazel/...
