### PR TITLE
test: per-target toolchain selection tests

### DIFF
--- a/test/unit/toolchain/BUILD
+++ b/test/unit/toolchain/BUILD
@@ -52,13 +52,36 @@ sh_binary(
     srcs = ["mock_clang_tidy.sh"],
 )
 
-# --- Mock toolchain ---
+# Second set of mock tools (to test multiple toolchains).
+sh_binary(
+    name = "mock_codechecker_2",
+    srcs = ["mock_codechecker_2.sh"],
+)
+
+sh_binary(
+    name = "mock_clang_2",
+    srcs = ["mock_clang_2.sh"],
+)
+
+sh_binary(
+    name = "mock_clang_tidy_2",
+    srcs = ["mock_clang_tidy_2.sh"],
+)
+
+# --- Mock toolchains ---
 
 codechecker_toolchain(
     name = "runfiles_mock_toolchain",
     clang_tidy = ":mock_clang_tidy",
     clangsa = ":mock_clang",
     codechecker = ":mock_codechecker",
+)
+
+codechecker_toolchain(
+    name = "runfiles_mock_toolchain_2",
+    clang_tidy = ":mock_clang_tidy_2",
+    clangsa = ":mock_clang_2",
+    codechecker = ":mock_codechecker_2",
 )
 
 # --- Tests ---
@@ -92,3 +115,20 @@ codechecker_test(
 )
 
 per_target_toolchain_test_suite(name = "per_target")
+
+codechecker_test(
+    name = "per_target_2_monolithic_subject",
+    tags = ["manual"],
+    targets = [":toolchain_test_lib"],
+    # toolchain = ":runfiles_mock_toolchain_2",
+)
+
+codechecker_test(
+    name = "per_target_2_per_file_subject",
+    per_file = True,
+    tags = ["manual"],
+    targets = [":toolchain_test_lib"],
+    # toolchain = ":runfiles_mock_toolchain_2",
+)
+
+per_target_toolchain_test_suite(name = "per_target_2")

--- a/test/unit/toolchain/BUILD
+++ b/test/unit/toolchain/BUILD
@@ -13,8 +13,24 @@
 # limitations under the License.
 
 load(
+    "@rules_cc//cc:defs.bzl",
+    "cc_library",
+)
+load(
+    "//:defs.bzl",
+    "codechecker_test",
+)
+load(
     "//src:codechecker_toolchain.bzl",
     "codechecker_toolchain",
+)
+load(
+    "//src:per_file.bzl",
+    "per_file_test",
+)
+load(
+    "//test/unit/toolchain:per_target_toolchain_test.bzl",
+    "per_target_toolchain_test_suite",
 )
 load(
     "//test/unit/toolchain:toolchain_runfiles_test.bzl",
@@ -52,3 +68,29 @@ codechecker_toolchain(
 # --- Tests ---
 
 runfiles_test_suite(name = "runfiles")
+
+# --- Per-target toolchain selection tests ---
+
+cc_library(
+    name = "toolchain_test_lib",
+    srcs = ["toolchain_test.cpp"],
+    tags = ["manual"],
+)
+
+codechecker_test(
+    name = "per_target_standard_subject",
+    tags = ["manual"],
+    targets = [":toolchain_test_lib"],
+    toolchain = ":runfiles_mock_toolchain",
+)
+
+per_file_test(
+    name = "per_target_per_file_subject",
+    tags = ["manual"],
+    targets = [":toolchain_test_lib"],
+    toolchain = ":runfiles_mock_toolchain",
+)
+
+per_target_toolchain_test_suite(
+    name = "per_target",
+)

--- a/test/unit/toolchain/BUILD
+++ b/test/unit/toolchain/BUILD
@@ -77,7 +77,7 @@ cc_library(
 )
 
 codechecker_test(
-    name = "per_target_standard_subject",
+    name = "per_target_monolithic_subject",
     tags = ["manual"],
     targets = [":toolchain_test_lib"],
     # toolchain = ":runfiles_mock_toolchain",

--- a/test/unit/toolchain/BUILD
+++ b/test/unit/toolchain/BUILD
@@ -25,10 +25,6 @@ load(
     "codechecker_toolchain",
 )
 load(
-    "//src:per_file.bzl",
-    "per_file_test",
-)
-load(
     "//test/unit/toolchain:per_target_toolchain_test.bzl",
     "per_target_toolchain_test_suite",
 )
@@ -70,6 +66,9 @@ codechecker_toolchain(
 runfiles_test_suite(name = "runfiles")
 
 # --- Per-target toolchain selection tests ---
+# TODO(per-target-toolchain): When the `toolchain` attribute is added,
+# uncomment the `toolchain` lines below and flip the assertions in
+# per_target_toolchain_test.bzl (change asserts.false to asserts.true).
 
 cc_library(
     name = "toolchain_test_lib",
@@ -81,16 +80,15 @@ codechecker_test(
     name = "per_target_standard_subject",
     tags = ["manual"],
     targets = [":toolchain_test_lib"],
-    toolchain = ":runfiles_mock_toolchain",
+    # toolchain = ":runfiles_mock_toolchain",
 )
 
-per_file_test(
+codechecker_test(
     name = "per_target_per_file_subject",
+    per_file = True,
     tags = ["manual"],
     targets = [":toolchain_test_lib"],
-    toolchain = ":runfiles_mock_toolchain",
+    # toolchain = ":runfiles_mock_toolchain",
 )
 
-per_target_toolchain_test_suite(
-    name = "per_target",
-)
+per_target_toolchain_test_suite(name = "per_target")

--- a/test/unit/toolchain/mock_clang_2.sh
+++ b/test/unit/toolchain/mock_clang_2.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "mock clang 2"

--- a/test/unit/toolchain/mock_clang_tidy_2.sh
+++ b/test/unit/toolchain/mock_clang_tidy_2.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "mock clang-tidy 2"

--- a/test/unit/toolchain/mock_codechecker_2.sh
+++ b/test/unit/toolchain/mock_codechecker_2.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "mock codechecker 2"

--- a/test/unit/toolchain/per_target_toolchain_test.bzl
+++ b/test/unit/toolchain/per_target_toolchain_test.bzl
@@ -19,12 +19,17 @@ When a codechecker_test or per_file_test target sets the `toolchain` attribute,
 the rule must use tools from that toolchain (not the registered default).
 This test asserts that the mock toolchain's tools appear in the target's
 runfiles and action inputs.
+
+TODO(per-target-toolchain): When the `toolchain` attribute is added:
+  1. Uncomment `toolchain` in the subject targets in the BUILD file.
+  2. Flip the assertions below: change `asserts.false` to `asserts.true`
+     (mock tools SHOULD appear when the feature works).
 """
 
 load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
 
 # ---------------------------------------------------------------------------
-# Helper: extract tool basenames from a target's actions
+# Helper
 # ---------------------------------------------------------------------------
 
 def _get_action_input_basenames(target):
@@ -51,28 +56,28 @@ def _test_standard_uses_explicit_toolchain_impl(ctx):
 
     target = analysistest.target_under_test(env)
 
-    # The mock tools should appear in the target's runfiles
     runfile_basenames = [
         f.basename
         for f in target[DefaultInfo].default_runfiles.files.to_list()
     ]
 
-    asserts.true(
+    # TODO(per-target-toolchain): Flip to asserts.true when feature is added.
+    asserts.false(
         env,
         _contains_basename(runfile_basenames, "mock_codechecker"),
-        "Expected mock_codechecker in runfiles, got: %s" % runfile_basenames,
+        "NOT Expected mock_codechecker in runfiles, got: %s" % runfile_basenames,
     )
 
-    asserts.true(
+    asserts.false(
         env,
         _contains_basename(runfile_basenames, "mock_clang"),
-        "Expected mock_clang in runfiles, got: %s" % runfile_basenames,
+        "NOT Expected mock_clang in runfiles, got: %s" % runfile_basenames,
     )
 
-    asserts.true(
+    asserts.false(
         env,
         _contains_basename(runfile_basenames, "mock_clang_tidy"),
-        "Expected mock_clang_tidy in runfiles, got: %s" % runfile_basenames,
+        "NOT Expected mock_clang_tidy in runfiles, got: %s" % runfile_basenames,
     )
 
     return analysistest.end(env)
@@ -90,28 +95,27 @@ def _test_per_file_uses_explicit_toolchain_impl(ctx):
 
     target = analysistest.target_under_test(env)
 
-    # The mock tools should appear in action inputs (since per_file passes
-    # tools via ctx.actions.run(tools = [info.runfiles]))
     action_basenames = _get_action_input_basenames(target)
 
-    asserts.true(
+    # TODO(per-target-toolchain): Flip to asserts.true when feature is added.
+    asserts.false(
         env,
         _contains_basename(action_basenames, "mock_codechecker"),
-        "Expected mock_codechecker in action inputs, got: %s" %
+        "NOT Expected mock_codechecker in action inputs, got: %s" %
         action_basenames,
     )
 
-    asserts.true(
+    asserts.false(
         env,
         _contains_basename(action_basenames, "mock_clang"),
-        "Expected mock_clang in action inputs, got: %s" %
+        "NOT Expected mock_clang in action inputs, got: %s" %
         action_basenames,
     )
 
-    asserts.true(
+    asserts.false(
         env,
         _contains_basename(action_basenames, "mock_clang_tidy"),
-        "Expected mock_clang_tidy in action inputs, got: %s" %
+        "NOT Expected mock_clang_tidy in action inputs, got: %s" %
         action_basenames,
     )
 
@@ -126,15 +130,14 @@ per_file_uses_explicit_toolchain_test = analysistest.make(
 # ---------------------------------------------------------------------------
 
 def per_target_toolchain_test_suite(name):
-    """Instantiates analysis tests for per-target toolchain selection.
+    """Wires analysis tests to the subject targets defined in BUILD.
 
-    The subject targets (codechecker_test and per_file_test with explicit
-    toolchain) must be defined in the BUILD file with names:
-      - {name}_standard_subject
-      - {name}_per_file_subject
+    Expects the BUILD file to define:
+      - {name}_standard_subject (codechecker_test)
+      - {name}_per_file_subject (codechecker_test with per_file = True)
 
     Args:
-        name: Name prefix for generated targets.
+        name: Name prefix matching the subject targets.
     """
 
     standard_uses_explicit_toolchain_test(

--- a/test/unit/toolchain/per_target_toolchain_test.bzl
+++ b/test/unit/toolchain/per_target_toolchain_test.bzl
@@ -48,10 +48,10 @@ def _contains_basename(basenames, name):
     return False
 
 # ---------------------------------------------------------------------------
-# Test: codechecker_test (standard) uses explicit toolchain tools
+# Test: codechecker_test (monolithic) uses explicit toolchain tools
 # ---------------------------------------------------------------------------
 
-def _test_standard_uses_explicit_toolchain_impl(ctx):
+def _test_monolithic_uses_explicit_toolchain_impl(ctx):
     env = analysistest.begin(ctx)
 
     target = analysistest.target_under_test(env)
@@ -82,8 +82,8 @@ def _test_standard_uses_explicit_toolchain_impl(ctx):
 
     return analysistest.end(env)
 
-standard_uses_explicit_toolchain_test = analysistest.make(
-    _test_standard_uses_explicit_toolchain_impl,
+monolithic_uses_explicit_toolchain_test = analysistest.make(
+    _test_monolithic_uses_explicit_toolchain_impl,
 )
 
 # ---------------------------------------------------------------------------
@@ -133,16 +133,16 @@ def per_target_toolchain_test_suite(name):
     """Wires analysis tests to the subject targets defined in BUILD.
 
     Expects the BUILD file to define:
-      - {name}_standard_subject (codechecker_test)
+      - {name}_monolithic_subject (codechecker_test)
       - {name}_per_file_subject (codechecker_test with per_file = True)
 
     Args:
         name: Name prefix matching the subject targets.
     """
 
-    standard_uses_explicit_toolchain_test(
-        name = name + "_standard_test",
-        target_under_test = name + "_standard_subject",
+    monolithic_uses_explicit_toolchain_test(
+        name = name + "_monolithic_test",
+        target_under_test = name + "_monolithic_subject",
     )
 
     per_file_uses_explicit_toolchain_test(
@@ -153,7 +153,7 @@ def per_target_toolchain_test_suite(name):
     native.test_suite(
         name = name,
         tests = [
-            name + "_standard_test",
+            name + "_monolithic_test",
             name + "_per_file_test",
         ],
     )

--- a/test/unit/toolchain/per_target_toolchain_test.bzl
+++ b/test/unit/toolchain/per_target_toolchain_test.bzl
@@ -1,0 +1,156 @@
+# Copyright 2026 Ericsson AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Analysis test verifying per-target toolchain selection.
+
+When a codechecker_test or per_file_test target sets the `toolchain` attribute,
+the rule must use tools from that toolchain (not the registered default).
+This test asserts that the mock toolchain's tools appear in the target's
+runfiles and action inputs.
+"""
+
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+
+# ---------------------------------------------------------------------------
+# Helper: extract tool basenames from a target's actions
+# ---------------------------------------------------------------------------
+
+def _get_action_input_basenames(target):
+    """Collect basenames of all inputs across all actions of a target."""
+    basenames = []
+    for action in target.actions:
+        for input_file in action.inputs.to_list():
+            basenames.append(input_file.basename)
+    return basenames
+
+def _contains_basename(basenames, name):
+    """Check if a basename (with or without .sh) is in the list."""
+    for b in basenames:
+        if b == name or b == name + ".sh":
+            return True
+    return False
+
+# ---------------------------------------------------------------------------
+# Test: codechecker_test (standard) uses explicit toolchain tools
+# ---------------------------------------------------------------------------
+
+def _test_standard_uses_explicit_toolchain_impl(ctx):
+    env = analysistest.begin(ctx)
+
+    target = analysistest.target_under_test(env)
+
+    # The mock tools should appear in the target's runfiles
+    runfile_basenames = [
+        f.basename
+        for f in target[DefaultInfo].default_runfiles.files.to_list()
+    ]
+
+    asserts.true(
+        env,
+        _contains_basename(runfile_basenames, "mock_codechecker"),
+        "Expected mock_codechecker in runfiles, got: %s" % runfile_basenames,
+    )
+
+    asserts.true(
+        env,
+        _contains_basename(runfile_basenames, "mock_clang"),
+        "Expected mock_clang in runfiles, got: %s" % runfile_basenames,
+    )
+
+    asserts.true(
+        env,
+        _contains_basename(runfile_basenames, "mock_clang_tidy"),
+        "Expected mock_clang_tidy in runfiles, got: %s" % runfile_basenames,
+    )
+
+    return analysistest.end(env)
+
+standard_uses_explicit_toolchain_test = analysistest.make(
+    _test_standard_uses_explicit_toolchain_impl,
+)
+
+# ---------------------------------------------------------------------------
+# Test: per_file_test uses explicit toolchain tools
+# ---------------------------------------------------------------------------
+
+def _test_per_file_uses_explicit_toolchain_impl(ctx):
+    env = analysistest.begin(ctx)
+
+    target = analysistest.target_under_test(env)
+
+    # The mock tools should appear in action inputs (since per_file passes
+    # tools via ctx.actions.run(tools = [info.runfiles]))
+    action_basenames = _get_action_input_basenames(target)
+
+    asserts.true(
+        env,
+        _contains_basename(action_basenames, "mock_codechecker"),
+        "Expected mock_codechecker in action inputs, got: %s" %
+        action_basenames,
+    )
+
+    asserts.true(
+        env,
+        _contains_basename(action_basenames, "mock_clang"),
+        "Expected mock_clang in action inputs, got: %s" %
+        action_basenames,
+    )
+
+    asserts.true(
+        env,
+        _contains_basename(action_basenames, "mock_clang_tidy"),
+        "Expected mock_clang_tidy in action inputs, got: %s" %
+        action_basenames,
+    )
+
+    return analysistest.end(env)
+
+per_file_uses_explicit_toolchain_test = analysistest.make(
+    _test_per_file_uses_explicit_toolchain_impl,
+)
+
+# ---------------------------------------------------------------------------
+# Test suite macro
+# ---------------------------------------------------------------------------
+
+def per_target_toolchain_test_suite(name):
+    """Instantiates analysis tests for per-target toolchain selection.
+
+    The subject targets (codechecker_test and per_file_test with explicit
+    toolchain) must be defined in the BUILD file with names:
+      - {name}_standard_subject
+      - {name}_per_file_subject
+
+    Args:
+        name: Name prefix for generated targets.
+    """
+
+    standard_uses_explicit_toolchain_test(
+        name = name + "_standard_test",
+        target_under_test = name + "_standard_subject",
+    )
+
+    per_file_uses_explicit_toolchain_test(
+        name = name + "_per_file_test",
+        target_under_test = name + "_per_file_subject",
+    )
+
+    native.test_suite(
+        name = name,
+        tests = [
+            name + "_standard_test",
+            name + "_per_file_test",
+        ],
+    )

--- a/test/unit/toolchain/toolchain_test.cpp
+++ b/test/unit/toolchain/toolchain_test.cpp
@@ -1,0 +1,2 @@
+// Minimal source file for per-target toolchain selection test.
+void toolchain_test_function() {}


### PR DESCRIPTION
Why:
We want test for our new feature.

What:
- Added test for overwriting toolchain on a per target bases.

Addresses:
#278 
