### PR TITLE
fix: Wrong branch in auto tag action

### DIFF
--- a/.github/workflows/pr-tag.yaml
+++ b/.github/workflows/pr-tag.yaml
@@ -2,7 +2,7 @@ name: Tag commits on main
 on:
   push:
     branches:
-      - master
+      - main
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Why:
On a PR merge or commit push, our new CI (#287) should have created tags, but it did not, as the target branch was mistakenly left on "master".

What:
- Changed branch from master to main

Addresses:
none
