### PR TITLE
ci: Remove Release prefix from release name

### DIFF
--- a/.github/workflows/pr-tag.yaml
+++ b/.github/workflows/pr-tag.yaml
@@ -16,9 +16,9 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       # Optionally create releases too.
-      #- name: Create a GitHub release
-      #  uses: ncipollo/release-action@v1
-      #  with:
-      #    tag: ${{ steps.tag_version.outputs.new_tag }}
-      #    name: Release ${{ steps.tag_version.outputs.new_tag }}
-      #    body: ${{ steps.tag_version.outputs.changelog }}
+      - name: Create a GitHub release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ steps.tag_version.outputs.new_tag }}
+          name: ${{ steps.tag_version.outputs.new_tag }}
+          body: ${{ steps.tag_version.outputs.changelog }}

--- a/.github/workflows/pr-tag.yaml
+++ b/.github/workflows/pr-tag.yaml
@@ -16,9 +16,9 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       # Optionally create releases too.
-      - name: Create a GitHub release
-        uses: ncipollo/release-action@v1
-        with:
-          tag: ${{ steps.tag_version.outputs.new_tag }}
-          name: Release ${{ steps.tag_version.outputs.new_tag }}
-          body: ${{ steps.tag_version.outputs.changelog }}
+      #- name: Create a GitHub release
+      #  uses: ncipollo/release-action@v1
+      #  with:
+      #    tag: ${{ steps.tag_version.outputs.new_tag }}
+      #    name: Release ${{ steps.tag_version.outputs.new_tag }}
+      #    body: ${{ steps.tag_version.outputs.changelog }}


### PR DESCRIPTION
Why:
We want the release name to be the same as the tag name.

What:
- Changed the name parameter for the release from `Release <tagname>` to `<tagname>`

Addresses:
none
