### PR TITLE
feat: Make per_file rule support severities

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -12,6 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 load("@rules_python//python:py_binary.bzl", "py_binary")
+load("@rules_python//python:py_library.bzl", "py_library")
+
+py_library(
+    name = "common",
+    srcs = ["common.py"],
+    imports = ["."],
+    visibility = ["//visibility:public"],
+)
 
 # Tool filter compile_commands.json file
 py_binary(
@@ -24,12 +32,14 @@ py_binary(
     name = "codechecker_script",
     srcs = ["codechecker_script.py"],
     visibility = ["//visibility:public"],
+    deps = [":common"],
 )
 
 py_binary(
     name = "per_file_script",
     srcs = ["per_file_script.py"],
     visibility = ["//visibility:public"],
+    deps = [":common"],
 )
 
 # The following are flags and default values for clang_tidy_aspect

--- a/src/codechecker.bzl
+++ b/src/codechecker.bzl
@@ -388,6 +388,7 @@ def codechecker_test(
             options = analyze,
             skip = skip,
             config = config,
+            severities = severities,
             toolchain = toolchain,
             tags = codechecker_tags,
             **kwargs

--- a/src/codechecker_script.py
+++ b/src/codechecker_script.py
@@ -25,7 +25,7 @@ import re
 import sys
 import argparse
 from common import (
-    log_file_name,
+    setup_logging,
     fail,
     execute,
     parse,
@@ -102,26 +102,6 @@ def parse_args(argv=None):
         codechecker_env=args.env,
         codechecker_severities=args.severities,
     )
-
-
-def setup(verbosity, codechecker_log):
-    """Setup logging parameters for execution session"""
-    if verbosity == "INFO":
-        log_level = logging.INFO
-    elif verbosity == "WARN":
-        log_level = logging.WARN
-    else:
-        log_level = logging.DEBUG
-    log_format = "[codechecker] %(levelname)5s: %(message)s"
-
-    if log_file_name(codechecker_log):
-        logging.basicConfig(
-            filename=log_file_name(codechecker_log),
-            level=log_level,
-            format=log_format,
-        )
-    else:
-        logging.basicConfig(level=log_level, format=log_format)
 
 
 def input_data(cfg):
@@ -353,7 +333,7 @@ def test(cfg):
 def main():
     """Main function"""
     cfg = parse_args()
-    setup(cfg.verbosity, cfg.codechecker_log)
+    setup_logging(cfg.verbosity, cfg.codechecker_log)
     input_data(cfg)
     try:
         if cfg.execution_mode == "Run":

--- a/src/codechecker_script.py
+++ b/src/codechecker_script.py
@@ -22,10 +22,16 @@ import logging
 import os
 import plistlib
 import re
-import shlex
-import subprocess
 import sys
 import argparse
+from common import (
+    log_file_name,
+    fail,
+    execute,
+    parse,
+    stage,
+    check_results,
+)
 
 
 @dataclass
@@ -98,65 +104,6 @@ def parse_args(argv=None):
     )
 
 
-def fail(codechecker_log, message, exit_code=1):
-    """Print error message and return exit code"""
-    logging.error(message)
-    print()
-    print("*" * 50)
-    print("codechecker script execution FAILED!")
-    if log_file_name(codechecker_log):
-        print(f"See: {log_file_name(codechecker_log)}")
-        print("*" * 50)
-        try:
-            with open(
-                log_file_name(codechecker_log), encoding="utf-8"
-            ) as log_file:
-                print(log_file.read())
-        except IOError:
-            print("File not accessible")
-    else:
-        print(message)
-    print("*" * 50)
-    print()
-    sys.exit(exit_code)
-
-
-def read_file(codechecker_log, filename):
-    """Read text file and return its contents"""
-    if not os.path.isfile(filename):
-        fail(codechecker_log, f"File not found: {filename}")
-    with open(filename, encoding="utf-8") as handle:
-        return handle.read()
-
-
-def separator(method="info"):
-    """Print log separator line to logging.info() or other logging methods"""
-    getattr(logging, method)("#" * 23)
-
-
-def stage(title, method="info"):
-    """Print stage title into log"""
-    separator(method)
-    getattr(logging, method)("### " + title)
-    separator(method)
-
-
-def valid_parameter(parameter):
-    """Check if external parameter is defined and valid"""
-    if parameter is None:
-        return False
-    if parameter and parameter[0] == "{":
-        return False
-    return True
-
-
-def log_file_name(codechecker_log):
-    """Check and return log file name"""
-    if valid_parameter(codechecker_log):
-        return codechecker_log
-    return None
-
-
 def setup(verbosity, codechecker_log):
     """Setup logging parameters for execution session"""
     if verbosity == "INFO":
@@ -191,31 +138,6 @@ def input_data(cfg):
     logging.debug("CODECHECKER_ENV      : %s", str(cfg.codechecker_env))
     logging.debug("COMPILE_COMMANDS     : %s", str(cfg.compile_commands))
     logging.debug("")
-
-
-def execute(codechecker_log, cmd, env=None, codes=None):
-    """Execute CodeChecker commands"""
-    if codes is None:
-        codes = [0]
-    with subprocess.Popen(
-        cmd,
-        env=env,
-        shell=True,
-        stdin=subprocess.PIPE,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    ) as process:
-        stdout, stderr = process.communicate()
-        stdout = stdout.decode("utf-8")
-        stderr = stderr.decode("utf-8")
-        if process.returncode not in codes:
-            fail(
-                codechecker_log,
-                f"\ncommand: {cmd}\nstdout: {stdout}\nstderr: {stderr}\n",
-            )
-        logging.debug("Executing: %s", cmd)
-        # logging.debug("Output:\n\n%s\n", stdout)
-    return stdout
 
 
 def create_folder(path):
@@ -407,100 +329,25 @@ def update_file_paths(codechecker_files):
     resolve_symlinks(codechecker_files)
 
 
-def parse(cfg):
-    """Run CodeChecker parse commands"""
-    stage("CodeChecker parse:")
-    logging.info("CodeChecker parse -e json")
-    codechecker_parse = (
-        f"{cfg.codechecker_path} parse --config "
-        f"{cfg.codechecker_config} {cfg.codechecker_files}/data"
-    )
-    # Save results to JSON file
-    command = (
-        f"{codechecker_parse} --export=json > "
-        f"{cfg.codechecker_files}/result.json"
-    )
-    execute(cfg.codechecker_log, command, codes=[0, 2])
-    # Save results as HTML report
-    logging.info("CodeChecker parse -e html")
-    command = (
-        codechecker_parse
-        + " --export=html --output="
-        + cfg.codechecker_files
-        + "/report"
-    )
-    execute(cfg.codechecker_log, command, codes=[0, 2])
-    # Save results to text file
-    logging.info("CodeChecker parse to text result")
-    command = codechecker_parse + " > " + cfg.codechecker_files + "/result.txt"
-    execute(cfg.codechecker_log, command, codes=[0, 2])
-    logging.info(
-        "Result:\n\n%s\n",
-        read_file(cfg.codechecker_log, cfg.codechecker_files + "/result.txt"),
-    )
-
-
 def run(cfg):
     """Perform all steps for "bazel build" phase"""
     prepare(cfg.codechecker_files)
     analyze(cfg)
-    parse(cfg)
-    update_file_paths(cfg.codechecker_files)
-
-
-def check_results(cfg):
-    """Check/verify CodeChecker results"""
-    stage("Checking result:")
-    # Get results file and read it
-    result_file = cfg.codechecker_files + "/result.txt"
-    logging.info("Find CodeChecker results in bazel-out")
-    logging.info("      all artifacts: %s/", cfg.codechecker_files)
-    logging.info(
-        "      HTML report:   %s/report/index.html", cfg.codechecker_files
+    parse(
+        cfg.codechecker_path,
+        cfg.codechecker_config,
+        cfg.codechecker_files + "/data",
+        cfg.codechecker_files,
+        cfg.codechecker_log,
     )
-    logging.info("      result file:   %s", result_file)
-    results = read_file(cfg.codechecker_log, result_file)
-    logging.info("Results: \n\n%s\n", results)
-    # Collect defect severities to detect
-    if not valid_parameter(cfg.codechecker_severities):
-        fail(
-            cfg.codechecker_log,
-            "CodeChecker defect severities are invalid: "
-            f"{str(cfg.codechecker_severities)}",
-        )
-    severities = shlex.split(cfg.codechecker_severities)
-    # Add HIGH severity by default
-    if not severities:
-        severities.append("HIGH")
-    # We should always detect CRITICAL defects
-    if "CRITICAL" not in severities:
-        severities.append("CRITICAL")
-    logging.debug("Severities: %s", str(severities))
-    issues = dict.fromkeys(severities, 0)
-    logging.debug("Issues: %s", str(issues))
-    # Grep results for defects according to severities
-    for issue in issues:
-        found = re.findall(rf"^{issue} .* (\d+)", results, re.M)
-        defects = sum(int(number) for number in found)
-        logging.debug("   %s : %s = %d", issue, str(found), defects)
-        issues[issue] = defects
-    logging.info("Defects: %s", str(issues))
-    # Check collected defects
-    passed = True
-    conclusion = ""
-    for issue, num in issues.items():
-        if num > 0:
-            passed = False
-            conclusion += f"{issue:>15} : {num}\n"
-    if passed:
-        logging.info("No defects found by CodeChecker")
-    else:
-        fail(cfg.codechecker_log, f"CodeChecker found defects:\n{conclusion}")
+    update_file_paths(cfg.codechecker_files)
 
 
 def test(cfg):
     """Perform all steps for "bazel test" phase"""
-    check_results(cfg)
+    check_results(
+        cfg.codechecker_files, cfg.codechecker_log, cfg.codechecker_severities
+    )
 
 
 def main():

--- a/src/codechecker_script.py
+++ b/src/codechecker_script.py
@@ -24,7 +24,9 @@ import plistlib
 import re
 import sys
 import argparse
-from common import (
+# pylint outside bazel cannot follow the dependency graph
+# This should be removed when pylint is integrated into bazel
+from common import (  # pylint: disable=no-name-in-module
     setup_logging,
     fail,
     execute,

--- a/src/common.py
+++ b/src/common.py
@@ -189,3 +189,23 @@ def check_results(data_dir, log, severities):
         logging.info("No defects found by CodeChecker")
     else:
         fail(log, f"CodeChecker found defects:\n{conclusion}")
+
+
+def setup_logging(verbosity, log):
+    """Setup logging parameters for execution session"""
+    if verbosity == "INFO":
+        log_level = logging.INFO
+    elif verbosity == "WARN":
+        log_level = logging.WARN
+    else:
+        log_level = logging.DEBUG
+    log_format = "[codechecker] %(levelname)5s: %(message)s"
+
+    if log_file_name(log):
+        logging.basicConfig(
+            filename=log_file_name(log),
+            level=log_level,
+            format=log_format,
+        )
+    else:
+        logging.basicConfig(level=log_level, format=log_format)

--- a/src/common.py
+++ b/src/common.py
@@ -1,0 +1,191 @@
+# Copyright 2023 Ericsson AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Common utilities for CodeChecker rules
+"""
+
+import logging
+import re
+import shlex
+import subprocess
+import sys
+import os
+
+
+def read_file(codechecker_log, filename):
+    """Read text file and return its contents"""
+    if not os.path.isfile(filename):
+        fail(codechecker_log, f"File not found: {filename}")
+    with open(filename, encoding="utf-8") as handle:
+        return handle.read()
+
+
+def separator(method="info"):
+    """Print log separator line to logging.info() or other logging methods"""
+    getattr(logging, method)("#" * 23)
+
+
+def stage(title, method="info"):
+    """Print stage title into log"""
+    separator(method)
+    getattr(logging, method)("### " + title)
+    separator(method)
+
+
+def valid_parameter(parameter):
+    """Check if external parameter is defined and valid"""
+    if parameter is None:
+        return False
+    if parameter and parameter[0] == "{":
+        return False
+    return True
+
+
+def log_file_name(codechecker_log):
+    """Check and return log file name"""
+    if valid_parameter(codechecker_log):
+        return codechecker_log
+    return None
+
+
+def fail(codechecker_log, message, exit_code=1):
+    """Print error message and return exit code"""
+    logging.error(message)
+    print()
+    print("*" * 50)
+    print("codechecker script execution FAILED!")
+    if log_file_name(codechecker_log):
+        print(f"See: {log_file_name(codechecker_log)}")
+        print("*" * 50)
+        try:
+            with open(
+                log_file_name(codechecker_log), encoding="utf-8"
+            ) as log_file:
+                print(log_file.read())
+        except IOError:
+            print("File not accessible")
+    else:
+        print(message)
+    print("*" * 50)
+    print()
+    sys.exit(exit_code)
+
+
+def execute(codechecker_log, cmd, env=None, codes=None):
+    """Execute CodeChecker commands"""
+    if codes is None:
+        codes = [0]
+    with subprocess.Popen(
+        cmd,
+        env=env,
+        shell=True,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    ) as process:
+        stdout, stderr = process.communicate()
+        stdout = stdout.decode("utf-8")
+        stderr = stderr.decode("utf-8")
+        if process.returncode not in codes:
+            fail(
+                codechecker_log,
+                f"\ncommand: {cmd}\nstdout: {stdout}\nstderr: {stderr}\n",
+            )
+        logging.debug("Executing: %s", cmd)
+        # logging.debug("Output:\n\n%s\n", stdout)
+    return stdout
+
+
+def parse(codechecker_path, config, plist_folder, output_folder, log):
+    """Run CodeChecker parse commands"""
+    stage("CodeChecker parse:")
+    logging.info("CodeChecker parse -e json")
+    codechecker_parse = (
+        f"{codechecker_path} parse --config "
+        f"{config} {plist_folder}"
+    )
+    # Save results to JSON file
+    command = (
+        f"{codechecker_parse} --export=json > "
+        f"{output_folder}/result.json"
+    )
+    execute(log, command, codes=[0, 2])
+    # Save results as HTML report
+    logging.info("CodeChecker parse -e html")
+    command = (
+        codechecker_parse
+        + " --export=html --output="
+        + output_folder
+        + "/report"
+    )
+    execute(log, command, codes=[0, 2])
+    # Save results to text file
+    logging.info("CodeChecker parse to text result")
+    command = codechecker_parse + " > " + output_folder + "/result.txt"
+    execute(log, command, codes=[0, 2])
+    logging.info(
+        "Result:\n\n%s\n",
+        read_file(log, output_folder + "/result.txt"),
+    )
+
+
+def check_results(data_dir, log, severities):
+    """Check/verify CodeChecker results"""
+    stage("Checking result:")
+    # Get results file and read it
+    result_file = data_dir + "/result.txt"
+    logging.info("Find CodeChecker results in bazel-out")
+    logging.info("      all artifacts: %s/", data_dir)
+    logging.info(
+        "      HTML report:   %s/report/index.html", data_dir
+    )
+    logging.info("      result file:   %s", result_file)
+    results = read_file(log, result_file)
+    logging.info("Results: \n\n%s\n", results)
+    # Collect defect severities to detect
+    if not valid_parameter(severities):
+        fail(
+            log,
+            "CodeChecker defect severities are invalid: "
+            f"{str(severities)}",
+        )
+    severities = shlex.split(severities)
+    # Add HIGH severity by default
+    if not severities:
+        severities.append("HIGH")
+    # We should always detect CRITICAL defects
+    if "CRITICAL" not in severities:
+        severities.append("CRITICAL")
+    logging.debug("Severities: %s", str(severities))
+    issues = dict.fromkeys(severities, 0)
+    logging.debug("Issues: %s", str(issues))
+    # Grep results for defects according to severities
+    for issue in issues:
+        found = re.findall(rf"^{issue} .* (\d+)", results, re.M)
+        defects = sum(int(number) for number in found)
+        logging.debug("   %s : %s = %d", issue, str(found), defects)
+        issues[issue] = defects
+    logging.info("Defects: %s", str(issues))
+    # Check collected defects
+    passed = True
+    conclusion = ""
+    for issue, num in issues.items():
+        if num > 0:
+            passed = False
+            conclusion += f"{issue:>15} : {num}\n"
+    if passed:
+        logging.info("No defects found by CodeChecker")
+    else:
+        fail(log, f"CodeChecker found defects:\n{conclusion}")

--- a/src/per_file.bzl
+++ b/src/per_file.bzl
@@ -107,6 +107,7 @@ def _run_code_checker(
             ctx.attr._per_file_script[DefaultInfo].files_to_run,
         ],
         arguments = [
+            "--mode=Run",
             "--codechecker",
             info.codechecker.path,
             "--commands",
@@ -202,6 +203,7 @@ def _per_file_impl(ctx):
         info = ctx.attr.toolchain[platform_common.ToolchainInfo].codecheckerinfo
     else:
         info = ctx.toolchains["//:toolchain_type"].codecheckerinfo
+
     for target in ctx.attr.targets:
         if not CcInfo in target:
             continue
@@ -230,29 +232,83 @@ def _per_file_impl(ctx):
                         sources_and_headers,
                     )
                     all_files += outputs
+
+    # Parse action: collect all plists into a directory and run
+    # CodeChecker parse to produce result.txt, result.json, HTML report
+    codechecker_files = ctx.actions.declare_directory(
+        ctx.label.name + "/parse",
+    )
+    codechecker_parse_log = ctx.actions.declare_file(
+        ctx.label.name + "/codechecker_parse.log",
+    )
+
+    # Build arguments for the parse action
+    # The data dir is where the per-file analyze actions put their plists
+    # All plists are in <name>/data/, derive path from first plist
+    #data_dir_path = plist_and_metadata_files[0].dirname if plist_and_metadata_files else ""
+
+    ctx.actions.run(
+        inputs = all_files + [config_file],
+        outputs = [codechecker_files, codechecker_parse_log],
+        executable = per_file_script,
+        tools = [
+            info.runfiles,
+            ctx.attr._per_file_script[DefaultInfo].files_to_run,
+        ],
+        arguments = [
+            "--mode",
+            "Parse",
+            "--codechecker",
+            info.codechecker.path,
+            "--data_dir",
+            codechecker_files.path,
+            "--log",
+            codechecker_parse_log.path,
+            "--config",
+            config_file.path,
+        ],
+        mnemonic = "CodeCheckerParse",
+        use_default_shell_env = True,
+        progress_message = "CodeChecker parse %s" % str(ctx.label),
+    )
+
+    all_files += [codechecker_files, codechecker_parse_log]
+
+    launcher = ctx.actions.declare_file(ctx.label.name + "_launcher.sh")
     ctx.actions.write(
-        output = ctx.outputs.test_script,
+        output = launcher,
+        content = """#!/bin/bash
+            exec {tool} --mode=Test \
+            --data_dir '{codechecker_files}' --severities '{severities}'
+            """.format(
+            tool = per_file_script.short_path,
+            codechecker_files = codechecker_files.short_path,
+            severities = " ".join(ctx.attr.severities),
+        ),
         is_executable = True,
-        content = """
-            DATA_DIR=$(dirname {dirname})
-            # ls -la $DATA_DIR/data
-            # find $DATA_DIR/data -name *.plist -exec sed -i -e "s|<string>.*execroot/codechecker_bazel/|<string>|g" {{}} \\;
-            # cat $DATA_DIR/data/test-src-lib.cc_clangsa.plist
-            echo "Running: CodeChecker parse $DATA_DIR/data"
-            $(realpath {codechecker}) parse $DATA_DIR/data
-        """.format(dirname = ctx.outputs.test_script.short_path, codechecker = info.codechecker.short_path),
     )
-    files = depset(
-        direct = all_files,
-    )
+
+    # Return test script and all required files
     run_files = [
-        ctx.outputs.test_script,
+        per_file_script,
+        launcher,
+        codechecker_files,
     ] + info.runfiles.to_list() + all_files
+    all_runfiles = ctx.runfiles(files = run_files)
+
+    # Add runfiles from the py_binary target (for common.py etc.)
+    all_runfiles = all_runfiles.merge(
+        ctx.attr._per_file_script[DefaultInfo].default_runfiles,
+    )
+
     return [
         DefaultInfo(
-            files = files,
-            runfiles = ctx.runfiles(files = run_files),
-            executable = ctx.outputs.test_script,
+            files = depset(all_files),
+            runfiles = all_runfiles,
+            executable = launcher,
+        ),
+        OutputGroupInfo(
+            codechecker_files = depset([codechecker_files]),
         ),
     ]
 
@@ -273,6 +329,10 @@ per_file_test = rule(
         "options": attr.string_list(
             default = [],
             doc = "List of CodeChecker options, e.g.: --ctu",
+        ),
+        "severities": attr.string_list(
+            default = ["HIGH"],
+            doc = "List of defect severities: HIGH, MEDIUM, LOW, STYLE etc",
         ),
         "skip": attr.string_list(
             default = [],
@@ -300,7 +360,6 @@ per_file_test = rule(
     },
     outputs = {
         "compile_commands": "%{name}/compile_commands.json",
-        "test_script": "%{name}/test_script.sh",
     },
     test = True,
     toolchains = ["//:toolchain_type"],

--- a/src/per_file_script.py
+++ b/src/per_file_script.py
@@ -17,18 +17,23 @@ Codechecker wrapper script for per-file analysis
 """
 
 import argparse
-from dataclasses import dataclass
 import os
 import re
 import shutil
 import subprocess
 import sys
+from dataclasses import dataclass
+import logging
+from common import check_results, fail, log_file_name, parse
 
 
 @dataclass
 class Config:  # pylint: disable=too-many-instance-attributes
     """Configuration parsed from command-line arguments."""
 
+    execution_mode: str
+    verbosity: str
+    severities: str
     codechecker_bin: str
     compile_commands: str
     codechecker_args: str
@@ -48,30 +53,35 @@ def parse_args(argv=None):
         description="CodeChecker per-file analysis wrapper"
     )
 
+    parser.add_argument("--mode", required=True, help="Execution mode")
+    parser.add_argument("--verbosity", default="INFO", help="Log level")
     parser.add_argument(
-        "--codechecker", required=True, help="Path to CodeChecker binary"
+        "--codechecker", required=False, help="Path to CodeChecker binary"
     )
     parser.add_argument(
-        "--commands", required=True, help="Path to compile_commands.json"
+        "--commands", required=False, help="Path to compile_commands.json"
     )
     parser.add_argument(
         "--analyze", default="", help="CodeChecker analyze arguments"
     )
-    parser.add_argument("--config", required=True, help="Path to config file")
+    parser.add_argument("--config", required=False, help="Path to config file")
     parser.add_argument(
         "--data_dir", required=True, help="Output directory for CodeChecker"
     )
     parser.add_argument(
-        "--file", required=True, help="Path to the file to be analyzed"
+        "--file", required=False, help="Path to the file to be analyzed"
     )
-    parser.add_argument("--log", required=True, help="Path to the log file")
-    parser.add_argument("--skip", required=True, help="Path to the skip file")
     parser.add_argument(
-        "--metadata", required=True, help="Path to the metadata file"
+        "--severities", required=False, help="Severities to check"
+    )
+    parser.add_argument("--log", required=False, help="Path to the log file")
+    parser.add_argument("--skip", required=False, help="Path to the skip file")
+    parser.add_argument(
+        "--metadata", required=False, help="Path to the metadata file"
     )
     parser.add_argument(
         "--analyzer_plists",
-        required=True,
+        required=False,
         help="Semicolon-separated list of analyzer,plist_path pairs",
     )
     parser.add_argument(
@@ -82,20 +92,27 @@ def parse_args(argv=None):
 
     args = parser.parse_args(argv)
 
-    analyzer_plist_paths = [
-        item.split(",") for item in args.analyzer_plists.split(";")
-    ]
-    analyzer_executables_env_var = ";".join(
-        f"{name}:{os.path.realpath(path)}"
-        for name, path in [
-            pair.split(":", 1)
-            for pair in args.analyzer_executables.split(";")
-            if pair
+    analyzer_plist_paths = []
+    if args.analyzer_plists:
+        analyzer_plist_paths = [
+            item.split(",") for item in args.analyzer_plists.split(";")
         ]
-    )
+    analyzer_executables_env_var = ""
+    if args.analyzer_executables:
+        analyzer_executables_env_var = ";".join(
+            f"{name}:{os.path.realpath(path)}"
+            for name, path in [
+                pair.split(":", 1)
+                for pair in args.analyzer_executables.split(";")
+                if pair
+            ]
+        )
 
     return Config(
-        codechecker_bin=os.path.realpath(args.codechecker),
+        execution_mode=args.mode,
+        verbosity=args.verbosity,
+        severities=args.severities,
+        codechecker_bin=os.path.realpath(args.codechecker or "/"),
         compile_commands=args.commands,
         codechecker_args=args.analyze,
         config_file=args.config,
@@ -292,15 +309,54 @@ def _move_output_files(cfg: Config):
             file.write("{}")
 
 
+def setup(verbosity, log):
+    """Setup logging parameters for execution session"""
+    if verbosity == "INFO":
+        log_level = logging.INFO
+    elif verbosity == "WARN":
+        log_level = logging.WARN
+    else:
+        log_level = logging.DEBUG
+    log_format = "[codechecker] %(levelname)5s: %(message)s"
+
+    if log_file_name(log):
+        logging.basicConfig(
+            filename=log_file_name(log),
+            level=log_level,
+            format=log_format,
+        )
+    else:
+        logging.basicConfig(level=log_level, format=log_format)
+
+
 def main():
     """
     Main function of CodeChecker wrapper
     """
     cfg = parse_args()
-    _create_compile_commands_json_with_absolute_paths(cfg)
-    _run_codechecker(cfg)
-    _move_output_files(cfg)
+    setup(cfg.verbosity, cfg.log_file)
+    if cfg.execution_mode == "Run":
+        _create_compile_commands_json_with_absolute_paths(cfg)
+        _run_codechecker(cfg)
+        _move_output_files(cfg)
+    elif cfg.execution_mode == "Parse":
+        open(cfg.log_file, "a", encoding="utf-8").close()
+        parse(cfg.codechecker_bin, cfg.config_file, cfg.data_dir + "/../data", cfg.data_dir, cfg.log_file)
+    elif cfg.execution_mode == "Test":
+        check_results(cfg.data_dir, cfg.log_file, cfg.severities)
+    else:
+        fail(
+            cfg.log_file,
+            f"Wrong codechecker script mode: {cfg.execution_mode}",
+        )
 
 
 if __name__ == "__main__":
     main()
+
+
+# I have conserved this comment from the original bash script
+# The sed commands are commented out, so we won't implement them
+# sed -i -e "s|<string>.*execroot/bazel_codechecker/|<string>|g" \
+# $CLANG_TIDY_PLIST
+# sed -i -e "s|<string>.*execroot/bazel_codechecker/|<string>|g" $CLANGSA_PLIST

--- a/src/per_file_script.py
+++ b/src/per_file_script.py
@@ -23,7 +23,11 @@ import shutil
 import subprocess
 import sys
 from dataclasses import dataclass
-from common import check_results, fail, log_file_name, parse, setup_logging
+# pylint outside bazel cannot follow the dependency graph
+# This should be removed when pylint is integrated into bazel
+from common import (  # pylint: disable=no-name-in-module
+    check_results, fail, parse, setup_logging,
+)
 
 
 @dataclass
@@ -319,8 +323,15 @@ def main():
         _run_codechecker(cfg)
         _move_output_files(cfg)
     elif cfg.execution_mode == "Parse":
-        open(cfg.log_file, "a", encoding="utf-8").close()
-        parse(cfg.codechecker_bin, cfg.config_file, cfg.data_dir + "/../data", cfg.data_dir, cfg.log_file)
+        with open(cfg.log_file, "a", encoding="utf-8"):
+            pass
+        parse(
+            cfg.codechecker_bin,
+            cfg.config_file,
+            cfg.data_dir + "/../data",
+            cfg.data_dir,
+            cfg.log_file,
+        )
     elif cfg.execution_mode == "Test":
         check_results(cfg.data_dir, cfg.log_file, cfg.severities)
     else:

--- a/src/per_file_script.py
+++ b/src/per_file_script.py
@@ -23,8 +23,7 @@ import shutil
 import subprocess
 import sys
 from dataclasses import dataclass
-import logging
-from common import check_results, fail, log_file_name, parse
+from common import check_results, fail, log_file_name, parse, setup_logging
 
 
 @dataclass
@@ -309,32 +308,12 @@ def _move_output_files(cfg: Config):
             file.write("{}")
 
 
-def setup(verbosity, log):
-    """Setup logging parameters for execution session"""
-    if verbosity == "INFO":
-        log_level = logging.INFO
-    elif verbosity == "WARN":
-        log_level = logging.WARN
-    else:
-        log_level = logging.DEBUG
-    log_format = "[codechecker] %(levelname)5s: %(message)s"
-
-    if log_file_name(log):
-        logging.basicConfig(
-            filename=log_file_name(log),
-            level=log_level,
-            format=log_format,
-        )
-    else:
-        logging.basicConfig(level=log_level, format=log_format)
-
-
 def main():
     """
     Main function of CodeChecker wrapper
     """
     cfg = parse_args()
-    setup(cfg.verbosity, cfg.log_file)
+    setup_logging(cfg.verbosity, cfg.log_file)
     if cfg.execution_mode == "Run":
         _create_compile_commands_json_with_absolute_paths(cfg)
         _run_codechecker(cfg)

--- a/test/unit/caching/BUILD
+++ b/test/unit/caching/BUILD
@@ -33,14 +33,14 @@ caching_test(
 
 caching_test(
     name = "caching_per_file_test",
-    expected_action_count = 1,
+    expected_action_count = 2,
     file_to_modify = "secondary.cc",
     target_name = "per_file_caching",
 )
 
 caching_test(
     name = "caching_per_file_ctu_test",
-    expected_action_count = 2,
+    expected_action_count = 3,
     file_to_modify = "secondary.cc",
     target_name = "per_file_caching_ctu",
 )


### PR DESCRIPTION
Development halted until issues with integration are ironed out. #199 
Why:
We want complete feature parity between the monolithic and the per_file rule.
The per_file rule currently does not support the severities attribute.

The per_file rule should behave exactly the same during parsing, and when checking the severities, any difference between the two should be considered a bug, not a feature.
That's why, instead of rewriting the logic for parsing and checking severities, I have reused the well-tested monolithic implementation.

What:
- Refactored necessary functions out of the codechecker script into a shared common library.
- Created a parse step for the per_file rule, reusing the one used for the monolithic version.
- Created a test step for the per_file rule, reusing the severity-checking function of the monolithic rule.

Addresses:
Fixes: #309
Fixes: #279 

Depends on: #311
