### PR TITLE
feat: Create fake path for codechecker

### DIFF
--- a/src/codechecker.bzl
+++ b/src/codechecker.bzl
@@ -93,6 +93,8 @@ def _codechecker_impl(ctx):
     config_file, codechecker_env = get_config_file(ctx)
 
     info = ctx.toolchains["//:toolchain_type"].codecheckerinfo
+    py_toolchain = ctx.toolchains["@rules_python//python:toolchain_type"]
+    py_interpreter_dir = py_toolchain.py3_runtime.interpreter.dirname
 
     codechecker_files = ctx.actions.declare_directory(ctx.label.name + "/codechecker-files")
 
@@ -122,6 +124,7 @@ def _codechecker_impl(ctx):
                 ctx.outputs.codechecker_skipfile,
                 config_file,
             ] + source_files,
+            transitive = [py_toolchain.py3_runtime.files],
         ),
         tools = [
             info.runfiles,
@@ -133,6 +136,9 @@ def _codechecker_impl(ctx):
         ],
         executable = codechecker_script,
         arguments = [cmd_args],
+        env = {
+            "PATH": info.fake_path.dirname + ":" + py_interpreter_dir,
+        },
         mnemonic = "CodeChecker",
         progress_message = "CodeChecker %s" % str(ctx.label),
         # use_default_shell_env = True,
@@ -207,6 +213,7 @@ codechecker = rule(
     },
     toolchains = [
         "//:toolchain_type",
+        "@rules_python//python:toolchain_type",
     ],
 )
 
@@ -323,6 +330,7 @@ _codechecker_test = rule(
     },
     toolchains = [
         "//:toolchain_type",
+        "@rules_python//python:toolchain_type",
     ],
     test = True,
 )

--- a/src/codechecker_script.py
+++ b/src/codechecker_script.py
@@ -251,8 +251,6 @@ def analyze(cfg):
         if env_list:
             codechecker_env = dict(item.split("=", 1) for item in env_list)
             env.update(codechecker_env)
-    if "PATH" not in env:
-        env["PATH"] = "/bin"  # NOTE: this is workaround for CodeChecker 6.24.4
     env["CC_ANALYZER_BIN"] = generate_analyzer_executables(cfg)
     logging.debug("env: %s", str(env))
 

--- a/src/codechecker_toolchain.bzl
+++ b/src/codechecker_toolchain.bzl
@@ -8,19 +8,39 @@ CodeCheckerInfo = provider(
         "clang_tidy": "clang-tidy executable",
         "clangsa": "Clang executable",
         "codechecker": "CodeChecker executable",
-        "runfiles": "Depset of files needed to run the tools: the three executables " +
-                    "plus their transitive data_runfiles. Pass to `tools` in " +
-                    "ctx.actions.run and include in test runfiles.",
+        "fake_path": "A File in the fake PATH directory. Use .dirname to get the directory path.",
+        "runfiles": "Depset of files needed to run the tools: the three executables, " +
+                    "fake PATH contents, plus their transitive data_runfiles. Pass to " +
+                    "`tools` in ctx.actions.run and include in test runfiles.",
     },
 )
 
 def _codechecker_toolchain_impl(ctx):
+    fake_path_dir = "fake_path"
+    uname = ctx.actions.declare_file(fake_path_dir + "/uname")
+    ctx.actions.symlink(
+        output = uname,
+        target_file = ctx.executable.uname,
+    )
+    dirname = ctx.actions.declare_file(fake_path_dir + "/dirname")
+    ctx.actions.symlink(
+        output = dirname,
+        target_file = ctx.executable.dirname,
+    )
+    openssl = ctx.actions.declare_file(fake_path_dir + "/openssl")
+    ctx.actions.symlink(
+        output = openssl,
+        target_file = ctx.executable.openssl,
+    )
+
+    fake_path_files = [uname, dirname, openssl]
+
     runfiles = depset(
         direct = [
             ctx.executable.codechecker,
             ctx.executable.clangsa,
             ctx.executable.clang_tidy,
-        ],
+        ] + fake_path_files,
         transitive = [
             # We also collect files necessary for these programs to run.
             # Those files should be declared with `data = [...]`
@@ -35,10 +55,14 @@ def _codechecker_toolchain_impl(ctx):
             codechecker = ctx.executable.codechecker,
             clang_tidy = ctx.executable.clang_tidy,
             clangsa = ctx.executable.clangsa,
+            fake_path = dirname,
             runfiles = runfiles,
         ),
     )
-    return [toolchain_info]
+    return [
+        toolchain_info,
+        DefaultInfo(files = depset(fake_path_files)),
+    ]
 
 codechecker_toolchain = rule(
     implementation = _codechecker_toolchain_impl,
@@ -58,6 +82,24 @@ codechecker_toolchain = rule(
         "codechecker": attr.label(
             default = "@default_codechecker_tools//:CodeChecker",
             doc = "Executable target for `CodeChecker`.",
+            executable = True,
+            cfg = "exec",
+        ),
+        "dirname": attr.label(
+            default = "@default_codechecker_tools//:dirname",
+            doc = "Executable target for dirname",
+            executable = True,
+            cfg = "exec",
+        ),
+        "openssl": attr.label(
+            default = "@default_codechecker_tools//:openssl",
+            doc = "Executable target for openssl",
+            executable = True,
+            cfg = "exec",
+        ),
+        "uname": attr.label(
+            default = "@default_codechecker_tools//:uname",
+            doc = "Executable target for uname",
             executable = True,
             cfg = "exec",
         ),

--- a/src/codechecker_toolchain.bzl
+++ b/src/codechecker_toolchain.bzl
@@ -17,18 +17,13 @@ CodeCheckerInfo = provider(
 
 def _codechecker_toolchain_impl(ctx):
     fake_path_dir = "fake_path"
-    uname = ctx.actions.declare_file(fake_path_dir + "/uname")
-    ctx.actions.symlink(
-        output = uname,
-        target_file = ctx.executable.uname,
-    )
     dirname = ctx.actions.declare_file(fake_path_dir + "/dirname")
     ctx.actions.symlink(
         output = dirname,
         target_file = ctx.executable.dirname,
     )
 
-    fake_path_files = [uname, dirname]
+    fake_path_files = [dirname]
 
     runfiles = depset(
         direct = [
@@ -83,12 +78,6 @@ codechecker_toolchain = rule(
         "dirname": attr.label(
             default = "@default_codechecker_tools//:dirname",
             doc = "Executable target for dirname",
-            executable = True,
-            cfg = "exec",
-        ),
-        "uname": attr.label(
-            default = "@default_codechecker_tools//:uname",
-            doc = "Executable target for uname",
             executable = True,
             cfg = "exec",
         ),

--- a/src/codechecker_toolchain.bzl
+++ b/src/codechecker_toolchain.bzl
@@ -27,13 +27,8 @@ def _codechecker_toolchain_impl(ctx):
         output = dirname,
         target_file = ctx.executable.dirname,
     )
-    openssl = ctx.actions.declare_file(fake_path_dir + "/openssl")
-    ctx.actions.symlink(
-        output = openssl,
-        target_file = ctx.executable.openssl,
-    )
 
-    fake_path_files = [uname, dirname, openssl]
+    fake_path_files = [uname, dirname]
 
     runfiles = depset(
         direct = [
@@ -88,12 +83,6 @@ codechecker_toolchain = rule(
         "dirname": attr.label(
             default = "@default_codechecker_tools//:dirname",
             doc = "Executable target for dirname",
-            executable = True,
-            cfg = "exec",
-        ),
-        "openssl": attr.label(
-            default = "@default_codechecker_tools//:openssl",
-            doc = "Executable target for openssl",
             executable = True,
             cfg = "exec",
         ),

--- a/src/per_file.bzl
+++ b/src/per_file.bzl
@@ -65,12 +65,15 @@ def _run_code_checker(
 
     codechecker_metadata = ctx.actions.declare_file(codechecker_metadata_file_name)
 
+    py_toolchain = ctx.toolchains["@rules_python//python:toolchain_type"]
+    py_interpreter_dir = py_toolchain.py3_runtime.interpreter.dirname
+
     if "--ctu" in options:
-        inputs = [
+        inputs = depset([
             compile_commands_json,
             config_file,
             config,
-        ] + sources_and_headers
+        ] + sources_and_headers, transitive = [py_toolchain.py3_runtime.files])
     else:
         # NOTE: we collect only headers, so CTU may not work!
         headers = depset(transitive = target[SourceFilesInfo].headers.to_list())
@@ -79,7 +82,7 @@ def _run_code_checker(
             config_file,
             src,
             config,
-        ], transitive = [headers])
+        ], transitive = [headers, py_toolchain.py3_runtime.files])
 
     outputs = [
         clang_tidy_plist,
@@ -118,8 +121,10 @@ def _run_code_checker(
             analyzer_output_paths,
             analyzer_executables,
         ],
+        env = {
+            "PATH": info.fake_path.dirname + ":" + py_interpreter_dir,
+        },
         mnemonic = "CodeChecker",
-        use_default_shell_env = True,
         progress_message = "CodeChecker analyze {}".format(src.short_path),
     )
     return outputs
@@ -283,5 +288,8 @@ per_file_test = rule(
         "test_script": "%{name}/test_script.sh",
     },
     test = True,
-    toolchains = ["//:toolchain_type"],
+    toolchains = [
+        "//:toolchain_type",
+        "@rules_python//python:toolchain_type",
+    ],
 )

--- a/src/tools.bzl
+++ b/src/tools.bzl
@@ -27,9 +27,6 @@ def _codechecker_local_repository_impl(repository_ctx):
     clang_tidy_bin_path = repository_ctx.which("clang-tidy")
     if not clang_tidy_bin_path:
         fail("ERROR! Clang-tidy is not detected")
-    uname_path = repository_ctx.which("uname")
-    if not uname_path:
-        fail("ERROR! uname is not detected")
     dirname_path = repository_ctx.which("dirname")
     if not dirname_path:
         fail("ERROR! dirname is not detected")
@@ -46,7 +43,6 @@ def _codechecker_local_repository_impl(repository_ctx):
     repository_ctx.symlink(codechecker_bin_path, "codechecker_bin")
     repository_ctx.symlink(clang_bin_path, "clang_bin")
     repository_ctx.symlink(clang_tidy_bin_path, "clang_tidy_bin")
-    repository_ctx.symlink(uname_path, "uname_bin")
     repository_ctx.symlink(dirname_path, "dirname_bin")
 
     repository_ctx.file(
@@ -65,11 +61,6 @@ filegroup(
 filegroup(
     name = "clang_tidy",
     srcs = ["clang_tidy_bin"],
-    visibility = ["//visibility:public"],
-)
-filegroup(
-    name = "uname",
-    srcs = ["uname_bin"],
     visibility = ["//visibility:public"],
 )
 filegroup(

--- a/src/tools.bzl
+++ b/src/tools.bzl
@@ -27,7 +27,15 @@ def _codechecker_local_repository_impl(repository_ctx):
     clang_tidy_bin_path = repository_ctx.which("clang-tidy")
     if not clang_tidy_bin_path:
         fail("ERROR! Clang-tidy is not detected")
-
+    uname_path = repository_ctx.which("uname")
+    if not uname_path:
+        fail("ERROR! uname is not detected")
+    openssl_path = repository_ctx.which("openssl")
+    if not openssl_path:
+        fail("ERROR! Openssl is not detected")
+    dirname_path = repository_ctx.which("dirname")
+    if not dirname_path:
+        fail("ERROR! dirname is not detected")
     defs = "CODECHECKER_BIN_PATH = '{}'\n".format(codechecker_bin_path)
     defs += "CLANG_BIN_PATH = '{}'\n".format(clang_bin_path)
     defs += "CLANG_TIDY_BIN_PATH = '{}'\n".format(clang_tidy_bin_path)
@@ -41,6 +49,9 @@ def _codechecker_local_repository_impl(repository_ctx):
     repository_ctx.symlink(codechecker_bin_path, "codechecker_bin")
     repository_ctx.symlink(clang_bin_path, "clang_bin")
     repository_ctx.symlink(clang_tidy_bin_path, "clang_tidy_bin")
+    repository_ctx.symlink(uname_path, "uname_bin")
+    repository_ctx.symlink(dirname_path, "dirname_bin")
+    repository_ctx.symlink(openssl_path, "openssl_bin")
 
     repository_ctx.file(
         repository_ctx.path("BUILD"),
@@ -58,6 +69,21 @@ filegroup(
 filegroup(
     name = "clang_tidy",
     srcs = ["clang_tidy_bin"],
+    visibility = ["//visibility:public"],
+)
+filegroup(
+    name = "uname",
+    srcs = ["uname_bin"],
+    visibility = ["//visibility:public"],
+)
+filegroup(
+    name = "dirname",
+    srcs = ["dirname_bin"],
+    visibility = ["//visibility:public"],
+)
+filegroup(
+    name = "openssl",
+    srcs = ["openssl_bin"],
     visibility = ["//visibility:public"],
 )
         """,

--- a/src/tools.bzl
+++ b/src/tools.bzl
@@ -30,9 +30,6 @@ def _codechecker_local_repository_impl(repository_ctx):
     uname_path = repository_ctx.which("uname")
     if not uname_path:
         fail("ERROR! uname is not detected")
-    openssl_path = repository_ctx.which("openssl")
-    if not openssl_path:
-        fail("ERROR! Openssl is not detected")
     dirname_path = repository_ctx.which("dirname")
     if not dirname_path:
         fail("ERROR! dirname is not detected")
@@ -51,7 +48,6 @@ def _codechecker_local_repository_impl(repository_ctx):
     repository_ctx.symlink(clang_tidy_bin_path, "clang_tidy_bin")
     repository_ctx.symlink(uname_path, "uname_bin")
     repository_ctx.symlink(dirname_path, "dirname_bin")
-    repository_ctx.symlink(openssl_path, "openssl_bin")
 
     repository_ctx.file(
         repository_ctx.path("BUILD"),
@@ -79,11 +75,6 @@ filegroup(
 filegroup(
     name = "dirname",
     srcs = ["dirname_bin"],
-    visibility = ["//visibility:public"],
-)
-filegroup(
-    name = "openssl",
-    srcs = ["openssl_bin"],
     visibility = ["//visibility:public"],
 )
         """,


### PR DESCRIPTION
Why:
We want the Bazel rule to be as hermetic as possible.

What:
- Added dirname to the toolchain. (This is the only tool we use from PATH. Running codechecker with strace reveals that it accesses openssl and uname too, but they seem to be optional)
- Added a custom PATH containing both the hermetic Python interpreter (even though the script running CodeChecker is a py_binary target, CodeChecker still wants to find Python in PATH) and dirname.

Addresses:
none

Notes:
* We might be able to remove Python from the fake PATH when switching to pip-installed CodeChecker.
Supporting standalone builds of CodeChecker, however, will still require Python in PATH.
