### PR TITLE
feat: Add platform to per_file rule

### DIFF
--- a/src/codechecker.bzl
+++ b/src/codechecker.bzl
@@ -384,6 +384,7 @@ def codechecker_test(
     if per_file:
         per_file_test(
             name = name,
+            platform = platform,
             targets = targets,
             options = analyze,
             skip = skip,

--- a/src/per_file.bzl
+++ b/src/per_file.bzl
@@ -20,10 +20,15 @@ for each translation unit.
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load("codechecker_config.bzl", "get_config_file")
 load(
+    "common.bzl",
+    "version_specific_attributes",
+)
+load(
     "compile_commands.bzl",
     "SourceFilesInfo",
     "compile_commands_aspect",
     "compile_commands_impl",
+    "platforms_transition",
 )
 
 # buildifier: disable=unused-variable
@@ -261,6 +266,7 @@ per_file_test = rule(
     attrs = {
         "config": attr.label(
             default = None,
+            cfg = platforms_transition,
             doc = "CodeChecker configuration",
         ),
         "default_options": attr.string_list(
@@ -274,6 +280,10 @@ per_file_test = rule(
             default = [],
             doc = "List of CodeChecker options, e.g.: --ctu",
         ),
+        "platform": attr.string(
+            default = "",  #"@platforms//os:linux",
+            doc = "Platform to build for",
+        ),
         "skip": attr.string_list(
             default = [],
             doc = "List of skip/ignore file rules. " +
@@ -283,6 +293,7 @@ per_file_test = rule(
             aspects = [
                 compile_commands_aspect,
             ],
+            cfg = platforms_transition,
             doc = "List of compilable targets which should be checked.",
         ),
         "toolchain": attr.label(
@@ -297,7 +308,7 @@ per_file_test = rule(
             cfg = "target",
             default = ":per_file_script",
         ),
-    },
+    } | version_specific_attributes(),
     outputs = {
         "compile_commands": "%{name}/compile_commands.json",
         "test_script": "%{name}/test_script.sh",


### PR DESCRIPTION
Why:
We want the per_file rule to be a drop-in replacement for the monolithic rule.
For this, every attribute of the monolithic rule should be supported in the per_file rule too.

What:
- Added a platform attribute to per_file.  

Addresses:
none
