### PR TITLE
fix: Compute compile flags once per target

### DIFF
--- a/src/compile_commands.bzl
+++ b/src/compile_commands.bzl
@@ -80,14 +80,16 @@ SYSTEM_INCLUDE = "-isystem "
 QUOTE_INCLUDE = "-iquote "
 EXTERNAL_INCLUDE = "-isystem "
 
-# Function copied from https://gist.github.com/oquenchil/7e2c2bd761aa1341b458cc25608da50c
-# NOTE: added local_defines
-def get_compile_flags(ctx, dep):
+def get_compile_flags(dep, local_defines = True):
     """ Return a list of compile options
 
+    Original function copied from
+    https://gist.github.com/oquenchil/7e2c2bd761aa1341b458cc25608da50c
+    Also added local_defines and external_includes
+
     Args:
-        ctx: The context variable.
         dep: A target with CcInfo.
+        local_defines: if local_defines should be added (default: True)
     Returns:
       List of compile options.
     """
@@ -97,8 +99,9 @@ def get_compile_flags(ctx, dep):
     for define in compilation_context.defines.to_list():
         options.append("-D'{}'".format(define))
 
-    for define in compilation_context.local_defines.to_list():
-        options.append("-D'{}'".format(define))
+    if local_defines:
+        for define in compilation_context.local_defines.to_list():
+            options.append("-D'{}'".format(define))
 
     for system_include in compilation_context.system_includes.to_list():
         if len(system_include) == 0:
@@ -114,42 +117,43 @@ def get_compile_flags(ctx, dep):
         if len(quote_include) == 0:
             quote_include = "."
         options.append(QUOTE_INCLUDE + quote_include)
+
     if hasattr(compilation_context, "external_includes"):
         for external_include in compilation_context.external_includes.to_list():
             if len(external_include) == 0:
                 external_include = "."
             options.append(EXTERNAL_INCLUDE + external_include)
 
-    for attr in SOURCE_ATTR:
-        if not hasattr(ctx.rule.attr, attr):
-            continue
-
-        deps = getattr(ctx.rule.attr, attr)
-        if not type(deps) == "list":
-            continue
-
-        for dep in deps:
-            if CcInfo not in dep:
-                continue
-
-            compilation_context = dep[CcInfo].compilation_context
-            for include in compilation_context.includes.to_list():
-                if len(include) == 0:
-                    include = "."
-                options.append("-I{}".format(include))
-
-            for system_include in compilation_context.system_includes.to_list():
-                if len(system_include) == 0:
-                    system_include = "."
-                options.append(SYSTEM_INCLUDE + system_include)
-
-            if hasattr(compilation_context, "external_includes"):
-                for external_include in compilation_context.external_includes.to_list():
-                    if len(external_include) == 0:
-                        external_include = "."
-                    options.append(EXTERNAL_INCLUDE + external_include)
-
     return options
+
+def get_implementation_deps_flags(ctx):
+    """ Return a list of compile options for implementation_deps
+
+    Unlike deps, implementation_deps is used in cc_library() to define private
+    (implementation-only) dependencies and intentionally does not propagate
+    its includes into the target's CcInfo.compilation_context,
+    so we must extract them explicitly.
+
+    Args:
+        ctx: The context variable.
+    Returns:
+      List of compile options for implementation_deps.
+    """
+    if not hasattr(ctx.rule.attr, "implementation_deps"):
+        return []
+
+    implementation_deps = getattr(ctx.rule.attr, "implementation_deps")
+    if type(implementation_deps) != "list":
+        return []
+
+    flags = []
+    for dep in implementation_deps:
+        if CcInfo not in dep:
+            continue
+        for flag in get_compile_flags(dep, local_defines = False):
+            if flag not in flags:
+                flags.append(flag)
+    return flags
 
 def get_sources(ctx):
     """ Return a list of source files
@@ -173,11 +177,9 @@ def _is_cpp_target(src):
     return src.extension in _cpp_extensions
 
 # Function copied from https://github.com/grailbio/bazel-compilation-database/blob/master/aspects.bzl
-def _cc_compiler_info(ctx, target, src, feature_configuration, cc_toolchain):
-    compile_variables = None
+def _cc_compiler_info(ctx, src, feature_configuration, cc_toolchain):
     compiler_options = None
     compiler = None
-    compile_flags = None
     force_language_mode_option = ""
 
     # This is useful for compiling .h headers as C++ code.
@@ -215,15 +217,9 @@ def _cc_compiler_info(ctx, target, src, feature_configuration, cc_toolchain):
         ),
     )
 
-    compile_flags = (compiler_options +
-                     get_compile_flags(ctx, target) +
-                     (ctx.rule.attr.copts if "copts" in dir(ctx.rule.attr) else []))
-
     return struct(
-        compile_variables = compile_variables,
         compiler_options = compiler_options,
         compiler = compiler,
-        compile_flags = compile_flags,
         force_language_mode_option = force_language_mode_option,
     )
 
@@ -247,6 +243,21 @@ def get_compilation_database(target, ctx):
         unsupported_features = ctx.disabled_features,
     )
 
+    # Common compiler flags
+    compile_flags = get_compile_flags(target)
+    for flag in get_implementation_deps_flags(ctx):
+        if flag not in compile_flags:
+            compile_flags.append(flag)
+    copts = ctx.rule.attr.copts if "copts" in dir(ctx.rule.attr) else []
+    compile_flags += copts
+    builtin_includes = [
+        # Use -I to indicate that we want to keep the normal position in the system include chain.
+        # See https://github.com/grailbio/bazel-compilation-database/issues/36#issuecomment-531971361.
+        "-I " + str(d)
+        for d in cc_toolchain.built_in_include_directories
+    ]
+    compile_flags += builtin_includes
+
     srcs = get_sources(ctx)
 
     directory = "."
@@ -254,22 +265,10 @@ def get_compilation_database(target, ctx):
     for src in srcs:
         if src.extension not in _c_and_cpp_extensions:
             continue
-        compiler_info = _cc_compiler_info(
-            ctx,
-            target,
-            src,
-            feature_configuration,
-            cc_toolchain,
-        )
-        compile_flags = compiler_info.compile_flags
-        compile_flags += [
-            # Use -I to indicate that we want to keep the normal position in the system include chain.
-            # See https://github.com/grailbio/bazel-compilation-database/issues/36#issuecomment-531971361.
-            "-I " + str(d)
-            for d in cc_toolchain.built_in_include_directories
-        ]
+        compiler_info = _cc_compiler_info(ctx, src, feature_configuration, cc_toolchain)
+        flags = compiler_info.compiler_options + compile_flags
         compile_command = compiler_info.compiler + " " + \
-                          " ".join(compile_flags) + compiler_info.force_language_mode_option
+                          " ".join(flags) + compiler_info.force_language_mode_option
         command = compile_command + " -c " + src.path
         compilation_db.append(
             struct(

--- a/test/unit/grep_check.py
+++ b/test/unit/grep_check.py
@@ -54,18 +54,29 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--contains",
         nargs="+",
+        action="extend",
         required=False,
         help="One or more string to assert are present in the file(s).",
     )
     parser.add_argument(
         "--excludes",
         nargs="+",
+        action="extend",
         required=False,
         help="One or more string to assert are not present in the file(s).",
     )
     parser.add_argument(
+        "--once",
+        nargs="+",
+        action="extend",
+        required=False,
+        help="One or more string to assert are present exactly once "
+        "in the file(s), for instance to detect duplicated flags.",
+    )
+    parser.add_argument(
         "--regex_patterns",
         nargs="+",
+        action="extend",
         required=False,
         help="One or more patterns to assert are present in the file(s).",
     )
@@ -81,13 +92,19 @@ def parse_args() -> argparse.Namespace:
 
 def check_args(args):
     """Checks wether the arguments are correct, aborts if not"""
-    if not args.contains and not args.excludes and not args.regex_patterns:
+    if (not args.contains and not args.excludes and
+            not args.regex_patterns and not args.once):
         fail("  [ERROR] Must define at least one pattern or negative pattern.")
 
 
 def exact_match(pattern: str, content: str) -> bool:
     """Default search: checks if pattern is exactly in content."""
     return pattern in content
+
+
+def single_match(pattern: str, content: str) -> bool:
+    """Checks if pattern is in content exactly once."""
+    return content.count(pattern) == 1
 
 
 def check_patterns(
@@ -134,6 +151,7 @@ def check_file(content: str, args) -> tuple[bool, set[str], set[str]]:
     groups = [
         (args.contains, exact_match, False),
         (args.excludes, exact_match, True),
+        (args.once, single_match, False),
         (args.regex_patterns, re.search, False),
     ]
 
@@ -219,6 +237,7 @@ def main() -> None:
         patterns = (
             (args.contains or [])
             + (args.excludes or [])
+            + (args.once or [])
             + (args.regex_patterns or [])
         )
 

--- a/test/unit/implementation_deps/BUILD
+++ b/test/unit/implementation_deps/BUILD
@@ -99,3 +99,130 @@ unit_test(
     data = [":compile_commands_implementation_deps"],
     files = "test/unit/implementation_deps/compile_commands_implementation_deps/compile_commands.json",
 )
+
+# Header only dependency declaring one flag of every kind.
+# It has no sources, therefore the compile commands of its consumers contain
+# their own source only, and every flag found there comes from this dependency.
+# Bazel propagates defines and includes through deps, but never through
+# implementation_deps, and never propagates local_defines at all.
+cc_library(
+    name = "flagged_dep_lib",
+    hdrs = glob(["inc/*.h"]),
+    defines = ["PROPAGATED_DEFINE=1"],
+    includes = ["inc"],
+    local_defines = ["PRIVATE_DEFINE=1"],
+    tags = ["manual"],
+)
+
+cc_library(
+    name = "flagged_implementation_deps_lib",
+    srcs = ["main.cpp"],
+    implementation_deps = [":flagged_dep_lib"],
+    tags = ["manual"],
+)
+
+# Control for the test above: with deps Bazel propagates the flags itself
+cc_library(
+    name = "flagged_deps_lib",
+    srcs = ["main.cpp"],
+    tags = ["manual"],
+    deps = [":flagged_dep_lib"],
+)
+
+# The same dependency in both attributes, its flags are collected twice
+cc_library(
+    name = "duplicated_dep_lib",
+    srcs = ["main.cpp"],
+    implementation_deps = [":flagged_dep_lib"],
+    tags = ["manual"],
+    deps = [":flagged_dep_lib"],
+)
+
+# local_defines of the target itself belong to its own compile line
+cc_library(
+    name = "own_local_defines_lib",
+    srcs = ["main.cpp"],
+    local_defines = ["OWN_PRIVATE_DEFINE=1"],
+    tags = ["manual"],
+)
+
+compile_commands(
+    name = "compile_commands_flagged_implementation_deps",
+    tags = ["manual"],
+    targets = [
+        ":flagged_implementation_deps_lib",
+    ],
+)
+
+compile_commands(
+    name = "compile_commands_flagged_deps",
+    tags = ["manual"],
+    targets = [
+        ":flagged_deps_lib",
+    ],
+)
+
+compile_commands(
+    name = "compile_commands_duplicated_dep",
+    tags = ["manual"],
+    targets = [
+        ":duplicated_dep_lib",
+    ],
+)
+
+compile_commands(
+    name = "compile_commands_own_local_defines",
+    tags = ["manual"],
+    targets = [
+        ":own_local_defines_lib",
+    ],
+)
+
+# implementation_deps does not propagate, the aspect must collect the flags of
+# the dependency explicitly, except its local_defines which stay private
+unit_test(
+    name = "compile_commands_flagged_implementation_deps_test",
+    contains = [
+        "-isystem test/unit/implementation_deps/inc",
+        "-D'PROPAGATED_DEFINE=1'",
+    ],
+    data = [":compile_commands_flagged_implementation_deps"],
+    excludes = ["-D'PRIVATE_DEFINE=1'"],
+    files = "test/unit/implementation_deps/compile_commands_flagged_implementation_deps/compile_commands.json",
+)
+
+# deps propagates the same flags without any collection in the aspect
+unit_test(
+    name = "compile_commands_flagged_deps_test",
+    contains = [
+        "-isystem test/unit/implementation_deps/inc",
+        "-D'PROPAGATED_DEFINE=1'",
+    ],
+    data = [":compile_commands_flagged_deps"],
+    excludes = ["-D'PRIVATE_DEFINE=1'"],
+    files = "test/unit/implementation_deps/compile_commands_flagged_deps/compile_commands.json",
+)
+
+# Flags of a dependency reachable through both attributes are not duplicated
+unit_test(
+    name = "compile_commands_duplicated_dep_test",
+    data = [":compile_commands_duplicated_dep"],
+    files = "test/unit/implementation_deps/compile_commands_duplicated_dep/compile_commands.json",
+    once = [
+        "-isystem test/unit/implementation_deps/inc",
+        "-D'PROPAGATED_DEFINE=1'",
+    ],
+)
+
+unit_test(
+    name = "compile_commands_own_local_defines_test",
+    contains = ["-D'OWN_PRIVATE_DEFINE=1'"],
+    data = [":compile_commands_own_local_defines"],
+    files = "test/unit/implementation_deps/compile_commands_own_local_defines/compile_commands.json",
+)
+
+# TODO: cover the local_includes attribute of cc_library.
+# local_includes is counterpart of local_defines:
+# it is added to compile flags of the target itself
+# and is not propagated to the targets depending on it.
+# See https://bazel.build/reference/be/c-cpp

--- a/test/unit/implementation_deps/inc/pub.h
+++ b/test/unit/implementation_deps/inc/pub.h
@@ -1,0 +1,7 @@
+#ifndef PUB_H
+#define PUB_H
+// Reachable only via the includes attribute of flagged_dep_lib
+inline int pub_value() {
+    return 1;
+}
+#endif  // PUB_H

--- a/test/unit/unit_test.bzl
+++ b/test/unit/unit_test.bzl
@@ -36,6 +36,7 @@ def unit_test(
         expected_missing_files = [],
         contains = None,
         excludes = None,
+        once = None,
         regex_patterns = None,
         require_patterns_in_each_file = True,
         tags = [],
@@ -51,6 +52,7 @@ def unit_test(
                                 disregard the missing file error.
         contains: Text that should be inside the files.
         excludes: Text that shouldn't be inside the files.
+        once: Text that should be inside the files exactly once.
         regex_patterns: Regex patterns that should be found inside the files.
         require_patterns_in_each_file: If False its enough if every pattern is found in at least one file.
         tags: Additional test tags.
@@ -65,6 +67,8 @@ def unit_test(
         contains = [contains]
     if type(excludes) == "string":
         excludes = [excludes]
+    if type(once) == "string":
+        once = [once]
     if type(regex_patterns) == "string":
         regex_patterns = [regex_patterns]
 
@@ -73,14 +77,29 @@ def unit_test(
         python_args.append("--missing_files")
         python_args.extend(expected_missing_files)
     if contains:
-        python_args.append("--contains")
-        python_args.extend(["\"{}\"".format(pat) for pat in contains])
+        # Pass every pattern with = so that patterns starting with a dash,
+        # like compiler flags, are not parsed as options
+        python_args.extend(
+            ["--contains=\"{}\"".format(pat) for pat in contains],
+        )
     if excludes:
-        python_args.append("--excludes")
-        python_args.extend(["\"{}\"".format(pat) for pat in excludes])
+        # Pass every pattern with = so that patterns starting with a dash,
+        # like compiler flags, are not parsed as options
+        python_args.extend(
+            ["--excludes=\"{}\"".format(pat) for pat in excludes],
+        )
+    if once:
+        # Pass every pattern with = so that patterns starting with a dash,
+        # like compiler flags, are not parsed as options
+        python_args.extend(
+            ["--once=\"{}\"".format(pat) for pat in once],
+        )
     if regex_patterns:
-        python_args.append("--regex_patterns")
-        python_args.extend(["\"{}\"".format(pat) for pat in regex_patterns])
+        # Pass every pattern with = so that patterns starting with a dash,
+        # like compiler flags, are not parsed as options
+        python_args.extend(
+            ["--regex_patterns=\"{}\"".format(pat) for pat in regex_patterns],
+        )
     if not require_patterns_in_each_file:
         python_args.append("--any")
 


### PR DESCRIPTION
Why:
Dependency flags, copts and built-in include directories
were recomputed for every source file of a target,
and get_compile_flags mixed two concerns:
flags of the given CcInfo target and walking deps of ctx.rule.attr.
That made the handling of implementation_deps hard to follow.

What:
- Split to get_compile_flags() and get_implementation_deps_flags()
- Collect dependency flags once per target and drop duplicates
- Move copts and built-in includes out of the per source loop
- Do not collect local_defines for implementation_deps
- Drop unused target parameter, compile_flags, compile_variables
- Add the once pattern to unit_test() to detect duplications
- Add tests for implementation_deps, flag propagation via deps,
  local_defines and deduplication

Addresses:
Fixes: #304 #305
#307